### PR TITLE
Fixes logic around extracting metadata for storage items

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/page/UploadFiles.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/UploadFiles.java
@@ -219,10 +219,7 @@ public class UploadFiles extends PageServlet {
 
                         item.save();
 
-                        Map<String, Object> metadata = StorageItemField.extractMetadata(item, Optional.empty());
-                        if (metadata != null) {
-                            item.getMetadata().putAll(metadata);
-                        }
+                        StorageItemField.tryExtractMetadata(item, item.getMetadata(), Optional.empty());
 
                         Object object = selectedType.createObject(null);
                         State state = State.getInstance(object);


### PR DESCRIPTION
This is mostly an aesthetic change to simplify usage of a storage item's InputStream for extracting metadata