### PR TITLE
Feature/productionguide notemplates

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/Guide.java
+++ b/db/src/main/java/com/psddev/cms/db/Guide.java
@@ -1,6 +1,5 @@
 package com.psddev.cms.db;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -9,10 +8,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.psddev.dari.db.Modification;
+import com.psddev.dari.db.ObjectType;
 import com.psddev.dari.db.Query;
 import com.psddev.dari.db.Record;
 import com.psddev.dari.db.ReferentialText;
-import com.psddev.dari.util.StorageItem;
 
 /**
  * A Production Guide is Editor-oriented Help documentation providing guidance on how to create and organize content for a site. It's content
@@ -34,9 +33,9 @@ public class Guide extends Record {
     @ToolUi.Note("Production Guide Title")
     private String title;
 
-    @ToolUi.Note("Select the templates (or one-off pages) to be included in this Production Guide in the order they should appear")
+    @ToolUi.Note("Select the template/page guides to be included in this Production Guide in the order they should appear")
     @BootstrapFollowReferences
-    private List<Page> templatesToIncludeInGuide;
+    private List<GuidePage> templatesToIncludeInGuide;
 
     @ToolUi.Note("Production Guide Overview Section")
     private ReferentialText overview;
@@ -57,12 +56,12 @@ public class Guide extends Record {
         this.overview = overview;
     }
 
-    public List<Page> getTemplatesToIncludeInGuide() {
+    public List<GuidePage> getTemplatesToIncludeInGuide() {
         return templatesToIncludeInGuide;
     }
 
     public void setTemplatesToIncludeInGuide(
-            List<Page> templatesToIncludeInGuide) {
+            List<GuidePage> templatesToIncludeInGuide) {
         this.templatesToIncludeInGuide = templatesToIncludeInGuide;
     }
 
@@ -106,12 +105,12 @@ public class Guide extends Record {
         }
 
         /**
-         * Get the Production Guide for the given template {@code content}
+         * Get the Production Guide for the given content type {@code content}
          */
