### PR TITLE
Richtext2 multiple repeatables, placeholder text, custom toolbar special chars, inline bugfix

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -393,6 +393,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.linkInit();
             self.enhancementInit();
             self.trackChangesInit();
+
+            // Refresh the editor after all the initialization is done.
+            // We put it in a timeout to ensure the editor has displayed before doing the refresh.
+            setTimeout(function(){
+                self.rte.refresh();
+            }, 1);
         },
 
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -249,7 +249,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          * @property {String} className
          * A class to place on the toolbar link so it can be styled.
          *
-         * @property {Boolean} separator
+         * @property {Boolean} [separator]
          * Set this and no other properties to add a separator between groups of toolbar icons.
          *
          * @property {Boolean} [inline=true]
@@ -260,6 +260,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          * Placeholder where you want any custom CMS styles to appear in the toolbar.
          * Set this to true.
          *
+         * @property {String} [value]
+         * When using action="insert" use the "value" attribute to specify text to be inserted.
+         *
          * @property {String} action
          * The name of a supported toolbar action. The following are supported:
          *
@@ -269,6 +272,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          *
          * @property {String} action='clear'
          * Clear all styles within the range.
+         *
+         * @property {String} action='insert'
+         * Insert text at the current selection or cursor position.
+         * Specify the text using the "value" attribute.
          *
          * @property {String} action='trackChangesToggle'
          * Toggle the track changes function.
@@ -285,6 +292,22 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          * @example:
          * For a single icon provide the following information:
          * { style: 'bold', text: 'B', className: 'rte2-toolbar-bold' },
+         *
+         * @example
+         *
+         * To add more buttons to the toolbar for an individual target, you can add to the Rte.toolbarConfig array.
+         * For example, to add some buttons for inserting special characters, run the following code before
+         * the rich text editor has been created on the page:
+         *
+         * require(['jquery', 'v3/input/richtext2'], function($, Rte) {
+         *     // Add buttons to the new rich text editor
+         *     $.merge(rte2.toolbarConfig, [
+         *         { separator:true },
+         *         { action: 'insert', text:'em-', className: 'rte2-toolbar-insert', tooltip:'Em-dash', value:'—'},
+         *         { action: 'insert', text:'…', className: 'rte2-toolbar-insert', tooltip:'Ellipsis', value:'…'}
+         *     ]);
+         * });
+         *
          */
         toolbarConfig: [
 
@@ -324,6 +347,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             { action: 'collapse', text: 'Collapse All Comments', className: 'rte2-toolbar-comment-collapse', collapseStyle: 'comment', tooltip: 'Collapse All Comments' },
             { action: 'cleartext', text: 'Remove Comment', className: 'rte2-toolbar-comment-remove', tooltip: 'Remove Comment', cleartextStyle: 'comment' }
 
+            // Example adding buttons to insert special characters or other text:
+            // { separator:true },
+            // { action: 'insert', text:'em-', className: 'rte2-toolbar-insert', tooltip:'Em-dash', value:'—'},
+            // { action: 'insert', text:'…', className: 'rte2-toolbar-insert', tooltip:'Ellipsis', value:'…'}
         ],
 
 
@@ -947,6 +974,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     self.enhancementCreate();
                     break;
 
+                case 'insert':
+                    if (item.value) {
+                        rte.insert(item.value);
+                    }
+                    break;
+                    
                 case 'marker':
 
                     // Stop the event from propagating, otherwise it will close the enhancement popup

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -393,7 +393,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.linkInit();
             self.enhancementInit();
             self.trackChangesInit();
-
+            self.placeholderInit();
+            
             // Refresh the editor after all the initialization is done.
             // We put it in a timeout to ensure the editor has displayed before doing the refresh.
             setTimeout(function(){
@@ -2342,6 +2343,71 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         },
 
 
+        /*==================================================
+         * Placeholder
+         *==================================================*/
+
+        /**
+         * Set the placeholder text for when the editor is empty,
+         * and periodically check to see if the placeholder text
+         * has changed.
+         */
+        placeholderInit: function() {
+            
+            var interval, self;
+
+            self = this;
+
+            // Set the placeholder
+            self.placeholderRefresh();
+
+            // Repeat checking the placeholder because it might change due to other plugins
+            // running on the page even after the page has completed loading
+            interval = setInterval(function(){
+
+                // Check if the editor is still on the page
+                if ($.contains(document, self.$el[0])) {
+                    self.placeholderRefresh();
+                } else {
+                    // If the editor has been removed from the DOM, stop running this!
+                    clearInterval(interval);
+                }
+                
+            }, 200);
+        },
+
+
+        /**
+         * Check to see if the textarea has a placeholder attribute, and
+         * if so display it over the rich text editor when the editor is empty.
+         */
+        placeholderRefresh: function() {
+
+            var attrName, count, placeholder, self, $wrapper;
+            self = this;
+
+            // Get the placeholder attribute from the textarea element
+            placeholder = self.$el.attr('placeholder') || '';
+
+            attrName = 'rte2-placeholder';
+            
+            // Is the editor empty?
+            count = self.rte.getCount();
+
+            if (count === 0 && placeholder) {
+
+                // Add a placeholder attribute to the container.
+                // CSS rules will overlay the text on top of the editor.
+                self.$container.attr(attrName, placeholder);
+                
+            } else {
+
+                // Remove the attribute so the text will not be overlayed
+                self.$container.removeAttr(attrName);
+            }
+        },
+
+        
         /*==================================================
          * Misc
          *==================================================*/

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2485,7 +2485,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // ??? Not really sure how plugin2 works, just copying existing code
 
             // Get the options from the element
-            options = this.option();
+            // Make a copy of the object with extend so we don't
+            // accidentally change any global default options
+            options = $.extend(true, {}, this.option());
 
             inline = $input.data('inline');
             if (inline !== undefined) {
@@ -2493,7 +2495,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             }
 
             // ???
-            $input.data('rte2-options', $.extend(true, { }, options));
+            $input.data('rte2-options', options);
 
 
             rte = Object.create(Rte);

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3304,6 +3304,18 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
 
         /**
+         * Add text to the editor at the current selection or cursor position.
+         */
+        insert: function(value) {
+            var self;
+
+            self = this;
+
+            self.codeMirror.replaceSelection(value);
+        },
+
+        
+        /**
          * Encode text so it is HTML safe.
          * @param {String} s
          * @return {String}

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -252,6 +252,17 @@
 }
 
 .rte2-wrapper {
+
+  position:relative;
+  
+  &::after {
+    content: attr(rte2-placeholder);
+    position:absolute;
+    left:0.5em;
+    top:0.5em;
+    color: @color-placeholder;
+    font-style: italic;
+  }
   
   .CodeMirror {
     
@@ -359,3 +370,4 @@
   color: @color-remove;
   float: right;
 }
+


### PR DESCRIPTION
The rich text editor did not display text until you clicked on it in repeatble-previewable object such as slideshows. This commit adds a refresh that seems to fix the problem.

Add support for placeholder text when the rich text editor is empty.
Note since placeholder text is loaded and changes dynamically, the placeholder text must be consistently polled and updated - functionally the same as the old rich text editor.

Added functionality that lets individual projects customize the rich text toolbar and add buttons that insert special characters such as em-dash or ellipsis.

Bugfix for all subsequent editors being created as "inline" after a single inline editor is created.