### PR TITLE
Gallery thumbnail image bugfix

### DIFF
--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -591,7 +591,13 @@ if (!isValueExternal) {
                 wp.writeStart("li",
                         "data-type", wp.getObjectLabel(itemType),
                         "data-label", wp.getObjectLabel(item),
-                        "data-preview", wp.getPreviewThumbnailUrl(item));
+                        
+                        // Add the image url for the preview thumbnail, plus the field name that provided the thumbnail
+                        // so if that field is changed the front-end knows that the thumbnail should also be updated
+                        "data-preview", wp.getPreviewThumbnailUrl(item),
+                        "data-preview-field", itemType.getPreviewField()
+                        
+                        );
                     wp.writeElement("input",
                             "type", "hidden",
                             "name", idName,

--- a/tool-ui/src/main/webapp/script/jquery.editableplaceholder.js
+++ b/tool-ui/src/main/webapp/script/jquery.editableplaceholder.js
@@ -4,38 +4,86 @@ $.plugin2('editablePlaceholder', {
     '_init': function(selector) {
         var plugin = this;
 
+        // NOTE:
+        // There are potential conflicts between this code and other code that fetches
+        // dynamic placeholders for the inputs: the placeholder attributes on the input
+        // can sometimes change without warning.
+        // Because of this, whenever we insert the placeholder value into the input,
+        // we must store that value for later comparison (because if we attempt to
+        // compare it against the placeholder value it might have been updated so it
+        // will not be what we expect and this might lead to erasing the input
+        // after the user enters a new value).
+        // 
         function getPlaceholder($input) {
             return $input.attr('data-editable-placeholder') || $input.prop('placeholder');
         }
+        
+        function setEditablePlaceholder($input, value) {
+            $input.data('editable-placeholder-value', value);
+        }
+        
+        function removeEditablePlaceholder($input) {
+            $input.removeData('editable-placeholder-value');
+        }
+        
+        function getEditablePlaceholder($input) {
+            return $input.data('editable-placeholder-value');
+        }
 
-        plugin.$caller.delegate(selector, 'focus.editablePlaceholder mouseenter.editablePlaceholder', function() {
-            var $input = $(this);
+        // If the input is empty and the user moves mouse over the input or focus on the input,
+        // put the placeholder value into the input.
+        plugin.$caller.on('focus.editablePlaceholder mouseenter.editablePlaceholder', selector, function() {
+            
+            var $input, placeholder;
+            
+            $input = $(this);
+            removeEditablePlaceholder($input);
 
             if (!$input.val()) {
-                $.data(this, 'editable-placeholder-empty-before-focus', true);
-                $input.val(getPlaceholder($input));
+                
+                $input.data('editable-placeholder-empty-before-focus', true);
+                placeholder = getPlaceholder($input);
+                setEditablePlaceholder($input, placeholder);
             }
         });
 
-        plugin.$caller.delegate(selector, 'input.editablePlaceholder', function() {
-            $.removeData(this, 'editable-placeholder-empty-before-focus');
+        // If the user changes the input then mark the input so we don't change it back to the empty value
+        plugin.$caller.on('input.editablePlaceholder', selector, function() {
+            var $input;
+            $input = $(this);
+            $input.removeData('editable-placeholder-empty-before-focus');
         });
 
-        plugin.$caller.delegate(selector, 'blur.editablePlaceholder', function() {
-            var $input = $(this);
+        // If the user leaves the input field, remove the placeholder
+        // unless the user has modified the field.
+        plugin.$caller.on('blur.editablePlaceholder', selector, function() {
+            var $input, placeholder;
+            
+            $input = $(this);
+            placeholder = getEditablePlaceholder($input);
 
-            if ($.data(this, 'editable-placeholder-empty-before-focus') ||
-                    $input.val() === getPlaceholder($input)) {
+            if ($input.data('editable-placeholder-empty-before-focus')
+                || $input.val() === getEditablePlaceholder($input)) {
+                
                 $input.val('');
+                removeEditablePlaceholder($input);
             }
         });
 
-        plugin.$caller.delegate(selector, 'mouseleave.editablePlaceholder', function() {
-            var $input = $(this);
-
-            if (!$input.is(':focus') &&
-                    $input.val() === getPlaceholder($input)) {
+        // If the user moves the mouse off the input field, remove the placeholder
+        // unless the user is currently editing the field,
+        plugin.$caller.on('mouseleave.editablePlaceholder', selector, function() {
+            var $input, placeholder;
+            
+            $input = $(this);
+            placeholder = getEditablePlaceholder($input);
+            
+            if (!$input.is(':focus')
+                && placeholder
+                && $input.val() === placeholder) {
+                
                 $input.val('');
+                removeEditablePlaceholder($input);
             }
         });
     }

--- a/tool-ui/src/main/webapp/script/v3/content/state.js
+++ b/tool-ui/src/main/webapp/script/v3/content/state.js
@@ -65,7 +65,7 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
                 $element.attr('data-dynamic-html') ||
                 $element.attr('data-dynamic-placeholder') ||
                 '')) +
-                '&_dtf=' + $element.attr('data-dynamic-field-name') || '';
+                  '&_dtf=' + ($element.attr('data-dynamic-field-name') || '');
           }).get().join(''),
 
           'success': function(data) {
@@ -75,7 +75,7 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
               var $element = $(this),
                   text = data._dynamicTexts[index];
 
-              if (text === null) {
+              if (text === null || text === '') {
                 return;
               }
 
@@ -112,7 +112,7 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
         });
       }
 
-      $form.bind('change input', function() {
+      $form.bind('create change input', function() {
         update();
 
         clearTimeout(idleTimeout);

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1449,6 +1449,7 @@ The HTML within the repeatable element must conform to these standards:
                 
                 var self = this;
                 var $item = $(item);
+                var itemId = $item.find('> input[type="hidden"][name$=".id"]').val();
                 var $editContainer;
 
                 // If necessary create the container for editing this item
@@ -1457,12 +1458,24 @@ The HTML within the repeatable element must conform to these standards:
                     $editContainer = $('<div/>', {
                         'class': 'itemEdit'
                     }).on('change', function(event) {
-                        // If a change is made to the preview image
-                        // update the thumbnail image in the carousel
-                        // and in the grid view
-                        var $target = $(event.target).closest('[data-preview]');
-                        var imageUrl = $target.attr('data-preview');
-                        if (imageUrl) {
+
+                        var imageUrl, $target, targetName, thumbnailName;
+                        
+                        // If a change is made to the preview image update the thumbnail image in the carousel and grid view
+                        $target = $(event.target).closest('[data-preview]');
+                        imageUrl = $target.attr('data-preview');
+                        targetName = $target.attr('name');
+
+                        // Make sure this changed item is actually used for the thumbnail
+                        // The data-preview-field contains the name of the field and the type,
+                        // so we need to remove the /type part
+                        thumbnailName = $item.attr('data-preview-field') || '';
+                        thumbnailName = thumbnailName.replace(/(.*)\/.*/, '$1'); // remove last / and beyond
+                        thumbnailName = itemId + '/' + thumbnailName;
+                        
+                        // Make sure the preview that was changed is actually used as the thumbnail for this repeatable object.
+                        // This will account for cases where the repeatable object contains multiple images, or nested objects.
+                        if (imageUrl && targetName === thumbnailName) {
                             self.modePreviewSetThumbnail($item, imageUrl);
                         }
                     }).appendTo(self.dom.$carouselTargetItems);


### PR DESCRIPTION
Fixed a problem where changing any image within a gallery item would update the thumbnail for the gallery tile.
Added a data-preview-field attribute to the repeatable object html, so the front-end could know which field provides the thumbnail.
Then when a change occurs within the gallery item, the front-end can update the tile image only if the expected field was updated.