### PR TITLE
Bugfix no add button in single input repeatable

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1011,7 +1011,7 @@ The HTML within the repeatable element must conform to these standards:
                 // So it will tell the back-end that this input should be added
                 // ???: this is not checked initially (but is is checked when the new input is added?)
                 $('<input/>', {
-                    'name': $singleInput.attr('name'),
+                    'name': $toggle.attr('name'),
                     'type': 'hidden',
                     'value': $toggle.attr('value')
                 }).appendTo($addButtonContainer);


### PR DESCRIPTION
For a "single input repeatable" such as SEO keywords, if you entered a value in the field but did not clicking the "add" button, your new keyword would not be added when you published the page. This commit modifies the javascript so it properly adds the ".toggle" hidden input so the keyword will be saved.