### PR TITLE
Bugfix for embeded forms in repeatable

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1314,7 +1314,7 @@ The HTML within the repeatable element must conform to these standards:
                 $editContainer = self.modePreviewCreateEditContainer($item);
                 
                 // Remove the item's edit form and move it to the edit container
-                $item.find('.objectInputs').appendTo($editContainer);
+                $item.find('> .objectInputs').appendTo($editContainer);
 
                 // Trigger a change to update any thumbnails
                 $editContainer.find(':input').trigger('change');


### PR DESCRIPTION
When repeatable preview forms contain embedded information, and the form is moved into the "Gallery" view, the embedded form structure was being changed.

This commit modifies the selector used to move the form so only the topmost element of the form is moved.
