### PR TITLE
inputContainer remove overflow:hidden to prevent cropping dropdown menus

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/form.less
+++ b/tool-ui/src/main/webapp/style/v3/form.less
@@ -147,7 +147,6 @@
 .inputContainer {
   margin: 0 0 10px 0;
   min-height: 30px;
-  overflow: hidden;
   position: relative;
 
   &:before {
@@ -165,6 +164,14 @@
     }
   }
 
+  // Most reliable way to clear floats and avoid margin collapse after the input container
+  // As described here: https://css-tricks.com/snippets/css/clear-fix/
+  &:after {
+    content: '';
+    display:table;
+    clear:both;
+  }
+  
   .message {
     margin-bottom: 5px;
   }


### PR DESCRIPTION
The overflow:hidden style on .inputContainer is cropping drop-down menus from the rich text editor, plus cropping image selectors (see screenshot below).

Removing the overflow hidden style doesn't seem to have any major effect, other than causing some margins to collapse.  Added an alternate :after style that clears the floats and prevents margins from collapsing (which I am guessing was the original intent of using the overflow:hidden style in the first place.

Before changes:
![overflow-hidden-cropped](https://cloud.githubusercontent.com/assets/185461/8914274/4787e29e-346c-11e5-99c5-850db6b4946a.jpg)
