### PR TITLE
Handle validation errors in repeatable gallery

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/carousel.js
+++ b/tool-ui/src/main/webapp/script/v3/input/carousel.js
@@ -362,6 +362,23 @@ function($, bsp_utils) {
 
         
         /**
+         * Set or clear the "error" class for a tile.
+         *
+         * @param {Number} n
+         * Number of the tile to retrieve (starting at 1 for the first tile).
+         *
+         * @param {Boolean} [state]
+         * True to set the error state, false to clear error state,
+         * or undefined to toggle the error state.
+         */
+        toggleTileError: function(n, state) {
+            var self = this;
+            var $tile = self.dom.tiles.find('> .carousel-tile').eq(n - 1);
+            $tile.toggleClass('carousel-tile-error', state);
+        },
+
+        
+        /**
          * @private
          * Move the carousel forward or back.
          *

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1057,7 +1057,7 @@ The HTML within the repeatable element must conform to these standards:
                 $topButtonContainer = $('<div/>', { 'class': 'repeatablePreviewControls' }).prependTo($container);
 
                 // Move the "action-upload" link into the top button container
-                $container.find('.action-upload').appendTo($topButtonContainer);
+                $container.find('> .action-upload').appendTo($topButtonContainer);
                 
                 // Add a placeholder for the "Add Item" button(s) to later be added to the top.
                 // Refer to initAddButton() to see how this is used.
@@ -1173,6 +1173,7 @@ The HTML within the repeatable element must conform to these standards:
                 var $controls;
                 var labelType = $item.attr('data-type') || 'Title';
                 var labelText = $item.attr('data-label') || '[Empty Title]';
+                var $editContainer;
                 
                 // Only do this for mode=preview
                 if (!self.modeIsPreview()) {
@@ -1236,6 +1237,19 @@ The HTML within the repeatable element must conform to these standards:
                 
                 // Add the item to the carousel
                 self.modePreviewInitItemCarousel($item);
+                
+                // Create the edit container for this item below the carousel,
+                // and if this item has a form already on the page move it there
+                $editContainer = self.modePreviewCreateEditContainer($item);
+                $item.find('.objectInputs').appendTo($editContainer);
+
+                // If there are validation messages in the form,
+                // mark  the gride and gallery tiles to show an error state,
+                // then select the item and show the edit form so user can correct the error.
+                if ($editContainer.find('.message-error').length) {
+                    self.modePreviewMarkError($item);
+                    self.modePreviewEdit($item);
+                }
             },
 
 
@@ -1600,6 +1614,26 @@ The HTML within the repeatable element must conform to these standards:
                 var isChanged = Boolean($editContainer.find('.state-changed').length > 0);
                 
                 $item.add($carouselTile).toggleClass('state-changed', isChanged);
+            },
+
+            /**
+             * Update the thumbnail so it shows an error state.
+             * This updates both the grid view and the carousel view thumbnail.
+             * Used in cases where there is a validation error within the item.
+             */
+            modePreviewMarkError: function(item) {
+
+                var self = this;
+                var $item = $(item);
+                var $thumbnails = $item.find('.previewable-image');
+                var $carouselTile = $(item).data('carouselTile');
+                var carousel = self.carousel;
+
+                if (carousel && $carouselTile) {
+                    carousel.toggleTileError( carousel.getTileIndex($carouselTile), true);
+                }
+                
+                $thumbnails.closest('li').addClass('state-error');
             }
             
         }; // END repeatableUtility

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1241,7 +1241,7 @@ The HTML within the repeatable element must conform to these standards:
                 // Create the edit container for this item below the carousel,
                 // and if this item has a form already on the page move it there
                 $editContainer = self.modePreviewCreateEditContainer($item);
-                $item.find('.objectInputs').appendTo($editContainer);
+                $item.find('> .objectInputs').appendTo($editContainer);
 
                 // If there are validation messages in the form,
                 // mark  the gride and gallery tiles to show an error state,

--- a/tool-ui/src/main/webapp/style/v3/carousel.less
+++ b/tool-ui/src/main/webapp/style/v3/carousel.less
@@ -124,6 +124,17 @@
     }
   }
 
+  &.carousel-tile-error {
+    // Using @color-remove because that's what error messages use
+    border: 2px solid @color-remove;
+    &:before {
+      border-color: @color-remove;
+    }
+    &:after {
+      border-color: @color-remove transparent transparent transparent;
+    }
+  }
+  
   .carousel-numbered & figure:before {
     @-borderWidth: 2px;
     @-offset: @carousel-tile-borderWidth + @carousel-tile-padding;

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -157,6 +157,10 @@
       > li.state-changed {
         .background-flat(@color-change);
       }
+
+      > li.state-error {
+        .background-flat(@color-remove);
+      }
       
       > li {
         background: white;
@@ -197,7 +201,7 @@
         .previewable-controls {
           height:22px;
           position:absolute;
-          width:208px;
+          width:100%;
           left:0;
           bottom:0;
           background-color:#f8f8f8;


### PR DESCRIPTION
If a validation error occurred in a repeatable preview form, the grid/gallery view was not displaying correctly when the page refreshed.

Added code to:
Detect the form already on the page and move it into the gallery.
Detect error messages within the form and mark the thumbnails in grid and gallery view.
Detect error messages and display the item that has an error.

![gallery-validation](https://cloud.githubusercontent.com/assets/185461/8089732/c0e1d72c-0f77-11e5-9c97-bcbb0689efa7.jpg)
