### PR TITLE
RTE add clipboardSanitizeFunction

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -158,6 +158,28 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
         
         /**
+         * Function for cleaning up the clipboard data when content is pasted
+         * from outside the RTE.
+         *
+         * @param {jQuery} $content
+         * The content that was pasted.
+         *
+         * @returns {jQuery}
+         * The modified content.
+         *
+         * @example
+         * function($content) {
+         *     // Remove anything with class "badclass"
+         *     $content.find('.badclass').remove();
+         *     return $content;
+         * }
+         */
+        clipboardSanitizeFunction: function($content) {
+            return $content;
+        },
+
+        
+        /**
          * Should we track changes?
          * Note: do not set this directly, use trackSet() or trackToggle()
          */
@@ -2639,14 +2661,20 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             dom = self.htmlParse(html);
             $el = $(dom);
 
+            // Apply the clipboard sanitize rules (if any)
             if (self.clipboardSanitizeRules) {
                 $el.find('p').after('<br/>');
                 $.each(self.clipboardSanitizeRules, function(selector, style) {
                     $el.find(selector).wrapInner( $('<span>', {'data-rte2-sanitize': style}) );
                 });
             }
-            
-            return dom;
+
+            // Run it through the clipboard sanitize function (if it exists)
+            if (self.clipboardSanitizeFunction) {
+                $el = self.clipboardSanitizeFunction($el);
+            }
+
+            return $el[0];
         },
 
         


### PR DESCRIPTION
Add a clipboardSanitizeFunction that can be set within the CMS.

For HTML from outside that is pasted into the editor, this function can modify the HTML before it is parsed by the editor. For example, to remove content.

To implement go to CMS settings > Debug > Extra Javacript, and add code like the following:

    require(['jquery', 'v3/input/richtextCodeMirror'], function($, rte) {
        rte.clipboardSanitizeFunction = function($d) {
            // Example:
            // $d.find('br').after('<p>Adding another paragraph!</p>');
            return $d;
        };
    });