### PR TITLE
Adds Bulk Edit type-level permission to restrict access to bulk editing functions.

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/search/BulkEditSearchResultAction.java
+++ b/db/src/main/java/com/psddev/cms/tool/search/BulkEditSearchResultAction.java
@@ -60,12 +60,24 @@ public class BulkEditSearchResultAction implements SearchResultAction {
         } else if (search != null) {
             ObjectType type = search.getSelectedType();
 
-            if (type == null || type.isAbstract()) {
+            if (type == null) {
+                return;
+            }
+
+            if (type.isAbstract()) {
                 return;
 
             } else {
                 typeId = type.getId();
             }
+        }
+
+        String typePermissionId = "type/" + typeId;
+
+        // Do not allow editing of types for which the user does not have Bulk Edit permission
+        if (!page.hasPermission(typePermissionId + "/bulkEdit") ||
+                !page.hasPermission(typePermissionId + "/write")) {
+            return;
         }
 
         page.writeStart("div", "class", "searchResult-action-simple");

--- a/db/src/main/java/com/psddev/cms/tool/search/BulkEditSearchResultAction.java
+++ b/db/src/main/java/com/psddev/cms/tool/search/BulkEditSearchResultAction.java
@@ -60,11 +60,7 @@ public class BulkEditSearchResultAction implements SearchResultAction {
         } else if (search != null) {
             ObjectType type = search.getSelectedType();
 
-            if (type == null) {
-                return;
-            }
-
-            if (type.isAbstract()) {
+            if (type == null || type.isAbstract()) {
                 return;
 
             } else {

--- a/tool-ui/src/main/webapp/WEB-INF/field/permissions.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/permissions.jsp
@@ -244,6 +244,10 @@ wp.writeStart("div", "class", "inputSmall permissions");
                                 writeChild(wp, permissions, "Publish", typePermissionId + "/publish");
                             wp.writeEnd();
 
+                            wp.writeStart("li");
+                                writeChild(wp, permissions, "Bulk Edit", typePermissionId + "/bulkEdit");
+                            wp.writeEnd();
+
                             Workflow workflow = workflows.get(type);
 
                             if (workflow != null) {


### PR DESCRIPTION
Adds Bulk Edit type-level permission to restrict access to bulk editing functions.

Prevents display of the “Bulk Edit” button in BulkEditSearchResultAction when the logged-in ToolUser does not have permission to Bulk Edit or Write to any of the selected or query result object types.