### PR TITLE
Fix for carousel left nav button

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/carousel.js
+++ b/tool-ui/src/main/webapp/script/v3/input/carousel.js
@@ -388,12 +388,6 @@ function($, bsp_utils) {
             // Number of tiles to shift
             var moveTiles = 0;
 
-            // If all tiles fit within the viewport then no movement needed
-            if (layout.tilesWidth <= layout.viewportWidth) {
-                self.update();
-                return;
-            }
-
             if ($.isNumeric(amount)) {
                 moveTiles = amount;
             } else {


### PR DESCRIPTION
In the case where a few tiles were added, clicking the third or fourth tile would cause the active tile to be centered in the carousel viewport, and the first tile would be partially hidden. In that case if you clicked the left navigation button, the carousel failed to scroll back to show the first tile.
To fix this, adjusting the logic so the carousel will move even when the width of all tiles fit within the viewport.