### PR TITLE
Richtext2 fix newlines after raw HTML and fix character count

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -153,7 +153,7 @@ function() {
   $doc.pageThumbnails('live', '.pageThumbnails');
   $doc.regionMap('live', '.regionMap');
 
-  if (DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR) {
+  if (window.DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR) {
     $doc.rte('live', '.richtext');
 
   } else {

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -304,12 +304,16 @@ function() {
 
       var $input = $(this);
 
+      // Skip textarea created inside CodeMirror editor
+      if ($input.closest('.CodeMirror').length) { return; }
+            
       updateWordCount(
           $input.closest('.inputContainer'),
           $input,
           $input.val());
     }));
 
+    // For original rich text editor, special handling for the word count
     $doc.onCreate('.wysihtml5-sandbox', function() {
       var iframe = this,
           $iframe = $(iframe),
@@ -329,6 +333,20 @@ function() {
         }
       }));
     });
+
+    // For new rich text editor, special handling for the word count.
+    // Note this counts only the text content not the final output which includes extra HTML elements.
+    $doc.on('rteChange', function(event, rte) {
+          
+        var $input, $container, count, text;
+
+        $input = rte.$el;
+        $container = $input.closest('.inputContainer');
+        text = rte.toText();
+          
+        updateWordCount($container, $input, text);
+    });
+
   })();
 
   // Handle file uploads from drag-and-drop.

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2650,7 +2650,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             // Loop through the content one line at a time
             doc.eachLine(function(line) {
 
-                var annotationStart, annotationEnd, blockOnThisLine, htmlStartOfLine, htmlEndOfLine, inlineActive, inlineElementsToClose, lineNo, outputChar, raw;
+                var annotationStart, annotationEnd, blockOnThisLine, htmlStartOfLine, htmlEndOfLine, inlineActive, inlineElementsToClose, lineNo, outputChar, raw, rawLastChar;
 
                 lineNo = line.lineNo();
                 
@@ -2706,7 +2706,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                                 // We are not already inside this style, so create the container element
                                 // and remember that we created it
                                 blockActive[container] = true;
-                                htmlStartOfLine += '<' + container + '>\n';
+                                htmlStartOfLine += '<' + container + '>';
                             }
                         }
 
@@ -2730,7 +2730,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                     if (!blockOnThisLine[container]) {
                         delete blockActive[container];
                         if (container) {
-                            html += '</' + container + '>\n';
+                            html += '</' + container + '>';
                         }
                     }
                 });
@@ -2901,16 +2901,27 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                     }
 
                     outputChar = line.text.charAt(charNum);
-                    if (raw) {
 
-                        if (outputChar === '<') {
-                            outputChar = '&raw_lt;';
+                    // In some cases (at end of line) output char might be empty
+                    if (outputChar) {
+                        
+                        if (raw) {
+
+                            if (outputChar === '<') {
+                                outputChar = '&raw_lt;';
+                            }
+
+                            rawLastChar = true;
+                        
+                        } else {
+                        
+                            outputChar = self.htmlEncode(outputChar);
+                        
+                            rawLastChar = false;
                         }
-
-                    } else {
-                        outputChar = self.htmlEncode(outputChar);
+                        
+                        html += outputChar;
                     }
-                    html += outputChar;
                 }
 
                 // If we reached end of line, close all the open block elements
@@ -2920,11 +2931,13 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                         var element;
                         element = this.element;
                         if (element) {
-                            html += '</' + element + '>\n';
+                            html += '</' + element + '>';
                         }
                     });
                     blockElementsToClose = [];
                     
+                } else if (rawLastChar) {
+                    html += '\n';
                 } else {
                     // No block elements so add a line break
                     html += '<br/>';
@@ -2941,7 +2954,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             $.each(blockActive, function(container) {
                 delete blockActive[container];
                 if (container) {
-                    html += '</' + container + '>\n';
+                    html += '</' + container + '>';
                 }
             });
 
@@ -2997,7 +3010,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                         // We got a text node, just add it to the value
                         // Remove any newlines at the beginning or end
                         // Remove "zero width space" character that the previous editor sometimes used
-                        val += next.textContent.replace(/^[\n\r]+|[\n\r]+$/g, '').replace(/\u200b|\u8203/g, '');
+                        //val += next.textContent.replace(/^[\n\r]+|[\n\r]+$/g, '').replace(/\u200b|\u8203/g, '');
+                        val += next.textContent.replace(/\u200b|\u8203/g, '');
                         
                     } else if (next.nodeType === 1) {
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -362,6 +362,9 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
          *
          * rteCursorActivity = the cursor has changed in the editor.
          * You can use this to update a toolbar for example.
+         *
+         * rteChange = a change has been made to the editor content.
+         * You can use this to update the character count for example.
          */
         initEvents: function() {
             
@@ -372,7 +375,11 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             editor = self.codeMirror;
 
             editor.on('cursorActivity', function(instance, event) {
-                self.$el.trigger('rteCursorActivity');
+                self.$el.trigger('rteCursorActivity', [self]);
+            });
+            
+            editor.on('changes', function(instance, event) {
+                self.$el.trigger('rteChange', [self]);
             });
         },
 
@@ -2362,6 +2369,18 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             self.codeMirror.focus();
         },
 
+
+        /**
+         * Returns the character count of the editor.
+         * Note this counts only the plain text, not including the HTML elements that will be in the final result.
+         * @returns Number
+         */
+        getCount: function() {
+            var count, self;
+            self = this;
+            return self.toText().length;
+        },
+
         
         /**
          * Gets the currently selected range.
@@ -2565,6 +2584,18 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
             return keymap;
         },
+
+
+        /**
+         * Get plain text from codemirror.
+         * @returns String
+         */
+        toText: function() {
+            var count, self;
+            self = this;
+            return self.codeMirror.getValue();
+        },
+
         
         /**
          * Get content from codemirror, analyze the marked up regions,


### PR DESCRIPTION
Modified HTML output and input to better support raw html.
For input: leaving newline characters in the input to force a new line
For output:
If a line ends with a character marked as raw HTML, do not add a BR element at the end of the line, instead add a newline character
For other lines, add a BR element to the end of the line
For lines that end with a block level element (like a UL or OL list) do not output a newline character.

This seems to prevent extra newlines from being added to the editor when importing arbitrary HTML for the most common cases. I don't think it will be possible to handle all cases perfectly, but this seems to be the best option.

---

Also added code to fix the character count / word count indicator.