### PR TITLE
Changes IllegalStateException in SearchResultsActions to instead create a new instance of SearchResultSelection for the ToolUser.

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/page/SearchResultActions.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/SearchResultActions.java
@@ -45,7 +45,11 @@ public class SearchResultActions extends PageServlet {
         SearchResultSelection selection = user.getCurrentSearchResultSelection();
 
         if (selection == null) {
-            throw new IllegalStateException();
+
+            selection = new SearchResultSelection();
+            selection.save();
+            user.setCurrentSearchResultSelection(selection);
+            user.save();
         }
 
         if ("item-add".equals(action)) {


### PR DESCRIPTION
Fixes issue where ToolUsers see an IllegalStateException if they have never seen a search result and the current search results listing has no results.