### PR TITLE
Add remove/restore to repeatable gallery view

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1275,7 +1275,16 @@ The HTML within the repeatable element must conform to these standards:
                     'data-dynamic-text': '${content.label}'
 
                 }).appendTo($carouselTile);
-                
+
+                // Add a remove/restore button to the carousel tile
+                // This will be hidden by CSS unless the tile is active or "toBeRemoved"
+                $('<span/>', {
+                    'class': 'removeButton',
+                    'text': self.options.removeButtonText
+                }).on('click', function(){
+                    self.removeItemToggle( $item );
+                }).appendTo($carouselTile);
+
                 // On the item, save a reference to the carousel tile,
                 // so later if user changes sort order of the items,
                 // we can determine which carousel tile needs to be moved

--- a/tool-ui/src/main/webapp/style/v3/carousel.less
+++ b/tool-ui/src/main/webapp/style/v3/carousel.less
@@ -105,6 +105,7 @@
       top: -1px;
       right: -1px;
       z-index: 1;
+      pointer-events: none;
     }
 
     // arrow.
@@ -121,6 +122,7 @@
       position: absolute;
       width: @-arrowWidth;
       z-index: 1;
+      pointer-events: none;
     }
   }
 
@@ -141,10 +143,6 @@
     text-align: center;
     top: @-offset;
     width: @-size;
-  }
-
-  &.toBeRemoved {
-    opacity: 0.5;
   }
 
   .link {

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -298,6 +298,55 @@
       float: left;
       margin: 0 10px 0 0;
     }
+
+    .carousel-tile {
+      
+      .removeButton {
+        .icon;
+        .icon-remove;
+        .icon-only;
+        .link;
+        color: @color-remove;
+        position: absolute;
+        right: 2px;
+        bottom: 4px;
+        
+        // Hide the remove button unless the tile is active
+        display:none;
+      }
+      
+      .toBeRemoved {
+        
+        opacity: 0.5;
+        text-decoration: line-through;
+
+        .removeButton {
+          // Always show the restore button even if tile is not active
+          display:block;
+          .icon-plus;
+          color: @color-link-dark;
+        }
+        
+        // Add padding to the caption to leave room for removeButton
+        figcaption {
+          padding-right: 1em;
+        }
+      }
+    }
+    
+    .carousel-tile-active {
+
+      // Always show remove/restore on the active tile
+      .removeButton {
+        display:block;
+      }
+
+      // Add padding to the caption to leave room for removeButton
+      figcaption {
+        padding-right: 1em;
+      }
+      
+    }
   }
 }
 


### PR DESCRIPTION
For the repeatable form grid/gallery views, currently you can only remove or restore items from the grid view. Then if you switch to gallery view, there is no indication which tiles have been marked for removal. From the gallery view there is no way to restore those tiles that have been marked, you must switch to the grid view to restore an item. This could lead to some confusion if the user doesn't realize they must switch to the grid view.

This pull request adds the following to the gallery view:
* Indicates items that have been marked for removal by displaying them with opacity and a line through the text.
* Adding a remove button (an "x" icon) to the tile. To prevent the design from getting too cluttered, this remove button appears only on the active tile (so the user must select the tile, then click the "x" icon to remove it).
* If a tile has been marked for removal, the restore button (a plus icon) appears on the tile. This icon always appears on tiles that have been marked for removal, even if the tile is not the active tile.

![gallery-remove-restor](https://cloud.githubusercontent.com/assets/185461/8138762/baeaa808-111b-11e5-8949-a799c7e5f298.jpg)
