### PR TITLE
Bugfix gallery carousel gets too wide

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/carousel.less
+++ b/tool-ui/src/main/webapp/style/v3/carousel.less
@@ -174,6 +174,7 @@
 
 .carousel-target {
   display: table;
+  table-layout:fixed;
   position: relative;
   width: 100%;
 }


### PR DESCRIPTION
For nested gallery carousels, the carousel was expanding to the right. This CSS change should prevent that.