### PR TITLE
Bugfix screens with left nav floating issue

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/layout.less
+++ b/tool-ui/src/main/webapp/style/v3/layout.less
@@ -10,5 +10,14 @@
 
   > .main {
     margin-left: (@rail-width + @gap-medium);
+
+
+    // Create a new "block formatting context" so when we clear floats within
+    // it does not clear the float of the leftNav
+    // https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+    > .widget {
+      display:inline-block;
+      width:100%;
+    }
   }
 }


### PR DESCRIPTION
On CMS screens that have a left nav (like settings pages), the previous change to the inputContainer styles is causing the first inputContainer to be stretched to the height of the left nav. Also when the page is scrolled and the left nav moves down, the inputContainer would stretch even more and prevent the page from scrolling correctly.

This commit adds some styles to the containing element to create a new "block formatting content" so when the float is cleared after the inputContainer it does not clear the left navigation float.