### PR TITLE
Fix tile height for repeatableObjectId-previewable

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -591,6 +591,11 @@
   }
 
   &.repeatableObjectId-previewable {
+    
+    > .addButtonContainer {
+      float:left;
+    }
+    
     > ol,
     > ul {
       list-style-type: none;
@@ -604,21 +609,40 @@
         box-sizing: border-box;
         float: left;
         margin: 0 10px 10px 0;
-        padding: 4px;
+        padding: 0;
         position: relative;
         width: 210px;
-
+        height:180px;
+        
         .objectId-select {
           background-color: white;
           border: none;
           box-sizing: border-box;
           display: block;
-          margin: -4px -4px 0 -4px;
-          padding: 4px 4px 10px 4px;
+          margin: 0;
+          margin-bottom:4px;
+          padding:4px;
           width: auto;
-
+          height:150px;
+          
           figure {
+            
             width: 100%;
+            height:100%;
+
+            img {
+              width: 100%;
+              height:100%;
+              cursor: pointer;
+          
+              // Resize the image so it's largest dimension fills the tile completely
+              // and keeps the correct aspect ratio.
+              object-fit: cover;
+
+              // In case src is blank set a background color
+              background-color:#ddd;
+            }
+
           }
 
           &:before,
@@ -627,13 +651,16 @@
           }
         }
 
-        .objectId-edit,
         .removeButton {
           .icon-only;
+          position:absolute;
+          right:1em;
         }
-
-        .removeButton {
-          float: right;
+        
+        .objectId-edit {
+          .icon-only;
+          position:absolute;
+          right:3em;
         }
       }
     }


### PR DESCRIPTION
For repeatableObjectId-previewable, the tile preview images were variable height. leading to problems in the display. These CSS changes make the tiles all the same size.

Note for previous work done for repeatable.js, repeatableForm-previewable was updated to display in a grid/gallery view; however, repeatableObjectId-previewable was not tested. Luckily the functionality still worked, but it did not get the same UI updates that came in with the other work, so that has been corrected with this commit.