### PR TITLE
BSP-748. Display content which fails save() during Bulk Update

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/page/ContentEditBulk.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/ContentEditBulk.java
@@ -1,5 +1,21 @@
 package com.psddev.cms.tool.page;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
 import com.psddev.cms.tool.CmsTool;
 import com.psddev.cms.tool.PageServlet;
 import com.psddev.cms.tool.Search;
@@ -12,22 +28,6 @@ import com.psddev.dari.util.CompactMap;
 import com.psddev.dari.util.JspUtils;
 import com.psddev.dari.util.ObjectUtils;
 import com.psddev.dari.util.RoutingFilter;
-
-import com.google.common.collect.ImmutableList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 
 @RoutingFilter.Path(application = "cms", value = "contentEditBulk")
 public class ContentEditBulk extends PageServlet {


### PR DESCRIPTION
Hi Hyoo,

This PR fixes a Bulk Update problem that we noticed on a client project, where our editors were making Bulk Updates which created non-unique permalinks.  (It's evidently the same problem that Karl noticed in a bug report in that our Section names are also part of the permalink computation, so, e.g. /sec1/some-name and /sec2/some-name is fine, but when you try to Bulk Edit the latter to put it into "sec1", it fails because there's content already assigned to that URL.)

The code around content.save() catches the Dari exception 
(which is what should happen) ... but swallows it with just a logging statement.  As a result, the editor sees a message "Successfully saved <n> items" even though some/all of the content was *not* successfully saved.

This PR doesn't try to solve the permalink resolution which Karl mentions in his ticket, but it does expose the fact that there *is* a problem to the editor, so they have some clue what's going on, which would help out our editors.

I tested this locally against release/2.4, which is what our current project is currently using.


