### PR TITLE
BSP-905 Sets “displayName” property on WorkflowState objects produced for WorkflowTransition “source” and “target” properties.

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/Workflow.java
+++ b/db/src/main/java/com/psddev/cms/db/Workflow.java
@@ -104,6 +104,7 @@ public class Workflow extends Record {
             for (Map<String, Object> s : rawStates) {
                 state = new WorkflowState();
                 state.setName((String) s.get("name"));
+                state.setDisplayName((String) s.get("displayName"));
                 states.put((String) s.get("id"), state);
             }
 
@@ -148,6 +149,7 @@ public class Workflow extends Record {
             for (Map<String, Object> s : rawStates) {
                 state = new WorkflowState();
                 state.setName((String) s.get("name"));
+                state.setDisplayName((String) s.get("displayName"));
                 states.put((String) s.get("id"), state);
             }
 


### PR DESCRIPTION
BSP-905 Sets “displayName” property on WorkflowState objects produced for WorkflowTransition “source” and “target” properties.