### PR TITLE
Add tile type label to the repeatable grid view

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1170,6 +1170,7 @@ The HTML within the repeatable element must conform to these standards:
                 var imageUrl;
                 var $label;
                 var $controls;
+                var labelType = $item.attr('data-type') || 'Title';
                 var labelText = $item.attr('data-label') || '[Empty Title]';
                 
                 // Only do this for mode=preview
@@ -1191,7 +1192,15 @@ The HTML within the repeatable element must conform to these standards:
                 }).appendTo($item);
                 
                 // Add the title of the slide here
-                $label = $('<div class="previewable-label"><span class="previewable-label-prefix">Title: </span></div>').appendTo($item);
+                //$label = $('<div class="previewable-label"><span class="previewable-label-prefix">' + labelType + ': </span></div>').appendTo($item);
+                $label = $('<div/>', {
+                    'class': 'previewable-label',
+                    html: $('<span/>', {
+                        'class': 'previewable-label-prefix',
+                        text: labelType + ': '
+                    })
+                }).appendTo($item);
+
                 $('<a/>', {
                     href: '#',
                     text: labelText,


### PR DESCRIPTION
For repeatable items, the grid view currently displays a label under the preview image:
Title: [label text]

This has been changed to dipslay the type of tile like the following:
Slideshow Slide: [label text]

Note: this could potentially cause a design problem if the tile type or the label is a long value, since there is limited room under the tile to display the label.

![gride-view-labels](https://cloud.githubusercontent.com/assets/185461/7753582/59c804a8-ffb4-11e4-8faf-e7e44d5ca1c4.jpg)
