### PR TITLE
RTE2 various fixes: end of line / track changes "show final" / enhancements

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2116,7 +2116,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             if ($el.hasClass('rte2-style-enhancement-left')) {
                 pos = 'left';
-            } else if ($el.hasClass('rte2-style-enhancement-left')) {
+            } else if ($el.hasClass('rte2-style-enhancement-right')) {
                 pos = 'right';
             }
 
@@ -2382,7 +2382,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 id = reference.record._ref;
             }
 
+            delete reference.alignment;
             alignment = self.enhancementGetPosition(el);
+            if (alignment) {
+                reference.alignment = alignment;
+            }
 
             if (id) {
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -87,6 +87,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 elementAttr: {
                     'class': 'rte rte-comment'
                 },
+                
+                // Hide this style when viewing in "show final" mode
+                showFinal:false,
+                
                 // Don't let this style be removed by the "Clear" toolbar button
                 internal: true
             },

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1565,25 +1565,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 // Save the data on the enhancement so it can be used later
                 self.enhancementSetReference($enhancement, data);
 
-                // Modify the Select button in the toolbar
-                $select = $enhancement.find('.rte2-enhancement-toolbar-change');
-                $select.text('Change');
-
-                // Modify the "Edit" button in the toolbar so it will pop up the edit dialog for the enhancement
-                $edit = $enhancement.find('.rte2-enhancement-toolbar-edit');
-                editUrl = $edit.attr('href') || '';
-                editUrl = $.addQueryParameters(editUrl, 'id', data.record._ref);
-                $edit.attr('href', editUrl);
-
+                // Close the popup - this will also trigger the enhancement display to be updated (see 'close' event below)
+                $target.popup('close');
+                
                 event.preventDefault();
                 event.stopImmediatePropagation();
-                $target.popup('close');
                 return false;
             });
 
 
             // Set up a global close event to determine when the enhancement popup is closed
-            // so we can remove the enhancement if nothing was selected.
+            // so we can update the enhancement display (or remove the enhancement)
             $(document).on('close', '.popup[name^="contentEnhancement-"]', function() {
 
                 var $enhancement, $popupTrigger, $popup;
@@ -1732,7 +1724,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 // Modify the "Edit" button in the toolbar so it will pop up the edit dialog for the enhancement
                 $edit = $enhancement.find('.rte2-enhancement-toolbar-edit');
                 editUrl = $edit.attr('href') || '';
-                editUrl = $.addQueryParameters(editUrl, 'id', reference.record._ref);
+                editUrl = $.addQueryParameters(editUrl,
+                                               'id', reference.record._ref,
+                                               'reference', JSON.stringify(reference));
                 $edit.attr('href', editUrl);
             }
         },

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -1916,9 +1916,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             setTimeout(function(){
                 self.refresh();
                 mark.changed();
+                self.triggerChange();
             }, 100);
-            
-            self.triggerChange();
             
             return mark;
         },
@@ -2040,12 +2039,14 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
          * @param Object mark
          * The mark that was returned when you called enhancementAdd().
          */
