### PR TITLE
RTE2 fixes for link popup and enhancement toolbar

### DIFF
--- a/tool-ui/src/main/webapp/content/linkByIdResult.jsp
+++ b/tool-ui/src/main/webapp/content/linkByIdResult.jsp
@@ -51,8 +51,8 @@ String removeId = wp.createId();
 
         $page.delegate('[data-permalink]', 'click', function() {
             var $sourceParent = $page.popup('source').parent(),
-                    $idInput = $sourceParent.find('.rte-dialogLinkId'),
-                    $hrefInput = $sourceParent.find('.rte-dialogLinkHref'),
+                    $idInput = $sourceParent.find('.rte-dialogLinkId, .rte2-dialogLinkId'),
+                    $hrefInput = $sourceParent.find('.rte-dialogLinkHref, .rte2-dialogLinkHref'),
                     $link = $(this);
 
             $idInput.val($link.attr('data-id'));

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1604,11 +1604,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Modify the Select and Edit buttons in the toolbar
             if (reference && reference.record && reference.record._ref) {
                 
-                $select = $enhancement.find('.rte-enhancement-toolbar-change');
+                $select = $enhancement.find('.rte2-enhancement-toolbar-change');
                 $select.text('Change');
 
                 // Modify the "Edit" button in the toolbar so it will pop up the edit dialog for the enhancement
-                $edit = $enhancement.find('.rte-enhancement-toolbar-edit');
+                $edit = $enhancement.find('.rte2-enhancement-toolbar-edit');
                 editUrl = $edit.attr('href') || '';
                 editUrl = $.addQueryParameters(editUrl, 'id', reference.record._ref);
                 $edit.attr('href', editUrl);

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -320,3 +320,42 @@
   }
 }
 
+.rte2-dialogLine {
+  margin-bottom: 5px;
+  position: relative;
+}
+
+.rte2-dialogLinkHref {
+  padding-right: 6em !important;
+  width: 100%;
+}
+
+.rte2-dialogLinkContent {
+  .icon;
+  .icon-action-search;
+
+  line-height: 26px;
+  position: absolute;
+  right: 5px;
+  top: 0;
+}
+
+.rte2-dialogLinkSave {
+  .icon;
+  .icon-ok;
+
+  margin-right: 10px;
+}
+
+.rte2-dialogLinkOpen {
+  .icon;
+  .icon-share;
+}
+
+.rte2-dialogLinkUnlink {
+  .icon;
+  .icon-unlink;
+
+  color: @color-remove;
+  float: right;
+}


### PR DESCRIPTION
Changing classnames broke several parts of RTE2:
Add styles to link popup.
Fix the "content" search popup in the link popup.
Fix the select/change and edit buttons in the enhancement toolbar.