### PR TITLE
Add change indicator to grid and gallery tiles

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1461,7 +1461,16 @@ The HTML within the repeatable element must conform to these standards:
                     }).on('change', function(event) {
 
                         var imageUrl, $target, targetName, thumbnailName;
-                        
+
+                        // Mark the tiles as changed so user can see which items have been modified.
+                        // Inputs are not marked as changed until the change event bubbles up to the body of the page,
+                        // so we put this in a timeout to hopefully force it to run after the event bubbles up.
+                        // An alternative would be to bind another event on the document body, but then we
+                        // would have no way to unbind that event.
+                        setTimeout(function(){
+                            self.modePreviewMarkAsChanged($item);
+                        }, 1);
+
                         // If a change is made to the preview image update the thumbnail image in the carousel and grid view
                         $target = $(event.target).closest('[data-preview]');
                         imageUrl = $target.attr('data-preview');
@@ -1480,6 +1489,7 @@ The HTML within the repeatable element must conform to these standards:
                             self.modePreviewSetThumbnail($item, imageUrl);
                         }
                     }).appendTo(self.dom.$carouselTargetItems);
+                    
                     $item.data('editContainer', $editContainer);
                 }
 
@@ -1575,6 +1585,21 @@ The HTML within the repeatable element must conform to these standards:
                 }
 
                 $thumbnails.attr('src', imageUrl);
+            },
+
+
+            /**
+             * Mark the tiles as changed so the user can see they have been updated.
+             * @param Boolean changed
+             * Set to true if the item was changed, or false if changes were removed.
+             */
+            modePreviewMarkAsChanged: function(item) {
+                var $item = $(item); // the thumbnail in grid view
+                var $carouselTile = $item.data('carouselTile'); // the tile in gallery view
+                var $editContainer = $item.data('editContainer'); // the edit form
+                var isChanged = Boolean($editContainer.find('.state-changed').length > 0);
+                
+                $item.add($carouselTile).toggleClass('state-changed', isChanged);
             }
             
         }; // END repeatableUtility

--- a/tool-ui/src/main/webapp/style/v3/carousel.less
+++ b/tool-ui/src/main/webapp/style/v3/carousel.less
@@ -154,6 +154,7 @@
   }
 
   figure {
+
     border-radius: @carousel-tile-borderRadius;
     bottom: 0;
     display: block;
@@ -164,6 +165,10 @@
     right: 0;
     top: 0;
 
+    &.state-changed figcaption {
+      .background-flat(@color-change);
+    }
+    
     img {
       height: 100%;
       object-fit: cover;

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -154,6 +154,10 @@
       // For a numbered carousel create a CSS counter
       counter-reset: @preview-counter;
 
+      > li.state-changed {
+        .background-flat(@color-change);
+      }
+      
       > li {
         background: white;
         box-sizing: border-box;


### PR DESCRIPTION
If a repeatable item is modified, color the grid and gallery tiles so they indicate a change has occurred.

![gallery-change](https://cloud.githubusercontent.com/assets/185461/7968140/d1a6009a-09fc-11e5-9631-109323ab0eb7.jpg)
