### PR TITLE
RTE2 bugfix for markers, data-rte2-raw attributes, blank tag in custom styles

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -93,7 +93,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             link: {
                 className: 'rte2-style-link',
                 element: 'a',
-
+                elementAttrAny: true, // Allow any attributes for this element
+                
                 // Do not allow links to span multiple lines
                 singleLine: true,
 
@@ -650,9 +651,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             $('body').toggleClass('rte-fullscreen');
             self.$container.toggleClass('rte-fullscreen');
             
-            //$(composer.parent.container).toggleClass('rte-fullscreen');
-            //$(composer.element).toggleClass('rte-fullscreen');
-
             // After changing fullscreen status, kick the toolbar in case it was moved due to scrolling
             self.toolbarHoist();
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -519,7 +519,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                             className: cmsClassName,
 
                             // The HTML element and class name to output for this style
-                            element: classConfig.tag.toLowerCase(),
+                            element: (classConfig.tag || 'span').toLowerCase(),
                             elementAttr: {
                                 'class': cmsClassName
                             }

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3331,7 +3331,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                         };
 
                         // Special case - is this an enhancement?
-                        if (elementName === 'span' && $(next).attr('class') === 'enhancement') {
+                        if (elementName === 'span' && $(next).hasClass('enhancement')) {
 
                             enhancements.push({
                                 line: from.line,


### PR DESCRIPTION
When adding a marker then publishing the page and returning to the editor, the marker appears as raw HTML instead of as a marker.

Remove data-rte2-raw from HTML export.

Fix error for custom CMS styles with blank tags.