### PR TITLE
Richtext2 enhancements: divs, newlines, toolbar z-index, improve comment collapse

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -976,7 +976,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
                 case 'collapse':
                     if (item.collapseStyle) {
-                        rte.inlineCollapse(item.collapseStyle, rte.getRangeAll());
+                        rte.inlineToggleCollapse(item.collapseStyle, rte.getRangeAll());
                     }
                     break;
 
@@ -1038,6 +1038,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 }
             }
 
+            // Certain styles like comments look strange when there are two
+            // adjacent marks, so combine adjacent marks if possible.
+            rte.inlineCombineAdjacentMarks();
+            
             // Update the toolbar so it makes the buttons active or inactive
             // based on the cursor position or selection
             self.toolbarUpdate();
@@ -2434,7 +2438,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          */
         placeholderRefresh: function() {
 
-            var attrName, count, placeholder, self, $wrapper;
+            var attrName, count, placeholder, self;
             self = this;
 
             // Get the placeholder attribute from the textarea element

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -224,11 +224,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     style: 'text-align:right'
                 },
                 clear: ['alignLeft', 'alignCenter', 'ol', 'ul']
-            },
-            div: {
-                className: 'rte2-style-div',
-                line: true,
-                element: 'div'
             }
 
         },

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -11,6 +11,11 @@
   vertical-align: top;
   
   z-index:3; // Give a higher z-index than the rich text editor
+  &:hover {
+    // When hovering the toolbar, give it a higher z-index than
+    // other toolbars below (so submenu will be on top of other toolbars)
+    z-index:4;
+  }
   
   .state-disabled & {
     display: none;
@@ -172,9 +177,11 @@
 }
 
 .rte2-style-html {
-  font-weight:bold;
   font-family: @fontFamily-code;
   background-color:fade(black, 10%);
+}
+.rte2-style-newline {
+  color: @color-placeholder;
 }
 .rte2-style-bold {
   font-weight:bold;


### PR DESCRIPTION
When importing HTML, treat \n as a special character. Display the newline as a carriage return symbol in the editor.
For output, convert back to \n

Added a keyboard shortcut Shift-Enter to manually create a newline.

Also made DIV elements import as raw HTML.

Also fixed a z-index issue where the toolbar submenu was being obscured if another rich text editor was below it.

Changes and bugfixes related to comment collapsing:

Bugfix for collapsing comments - multiple collapsed marks were being created, so you would have to click multiple times to uncollapse.

Change behavior of toolbar collapse icon so it will be a toggle to collapse / uncollapse all the comments in the editor.