### PR TITLE
Adds internal tracking of cleaned UUIDs to prevent circular logic when processing @RichText fields on different Content that reference each other.

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/RichTextDatabase.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextDatabase.java
@@ -2,8 +2,11 @@ package com.psddev.cms.db;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -31,6 +34,8 @@ public class RichTextDatabase extends ForwardingDatabase {
                 }
             });
 
+    private final Set<UUID> cleaned = new HashSet<UUID>();
+
     // --- ForwardingDatabase support ---
 
     public <T> T clean(T object) {
@@ -39,6 +44,11 @@ public class RichTextDatabase extends ForwardingDatabase {
         }
 
         State state = State.getInstance(object);
+
+        if (!cleaned.add(state.getId())) {
+            return object;
+        }
+
         ObjectType type = state.getType();
 
         if (type != null) {


### PR DESCRIPTION
Adds internal tracking of cleaned UUIDs to prevent circular logic when processing @RichText fields on different Content that reference each other.