### PR TITLE
RichTextEditor2 update preview on change

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -592,6 +592,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             // Set the content into the editor
             self.rte.fromHTML(content);
+
+            // Set up periodic update of the textarea
+            self.previewInit();
         },
 
 
@@ -2454,6 +2457,51 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
                 // Remove the attribute so the text will not be overlayed
                 self.$container.removeAttr(attrName);
+            }
+        },
+
+        
+        /*==================================================
+         * Preview
+         * To support brightspot cms preview functionality,
+         * we must keep the textarea updated with the most recent data.
+         * Triggering an "input" event will update the preview.
+         *==================================================*/
+
+        
+        /**
+         * Initialize an event listener so whenever the rich text editor changes,
+         * we update the textarea with the latest content, and trigger an
+         * event to update the preview.
+         *
+         * This is throttled agressively to prevent performance problems.
+         */
+        previewInit: function() {
+            
+            var self;
+            self = this;
+
+            self.$container.on('rteChange', $.throttle(2000, function(){
+                self.previewUpdate();
+            }));
+        },
+
+        
+        /**
+         * Update the textarea with the latest content from the rich text editor,
+         * plus trigger an "input" event so the preview will be updated.
+         */
+        previewUpdate: function() {
+            
+            var html, self;
+            
+            self = this;
+
+            html = self.toHTML();
+            
+            if (html !== self.previewUpdateSaved) {
+                self.previewUpdateSaved = html;
+                self.$el.val(html).trigger('input');
             }
         },
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -385,7 +385,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             });
             
             editor.on('changes', function(instance, event) {
-                self.$el.trigger('rteChange', [self]);
+                self.triggerChange();
             });
 
             editor.on('focus', function(instance, event) {
@@ -397,7 +397,18 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             });
         },
 
+        
+        /**
+         * Trigger an rteChange event.
+         * This can happen when user types changes into the editor, or if some kind of mark is modified.
+         */
+        triggerChange: function() {
+            var self;
+            self = this;
+            self.$el.trigger('rteChange', [self]);
+        },
 
+        
         //==================================================
         // STYLE FUNCTIONS
         // The following functions deal with inline or block styles.
@@ -457,7 +468,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             }
 
             self.rawCleanup();
-            
+
             return mark;
         },
 
@@ -595,6 +606,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             // Trigger a cursorActivity event so for example toolbar can pick up changes
             CodeMirror.signal(editor, "cursorActivity");
 
+            self.triggerChange();
+            
             return mark;
             
         }, // initSetStyle
@@ -862,6 +875,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
             // Trigger a cursor activity event so the toolbar can update
             CodeMirror.signal(editor, "cursorActivity");
+            
+            self.triggerChange();
         },
 
 
@@ -890,6 +905,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
                 // Delete the mark
                 mark.clear();
+                
+                self.triggerChange();
             }
         },
 
@@ -1585,6 +1602,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             // Refresh the editor display since our line classes
             // might have padding that messes with the cursor position
             editor.refresh();
+            
+            self.triggerChange();
         },
 
         
@@ -1629,6 +1648,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             // Refresh the editor display since our line classes
             // might have padding that messes with the cursor position
             editor.refresh();
+            
+            self.triggerChange();
         },
         
 
@@ -1879,6 +1900,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                 mark.changed();
             }, 100);
             
+            self.triggerChange();
+            
             return mark;
         },
 
@@ -1949,6 +1972,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             }
             mark.clear();
             self.codeMirror.removeLineWidget(mark);
+            
+            self.triggerChange();
         },
 
 


### PR DESCRIPTION
To support CMS preview functionality, added code to trigger "input" event on the textarea whenever a change is made, and update the textarea content with latest HTML from the editor.