### PR TITLE
RTE2 bugfix for Firefox pasting from MSWord

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -429,3 +429,9 @@
   float: right;
 }
 
+// Div that is used as a paste clipboard
+// Note this cannot be hidden because it needs to get focus
+.rte2-clipboard {
+  max-height:1px;
+  overflow:hidden;
+}


### PR DESCRIPTION
Add a workaround for the rich text editor, only in Windows Firefox browser, to allow styled content to be pasted from Microsoft Word. Only works for Ctrl-V pasting (not selecting Edit>Paste from the menu).
