### PR TITLE
Repeatable thumbnail not updating for new item

### DIFF
--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -633,7 +633,10 @@ if (!isValueExternal) {
                 wp.writeStart("script", "type", "text/template");
                     wp.writeStart("li",
                             "class", !bulkUploadTypes.isEmpty() ? "collapsed" : null,
-                            "data-type", wp.getObjectLabel(type));
+                            "data-type", wp.getObjectLabel(type),
+                            // Add the name of the preview field so the front end knows
+                            // if that field is updated it should update the thumbnail
+                            "data-preview-field", type.getPreviewField());
                         wp.writeStart("a",
                                 "href", wp.cmsUrl("/content/repeatableObject.jsp",
                                         "inputName", inputName,


### PR DESCRIPTION
For a repeatable form item, adding a new item was not updating the thumbnail image in the grid/gallery view. Note this bug was introduced due to another bugfix that prevented the thumbnail from updating for the wrong image.

Modified back-end code to add data-preview-field attribute to the template, so the front-end will know which field is used for the thumbnail.