-        enhancementSetInline: function(mark) {
+        enhancementSetInline: function(mark, options) {
             
-            var content, lineNumber, self;
+            var content, $content, lineNumber, self;
 
             self = this;
 
+            options = options || {};
+            
             lineNumber = self.enhancementGetLineNumber(mark);
             
             content = self.enhancementGetContent(mark);
@@ -2053,7 +2054,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
             self.enhancementRemove(mark);
             
-            return self.enhancementAdd($content[0], lineNumber);
+            return self.enhancementAdd($content[0], lineNumber, $.extend({}, mark.options || {}, options, {block:false}));
         },
 
         
@@ -2068,7 +2069,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
          */
         enhancementSetBlock: function(mark, options) {
 
-            var content, lineNumber, self;
+            var content, $content, lineNumber, self;
 
             self = this;
 
@@ -2081,7 +2082,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
             self.enhancementRemove(mark);
             
-            return self.enhancementAdd($content[0], lineNumber, $.extend({}, options, {block:true}));
+            return self.enhancementAdd($content[0], lineNumber, $.extend({}, mark.options || {}, options, {block:true}));
         },
 
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -114,19 +114,21 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             trackDelete: {
                 className: 'rte2-style-track-delete',
                 element: 'del',
-                internal: true
+                internal: true,
+                showFinal: false
             },
 
             // The following styles are used internally to show the final results of the user's tracked changes.
             // The user can toggle between showing the tracked changes (insertions and deletions) or showing
             // the final result.
             
-            trackDeleteHidden: {
+            trackHideFinal: {
                 // This class is used internally to hide deleted content temporarily.
                 // It does not create an element for output.
-                className: 'rte2-style-track-delete-hidden',
+                className: 'rte2-style-track-hide-final',
                 internal: true
             },
+            
             trackDisplay: {
                 // This class is placed on the wrapper elemnt for the entire editor,
                 // and is used to remove the colors from inserted content temporarily.
@@ -2499,22 +2501,28 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             // Find all the marks for deleted elements
             $.each(editor.getAllMarks(), function(i, mark) {
 
-                // Remove of the trackDeleteHidden marks that were previously set
-                if (mark.className === self.styles.trackDeleteHidden.className) {
+                var styleObj;
+                
+                styleObj = self.classes[ mark.className ] || {};
+                
+                // Remove of the trackHideFinal marks that were previously set
+                if (mark.className === self.styles.trackHideFinal.className) {
                     mark.clear();
                 }
 
-                if (mark.className === self.styles.trackDelete.className && !self.trackDisplay) {
+                // Check if this style should be hidden when in "Show Final" mode
+                if (styleObj.showFinal === false && !self.trackDisplay) {
 
                     // Hide the deleted elements by creating a new mark that collapses (hides) the text
                     
                     pos = mark.find();
                     
                     editor.markText(pos.from, pos.to, {
-                        className: self.styles.trackDeleteHidden.className,
+                        className: self.styles.trackHideFinal.className,
                         collapsed: true
                     });
                 }
+
             });
         },
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -187,6 +187,14 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
          */
         rawAddDataAttribute: false,
 
+
+        /**
+         * When a line ends in a character marked as raw HTML, should we add a BR element?
+         * If true, add a BR element at the end of every line.
+         * If false, add a newline if the last character in the line is marked as raw HTML.
+         */
+        rawBr: true,
+
         
         /**
          *
@@ -3154,8 +3162,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
                         }
                     });
                     blockElementsToClose = [];
-                    
-                } else if (rawLastChar) {
+
+                } else if (rawLastChar && !self.rawBr) {
                     html += '\n';
                 } else {
                     // No block elements so add a line break


### PR DESCRIPTION
Added a parameter (defaulting to true) so the end of each line in the editor will always output a BR element.

The previous behavior was to detect if the last character in a line was marked as raw HTML, and to output a newline character instead. This caused certain inconsistencies if the user entered text on an existing line then marked it as raw HTML (in some cases a BR element was changed to a newline in that case).

The new behavior has some downsides as well - if you enter multiple lines of text then mark them all as raw HTML, you could get some extra BR elements. To prevent this from happening, any HTML entered this way should be entered on a single line.

---

When the "show final" option (eyeball icon in the toolbar) is active, comments should be hidden. Modified the configuration parameters so any style can be marked showFinal:false to hide it in show final mode.

---

The "edit" button for enhancements was not passing the 'reference' parameter (which is required to allow overrides for the enhancement). According to the bug description: When using the `ToolUi.Referenceable` annotation, the developer has an option to pass in a class name. We use this on Images to allow an editor to override a caption/alt text and to add a link to a specific enhancement. When using the new RTE this data is no longer being saved in the CMS. Still works as expected in the old RTE.

---

When enhancement was changed to float left or right, the enhancement was no longer being saved. This commit fixes the saving issue, and also fixes the attributes that are added to the enhancement when it is floated left or right.