### PR TITLE
RTE add editable placeholder + misc bugfixes

### DIFF
--- a/tool-ui/src/main/webapp/script/jquery.editableplaceholder.js
+++ b/tool-ui/src/main/webapp/script/jquery.editableplaceholder.js
@@ -8,25 +8,85 @@ $.plugin2('editablePlaceholder', {
             return $input.attr('data-editable-placeholder') || $input.prop('placeholder');
         }
 
-        plugin.$caller.delegate(selector, 'focus.editablePlaceholder mouseenter.editablePlaceholder', function() {
-            var $input = $(this);
+        /**
+         * Get or set the value for an input or a rich text editor.
+         *
+         * @param {Element|jQuery} $input
+         * Element or jQuery object for the input or text area.
+         *
+         * @param {String} [value]
+         * Optional value to set.
+         * If provided we will set the value.
+         * If not provided we will get the value.
+         */
+        function val($input, value) {
+            
+            var rte;
+            
+            // Convert element to jquery object if necessary
+            $input = $($input);
 
-            if (!$input.val()) {
+            // Determine if this is a textarea rich text editor.
+            // The rte controller is stored in the 'rte2' data.
+            rte = $input.data('rte2');
+
+            if (rte) {
+                if (value === undefined) {
+                    return rte.toHTML();
+                } else {
+                    if (value==='') {
+                        rte.rte.empty();
+                    } else {
+                        rte.fromHTML(value);
+                    }
+
+                    // In some cases when we put HTML into the rich text editor,
+                    // it might get modified when we pull it back out.
+                    // So to ensure that we know when the value was actually modified by the user,
+                    // we'll pull out the HTML right after we put it in, and save
+                    // it for future comparison.
+                    $input.data('editable-placeholder-rte-value', rte.toHTML());
+
+                    rte.placeholderRefresh();
+                }
+            } else {
+                if (value === undefined) {
+                    return $input.val();
+                } else {
+                    $input.val(value);
+                }
+            }
+        }
+
+        plugin.$caller.delegate(selector, 'focus.editablePlaceholder mouseenter.editablePlaceholder rteFocus', function() {
+            var $input = $(this);
+            
+            if (!val($input)) {
+                val($input, getPlaceholder($input));
                 $.data(this, 'editable-placeholder-empty-before-focus', true);
-                $input.val(getPlaceholder($input));
             }
         });
 
-        plugin.$caller.delegate(selector, 'input.editablePlaceholder', function() {
+        plugin.$caller.delegate(selector, 'input.editablePlaceholder rteChange', function() {
             $.removeData(this, 'editable-placeholder-empty-before-focus');
         });
 
-        plugin.$caller.delegate(selector, 'blur.editablePlaceholder', function() {
-            var $input = $(this);
+        plugin.$caller.delegate(selector, 'blur.editablePlaceholder rteBlur', function() {
+            
+            var $input = $(this), placeholder, rte, value, valueRte;
 
-            if ($.data(this, 'editable-placeholder-empty-before-focus') ||
-                    $input.val() === getPlaceholder($input)) {
-                $input.val('');
+            value = val($input);
+            
+            // In case this is a rich text editor, get the value that was originally set on the focus event
+            valueRte = $input.data('editable-placeholder-rte-value');
+            
+            placeholder = getPlaceholder($input);
+
+            if ( $.data(this, 'editable-placeholder-empty-before-focus') ||
+                 value === placeholder ||
+                 value === valueRte) {
+                
+                val($input, '');
             }
         });
 
@@ -34,8 +94,9 @@ $.plugin2('editablePlaceholder', {
             var $input = $(this);
 
             if (!$input.is(':focus') &&
-                    $input.val() === getPlaceholder($input)) {
-                $input.val('');
+                val($input) === getPlaceholder($input)) {
+                
+                val($input, '');
             }
         });
     }

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -631,7 +631,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // This is useful for when the external code doesn't know the self.$el (textarea)
             self.$container.data('rte2', self);
 
-            self.$editor = $('<div/>').appendTo(self.$container);
+            self.$editor = $('<div/>', {'class':'rte2-codemirror'}).appendTo(self.$container);
                 
             // Hide the textarea
             self.$el.hide();
@@ -2566,12 +2566,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
                 // Add a placeholder attribute to the container.
                 // CSS rules will overlay the text on top of the editor.
-                self.$container.attr(attrName, placeholder);
+                self.$editor.attr(attrName, placeholder);
                 
             } else {
 
                 // Remove the attribute so the text will not be overlayed
-                self.$container.removeAttr(attrName);
+                self.$editor.removeAttr(attrName);
             }
         },
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -631,6 +631,21 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // This is useful for when the external code doesn't know the self.$el (textarea)
             self.$container.data('rte2', self);
 
+            // Since the rte will trigger special events on the container,
+            // we should catch them and pass them to the textarea
+            self.$container.on('rteFocus', function(){
+                self.$el.trigger('rteFocus', [self]);
+                return false;
+            });
+            self.$container.on('rteBlur', function(){
+                self.$el.trigger('rteBlur', [self]);
+                return false;
+            });
+            self.$container.on('rteChange', function(){
+                self.$el.trigger('rteChange', [self]);
+                return false;
+            });
+
             self.$editor = $('<div/>', {'class':'rte2-codemirror'}).appendTo(self.$container);
                 
             // Hide the textarea
@@ -2637,6 +2652,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self = this;
             html = self.rte.toHTML();
             return html;
+        },
+
+        toText: function() {
+            var self, text;
+            self = this;
+            text = self.rte.toText();
+            return text;
         },
 
         focus: function() {

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -257,6 +257,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Google docs styles
             'span[style*="font-style:italic"]': 'italic',
             'span[style*="font-weight:700"]': 'bold',
+            'span[style*="font-weight:bold"]': 'bold',
+            'span[style*="font-weight: bold"]': 'bold',
             'span[style*="text-decoration:underline"]': 'underline',
             'span[style*="vertical-align:super"]': 'superscript',
             'span[style*="vertical-align:sub"]': 'subscript',

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3791,8 +3791,8 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
             processNode(el);
 
-            // Set the text in the editor
-            val = val.replace(/[\n\r]+$/, '');
+            // Replace multiple newlines at the end with single newline
+            val = val.replace(/[\n\r]+$/, '\n');
 
             if (range) {
 

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -259,13 +259,23 @@
 
   position:relative;
   
-  &::after {
-    content: attr(rte2-placeholder);
-    position:absolute;
-    left:0.5em;
-    top:0.5em;
-    color: @color-placeholder;
-    font-style: italic;
+  .rte2-codemirror {
+    position:relative;
+    &::after {
+      content: attr(rte2-placeholder);
+      position:absolute;
+      left:0.5em;
+      top:0.5em;
+      color: @color-placeholder;
+      font-style: italic;
+
+      // Temporary styles to limit palceholder to single line
+      // until we can implement editable placeholder correctly
+      width:95%;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
+    }
   }
 
   &.rte-fullscreen {


### PR DESCRIPTION
Change to placeholder text extending outside the RTE, to truncate the text.

Modified editable placeholder plugin to support new RTE. Due to performance and usability issues, inserts the placeholder text only when editor gets focus (not on mouseover).

---

Also adds support for bold + italic text imported from Gmail HTML.

---

Fixed problem when enhancement was on last line of the editor and was being moved up one line when the editor reloads.