-        public static GuidePage getPageProductionGuide(Page content) {
-            if (content != null) {
+        public static GuidePage getPageProductionGuide(ObjectType contentType) {
+            if (contentType != null) {
                 GuidePage guide = Query.from(GuidePage.class)
-                        .where("pageType = ?", content.getId()).first();
+                        .where("pageTypes = ?", contentType).first();
                 if (guide != null) {
                     return guide;
                 }
@@ -120,166 +119,53 @@ public class Guide extends Record {
 
         }
 
+
         /**
-         * Get the Production Guide summary description for the given template {@code content}
+         * Return all pages/templates that the given section appears on,
+         * excluding the provided (usually current) page.
          */
-        public static ReferentialText getSummaryDescription(Page content) {
-            if (content != null) {
-                GuidePage guide = Static.getPageProductionGuide(content);
-                if (guide != null) {
-                    return guide.getDescription();
-                }
-            }
+        public static List<GuidePage> getSectionReferences(GuideSection section, GuidePage page) {
+            // TODO: New way to identify related templates
             return null;
 
         }
 
-        /**
-         * Get the Production Guide sample page for the given template {@code content}
-         */
-        public static Content getSamplePage(Page content) {
-            if (content != null) {
-                GuidePage guide = Static.getPageProductionGuide(content);
-                if (guide != null) {
-                    return guide.getSamplePage();
-                }
-            }
-            return null;
-
-        }
-
-        /**
-         * Get the Production Guide sample page snapshot for the given template {@code content}
-         */
-        public static StorageItem getSamplePageSnapshot(Page content) {
-            if (content != null) {
-                GuidePage guide = Static.getPageProductionGuide(content);
-                if (guide != null) {
-                    return guide.getSamplePageSnapshot();
-                }
-            }
-            return null;
-
-        }
-
-        /**
-         * Return all pages/templates that the given section appears on (if it
-         * is shareable), excluding the provided (usually current) page.
-         */
-        public static List<Page> getSectionReferences(Section section, Page page) {
-            if (section != null && section.isShareable()) {
-                List<Page> references = Query
-                        .from(Page.class)
-                        .where("* matches ? && not id = ?", section.getId(),
-                                page.getId()).selectAll();
-                return references;
-            }
-            return null;
-
-        }
-
-        /**
-         * Get the Production Guide description for a template section
-         */
-        public static GuideSection getSectionGuide(Page page, Section section) {
-            if (section != null && page != null) {
-                GuidePage pageGuide = getPageProductionGuide(page);
-                if (pageGuide != null) {
-                    return pageGuide.findOrCreateSectionGuide(section);
-                }
-            }
-            return null;
-        }
-
-        /**
-         * Get the Production Guide description for a template section
-         */
-        public static ReferentialText getSectionDescription(Page page,
-                Section section) {
-            if (section != null && page != null) {
-                GuidePage pageGuide = getPageProductionGuide(page);
-                if (pageGuide != null) {
-                    return pageGuide.getSectionDescription(section);
-                }
-            }
-            return null;
-        }
-
-        /**
-         * Get the Production Guide tips for a template section
-         */
-        public static ReferentialText getSectionTips(Page page, Section section) {
-            if (section != null && page != null) {
-                GuidePage pageGuide = getPageProductionGuide(page);
-                if (pageGuide != null) {
-                    return pageGuide.getSectionTips(section);
-                }
-            }
-            return null;
-        }
 
         /**
          * Return the related templates (other than the one provided) that have
          * a sample page defined
          */
-        public static List<Template> getRelatedTemplates(Object object,
-                Page ignoreTemplate) {
-            List<Template> relatedTemplates = new ArrayList<Template>();
-            List<Template> usableTemplates = Template.Static.findUsable(object);
-            for (Template template : usableTemplates) {
-                if (!template.getId().equals(ignoreTemplate.getId()) &&
-                        Guide.Static.getSamplePage(template) != null) {
-                    relatedTemplates.add(template);
-                }
-            }
-            return relatedTemplates;
+        public static List<GuidePage> getRelatedPages(Object content,
+                GuidePage ignorePage) {
+            // TODO: New way to identify related templates
+            return null;
         }
 
         /**
          * Return a map of section ids to names where names are a concatenation
          * of the section name along with it's parental lineage in the layout
+         * TODO: New way to establish parental lineage of sections
          */
         public static HashMap<UUID, String> getSectionNameMap(
-                Iterable<Section> sections) {
+                Iterable<GuideSection> sections) {
             HashMap<UUID, String> nameMap = new HashMap<UUID, String>();
 
-            // This assumes that the sections are provided in an order such that
-            // parents are
-            // evaluated before children, which is how they get returned from
-            // Section
             if (sections == null) {
                 return nameMap;
             }
-            for (Section section : sections) {
+            for (GuideSection section : sections) {
                 String sectionName = "";
                 if (!nameMap.containsKey(section.getId())) {
-                    if (section.getName() != null && !section.getName().isEmpty()) {
-                        sectionName = section.getName();
+                    if (section.getSectionName() != null && !section.getSectionName().isEmpty()) {
+                        sectionName = section.getSectionName();
                     } else {
-                        // if the section wasn't given an explicit name, we use
-                        // the class name (e.g. VerticalContainerSection)
-                        sectionName = section.getClass().getSimpleName();
+                        sectionName = "Unnamed";
                     }
                     nameMap.put(section.getId(), sectionName);
                 } else {
                     sectionName = nameMap.get(section.getId());
                 }
 
-                if (section instanceof ContainerSection) {
-                    String childName = "";
-                    for (Section child : ((ContainerSection) section)
-                            .getChildren()) {
-                        if (!child.getName().isEmpty()) {
-                            childName = child.getName();
-                        } else {
-                            childName = child.getClass().getSimpleName();
-                        }
-
-                        if (!nameMap.containsKey(child.getId())) {
-                            nameMap.put(child.getId(), sectionName + " - " + childName);
-                        }
-                    }
-                }
             }
             return nameMap;
         }

--- a/db/src/main/java/com/psddev/cms/db/GuidePage.java
+++ b/db/src/main/java/com/psddev/cms/db/GuidePage.java
@@ -1,55 +1,84 @@
 package com.psddev.cms.db;
 
-import com.psddev.dari.db.Query;
-import com.psddev.dari.db.Record;
-import com.psddev.dari.db.ReferentialText;
-import com.psddev.dari.util.StorageItem;
-
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.psddev.dari.db.ObjectType;
+import com.psddev.dari.db.Record;
+import com.psddev.dari.db.ReferentialText;
+import com.psddev.dari.util.StorageItem;
+
 /**
  * Production Guide class to hold information about Pages and Templates (objects with layouts)
  *
  */
-@Record.LabelFields({ "pageType/name" })
+@Record.LabelFields({ "name" })
 @Record.BootstrapPackages("Production Guides")
 public class GuidePage extends Record {
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(GuidePage.class);
 
-    @ToolUi.Note("Page type for Production Guide information. On Save, the Section list will be populated with all non-container sections in the current layout")
+    @ToolUi.Note("Name for this template/page guide")
     @Required
     @Indexed(unique = true)
-    @DisplayName("Template or One-Off Page")
+    @DisplayName("Name")
     @BootstrapFollowReferences
+    String name;
+
+    @ToolUi.Hidden
+    @Deprecated
+    // old association to template - retained
     Page pageType;
+
+    @ToolUi.Note("Content Types associated with this page guide (will be displayable from their Edit form)")
+    @Required
+    @DisplayName("Page Types")
+    @BootstrapFollowReferences
+    @Indexed
+    List<ObjectType> pageTypes;
 
     @ToolUi.Note("Production Guide summary for this page type")
     @DisplayName("Summary")
     ReferentialText description;
 
-    @ToolUi.Note("Sample (Published) Page as documentation example for this page/template")
+    @ToolUi.Note("Sample (Published) Page as documentation example for this page")
     @BootstrapFollowReferences
     private Content samplePage;
 
     @ToolUi.Note("Sample Page snapshot image used for Printouts")
     private StorageItem samplePageSnapshot;
 
-    @ToolUi.Note("Production Guide section descriptions for this page/template")
+    @ToolUi.Note("Production Guide section descriptions for this page")
     @Embedded
     private List<GuideSection> sectionDescriptions;
 
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Deprecated
     public Page getPageType() {
         return pageType;
     }
 
+    @Deprecated
     public void setPageType(Page pageType) {
         this.pageType = pageType;
+    }
+
+    public List<ObjectType> getPageTypes() {
+        return pageTypes;
+    }
+
+    public void setPageTypes(List<ObjectType> pageTypes) {
+        this.pageTypes = pageTypes;
     }
 
     public ReferentialText getDescription() {
@@ -97,107 +126,10 @@ public class GuidePage extends Record {
         return false;
     }
 
-    public ReferentialText getSectionDescription(Section section) {
-        if (section != null) {
-            GuideSection gs = findOrCreateSectionGuide(section);
-            if (gs != null) {
-                return gs.getDescription();
-            }
-        }
-        return null;
-    }
-
-    public ReferentialText getSectionTips(Section section) {
-        if (section != null) {
-            GuideSection gs = findOrCreateSectionGuide(section);
-            if (gs != null) {
-                return gs.getTips();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Return the GuideSection entry that matches the given {@code section} of the template
-     * associated with this guide object. If none exists, create one.
-     */
-    public GuideSection findOrCreateSectionGuide(Section section) {
-        if (section instanceof ContainerSection) {
-            return null;
-        }
-        // Only allowed to create a production guide for a named section
-        if (section.getName() == null || section.getName().isEmpty()) {
-            return null;
-        }
-        if (sectionDescriptions == null) {
-            sectionDescriptions = new ArrayList<GuideSection>();
-        }
-        if (!sectionDescriptions.isEmpty()) {
-            for (GuideSection gs : sectionDescriptions) {
-                if (gs.getSectionName() != null &&
-                        gs.getSectionName().equals(section.getName())) {
-                    return gs;
-                }
-            }
-        }
-        // else create it
-        GuideSection gs = new GuideSection();
-        gs.setSectionName(section.getName());
-        sectionDescriptions.add(gs);
-        return gs;
-    }
-
-    /**
-     * Create a GuideSection entry in the sectionList for all sections in the object's
-     * referenced page/template.
-     */
-    public void generateSectionDescriptionList() {
-        // Create an entry for each field
-        Page type = getPageType();
-        if (type != null) {
-            Iterable<Section> sections = type.findSections();
-            if (sections != null) {
-                for (Section section : sections) {
-                    findOrCreateSectionGuide(section);
-                }
-            }
-        }
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.psddev.dari.db.Record#beforeSave()
-     */
-    public void beforeSave() {
-        generateSectionDescriptionList();
-    }
 
     /** Static utility methods. */
     public static final class Static {
 
-        /**
-         * Generate any missing guides for existing templates
-         */
-        public static synchronized void createDefaultTemplateGuides() {
-            List<GuidePage> pageGuides = Query.from(GuidePage.class).selectAll();
-            List<Template> templates = Query.from(Template.class).selectAll();
-            // eliminate templates that already have guides
-            for (GuidePage guide : pageGuides) {
-                int i = templates.indexOf(guide.getPageType());
-                if (i >= 0) {
-                    templates.remove(i);
-                }
-            }
-            if (!templates.isEmpty()) {
-                for (Template template : templates) {
-                    GuidePage newGuide = new GuidePage();
-                    newGuide.setPageType(template);
-                    newGuide.saveImmediately();
-                }
-            }
-            return;
-        }
     }
 
 }

--- a/db/src/main/java/com/psddev/cms/db/GuideSection.java
+++ b/db/src/main/java/com/psddev/cms/db/GuideSection.java
@@ -12,13 +12,9 @@ import com.psddev.dari.db.ReferentialText;
 public class GuideSection extends Record {
 
     @Required
-    @ToolUi.Note("Section name in template definition")
+    @ToolUi.Note("Name of the page section to be described")
+    @Indexed
     private String sectionName;
-
-    // Would rather use this for uniqueness, but at this time, the sectionId can change anytime
-    // a template is saved.
-    //@Required
-    //private UUID sectionId;
 
     @ToolUi.Note("Production Guide description for this section")
     private ReferentialText description;
@@ -33,14 +29,6 @@ public class GuideSection extends Record {
     public void setSectionName(String sectionName) {
         this.sectionName = sectionName;
     }
-
-//    public UUID getSectionId() {
-//        return sectionId;
-//    }
-//
-//    public void setSectionId(UUID sectionId) {
-//        this.sectionId = sectionId;
-//    }
 
     public ReferentialText getDescription() {
         return description;

--- a/db/src/main/java/com/psddev/cms/tool/CmsTool.java
+++ b/db/src/main/java/com/psddev/cms/tool/CmsTool.java
@@ -768,6 +768,7 @@ public class CmsTool extends Tool {
         plugins.add(createJspWidget("Schedules", "dashboard.scheduledEvents", "/misc/scheduledEvents.jsp", DASHBOARD_WIDGET_POSITION, dashboardColumn, dashboardRow ++));
         plugins.add(createPageWidget("Drafts", "dashboard.unpublishedDrafts", "/unpublishedDrafts", DASHBOARD_WIDGET_POSITION, dashboardColumn, dashboardRow ++));
         plugins.add(createJspWidget("Resources", "dashboard.resources", "/resources", DASHBOARD_WIDGET_POSITION, dashboardColumn, dashboardRow ++));
+        plugins.add(createJspWidget("Production Guides", "dashboard.productionGuides", "/misc/productionGuides", DASHBOARD_WIDGET_POSITION, dashboardColumn, dashboardRow ++));
 
         // Content right widgets.
         double rightColumn = 0.0;
@@ -848,6 +849,7 @@ public class CmsTool extends Tool {
             this.file = file;
         }
 
+        @Override
         public String getUrl() {
             StorageItem file = getFile();
             return file != null ? file.getPublicUrl() : null;

--- a/db/src/main/java/com/psddev/cms/tool/page/ProductionGuides.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/ProductionGuides.java
@@ -1,0 +1,61 @@
+package com.psddev.cms.tool.page;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import com.psddev.cms.db.Guide;
+import com.psddev.cms.tool.PageServlet;
+import com.psddev.cms.tool.ToolPageContext;
+import com.psddev.dari.db.Query;
+import com.psddev.dari.util.ObjectUtils;
+import com.psddev.dari.util.RoutingFilter;
+
+@RoutingFilter.Path(application = "cms", value = "/misc/productionGuides")
+public class ProductionGuides extends PageServlet {
+
+    @Override
+    protected String getPermissionId() {
+        return "area/dashboard";
+    }
+
+    @Override
+    protected void doService(ToolPageContext page) throws IOException,
+            ServletException {
+
+        List<Guide> guides = Query.from(Guide.class).selectAll();
+
+        page.writeStart("div", "class", "widget");
+
+        page.writeStart("h1", "class", "icon icon-book");
+        page.writeHtml("Production Guides");
+        page.writeEnd();
+
+        if (ObjectUtils.isBlank(guides)) {
+            page.writeStart("div", "class", "message message-info");
+            page.writeStart("p");
+            page.writeHtml("There aren't any production guides.");
+            page.writeEnd();
+            page.writeEnd();
+        } else {
+            page.writeStart("table", "class",
+                    "links table-striped pageThumbnails").writeStart("tbody");
+
+            for (Guide guide : guides) {
+                page.writeStart("tr");
+                page.writeStart("td");
+                page.write(" <a target=\"_blank\" href=\"", page.url(
+                        "/content/guideType.jsp", "guideId", guide.getId()), "\">",
+                        guide.getTitle(), "</a>");
+                page.writeEnd();
+                page.writeEnd();
+            }
+
+            page.writeEnd().writeEnd();
+        }
+
+        page.writeEnd();
+    }
+
+}

--- a/tool-ui/src/main/webapp/admin/guides.jsp
+++ b/tool-ui/src/main/webapp/admin/guides.jsp
@@ -33,9 +33,7 @@ if (wp.tryStandardUpdate(selected)) {
 
 // Ensure that there is a GuidePage object created for any templates
 GuideSettings settings = (wp.getCmsTool()).as(GuideSettings.class);
-if (settings.isAutoGenerateTemplateGuides() == true) {
-    GuidePage.Static.createDefaultTemplateGuides();
-}
+
 // Ensure that there is a GuideType object created for any objects referenced by templates.
 if (settings.isAutoGenerateContentTypeGuides() == true) {
     GuideType.Static.createDefaultTypeGuides();
@@ -43,7 +41,7 @@ if (settings.isAutoGenerateContentTypeGuides() == true) {
 
 List<Guide> guides = Query.from(Guide.class).sortAscending("title").select();
 List<GuideType> typeGuides = Query.from(GuideType.class).sortAscending("documentedType/name").select();
-List<GuidePage> pageGuides = Query.from(GuidePage.class).sortAscending("pageType/name").select();
+List<GuidePage> pageGuides = Query.from(GuidePage.class).sortAscending("name").select();
 List<Page> templates = Query.from(Page.class).sortAscending("name").select();
 String incompleteIndicator = "*";
 

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -248,9 +248,9 @@ if (!Query.from(CmsTool.class).first().isDisableContentLocking() &&
                         <a class="icon icon-beaker" href="<%= wp.url("", "ab", !wp.param(boolean.class, "ab")) %>">A/B</a>
                     <% } %>
                     <%
-                    GuidePage guide = Guide.Static.getPageProductionGuide(template);
+                    GuidePage guide = Guide.Static.getPageProductionGuide(state.getType());
                     if (guide != null && guide.getDescription() != null && !guide.getDescription().isEmpty()) {
-                        wp.write("<a class=\"icon icon-object-guide\" target=\"guideType\" href=\"", wp.objectUrl("/content/guideType.jsp", selected, "templateId", template.getId(), "variationId", wp.uuidParam("variationId"), "popup", true), "\">PG</a>");
+                        wp.write("<a class=\"icon icon-object-guide\" target=\"guideType\" href=\"", wp.objectUrl("/content/guideType.jsp", selected, "pageGuideId", guide.getId(),  "popup", true), "\">PG</a>");
                     }
                     %>
                 </div>

--- a/tool-ui/src/main/webapp/content/guideType.jsp
+++ b/tool-ui/src/main/webapp/content/guideType.jsp
@@ -571,7 +571,7 @@ if (typeof jQuery !== 'undefined') (function($, win, undef) {
                  if (minX > itemMinX) {
                      minX = itemMinX;
                  }
-                 if (maxX < itmMaxX) {
+                 if (maxX < itemMaxX) {
                      maxX = itemMaxX;
                  }
                  if (minY > itemMinY) {

--- a/tool-ui/src/main/webapp/content/guideType.jsp
+++ b/tool-ui/src/main/webapp/content/guideType.jsp
@@ -154,9 +154,9 @@
 
                 <%
                     if (guide != null) {
-                        Page prevT = null;
-                        Page nxtT = null;
-                        Page curT = null;
+                        GuidePage prevT = null;
+                        GuidePage nxtT = null;
+                        GuidePage curT = null;
                         foundSelected = false;
                         int pageCnt = 1;
 
@@ -178,7 +178,7 @@
                             if (curT != null && !foundSelected) {
                                 prevT = curT;
                             }
-                            curT = (Page) iter.next();
+                            curT = (GuidePage) iter.next();
                             if (nxtT == null && (foundSelected || overviewPage)) {
                                 nxtT = curT;
                                 nextPageGuideId = nxtT.getId().toString();


### PR DESCRIPTION
Convert page level production guides to associate with content types instead of no-longer-used template and section types. Add dashboard widget to view top-level Production Guides.