### PR TITLE
Adds option to count character length of placeholder

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -53,6 +53,7 @@ public class ToolUi extends Modification<Object> {
     private String placeholder;
     private String placeholderDynamicText;
     private Boolean placeholderEditable;
+    private Boolean placeholderCountable;
     private Boolean referenceable;
     private String referenceableViaClassName;
     private Boolean readOnly;
@@ -301,6 +302,14 @@ public class ToolUi extends Modification<Object> {
 
     public void setPlaceholderEditable(boolean placeholderEditable) {
         this.placeholderEditable = Boolean.TRUE.equals(placeholderEditable) ? Boolean.TRUE : null;
+    }
+
+    public boolean isPlaceholderCountable() {
+        return Boolean.TRUE.equals(placeholderCountable);
+    }
+
+    public void setPlaceholderCountable(boolean placeholderCountable) {
+        this.placeholderCountable = Boolean.TRUE.equals(placeholderCountable) ? Boolean.TRUE : null;
     }
 
     public String getPlaceholderDynamicText() {
@@ -891,6 +900,12 @@ public class ToolUi extends Modification<Object> {
          * when the user clicks into the input.
          */
         boolean editable() default false;
+
+        /**
+         * {@code true} if word count and suggested max/min should be diplayed
+         * for placeholder alone.
+         */
+        boolean countPlaceholder() default false;
     }
 
     private static class PlaceholderProcessor implements ObjectField.AnnotationProcessor<Annotation> {
@@ -908,6 +923,7 @@ public class ToolUi extends Modification<Object> {
                 ui.setPlaceholder(placeholder.value());
                 ui.setPlaceholderDynamicText(placeholder.dynamicText());
                 ui.setPlaceholderEditable(placeholder.editable());
+                ui.setPlaceholderCountable(placeholder.countPlaceholder());
             }
         }
     }

--- a/tool-ui/src/main/webapp/WEB-INF/field/text.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/text.jsp
@@ -104,6 +104,7 @@ if (validValues != null) {
             "data-dynamic-placeholder", ui.getPlaceholderDynamicText(),
             "data-code-type", ui.getCodeType(),
             "data-editable-placeholder", ui.isPlaceholderEditable() ? ui.getPlaceholder() : null,
+            "data-count-placeholder", ui.isPlaceholderCountable() ? true : null,
             "data-suggested-maximum", suggestedMaximum != null ? suggestedMaximum.intValue() : null,
             "data-suggested-minimum", suggestedMinimum != null ? suggestedMinimum.intValue() : null,
             "data-inline", true,

--- a/tool-ui/src/main/webapp/script/cms.js
+++ b/tool-ui/src/main/webapp/script/cms.js
@@ -513,13 +513,13 @@ $doc.delegate('.exception > *', 'click', function() {
     var TRIM_RE = /^\s+|\s+$/g,
             WHITESPACE_RE = /\s+/;
 
-    function updateWordCount($container, $input, value) {
+    function updateWordCount($container, $input, value, placeholder) {
         var minimum = +$input.attr('data-suggested-minimum'),
                 maximum = +$input.attr('data-suggested-maximum'),
                 cc,
                 wc;
 
-        value = (value || '').replace(TRIM_RE, '');
+        value = (value || placeholder || '').replace(TRIM_RE, '');
         cc = value.length;
         wc = value ? value.split(WHITESPACE_RE).length : 0;
 
@@ -539,7 +539,8 @@ $doc.delegate('.exception > *', 'click', function() {
         updateWordCount(
                 $input.closest('.inputContainer'),
                 $input,
-                $input.val());
+                $input.val(),
+                $input.attr('data-count-placeholder') === "true" ? $input.attr('placeholder') : '');
     }));
 
     $doc.onCreate('.wysihtml5-sandbox', function() {
@@ -557,7 +558,8 @@ $doc.delegate('.exception > *', 'click', function() {
                 updateWordCount(
                         $toolbar,
                         $textarea,
-                        $bodyClone.text());
+                        $bodyClone.text(),
+                        $textarea.attr('data-count-placeholder') === "true" ? $textarea.attr('placeholder') : '');
             }
         }));
     });


### PR DESCRIPTION
We often use the value of one field as a dynamic placeholder of another field if the second field, when empty, defaults to the first field.  This is probably a very common use of this feature.  However, sometimes those fields have different suggested maximums/minimums. We have been getting requests from editorial to display the "too long" text on a field that is inheriting text longer than its suggested maximum.

This request can be fulfilled by applying the same charactering-counting JS logic to an input's placeholder when its value is blank.  Sometimes, placeholders are used for things other than default text, so this behavior should be optional.  I made it an opt-in attribute of the ToolUi.Placeholder annotation.