### PR TITLE
RTE2 exclude track changes deleted content from word count

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -330,16 +330,22 @@ function() {
 
     // For new rich text editor, special handling for the word count.
     // Note this counts only the text content not the final output which includes extra HTML elements.
-    $doc.on('rteChange', function(event, rte) {
+    $doc.on('rteChange', $.throttle(1000, function(event, rte) {
           
-        var $input, $container, count, text;
+        var $input, $container, html, $html, text;
 
         $input = rte.$el;
         $container = $input.closest('.inputContainer');
-        text = rte.toText();
-          
+        
+        html = rte.toHTML();
+        $html = $('<div/>').append(html);
+        $html.find('del').remove();
+        $html.find('br,p,div,ul,ol,li').after('\n');
+        text = $html.text();
+
         updateWordCount($container, $input, text);
-    });
+
+    }));
 
   })();
 

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -338,7 +338,7 @@ function() {
         $container = $input.closest('.inputContainer');
         
         html = rte.toHTML();
-        $html = $('<div/>').append(html);
+        $html = $(new DOMParser().parseFromString(html, "text/html").body);
         $html.find('del').remove();
         $html.find('br,p,div,ul,ol,li').after('\n');
         text = $html.text();

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2463,6 +2463,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             }
             
             mark.clear();
+            self.triggerChange();
         },
 
 
@@ -2483,6 +2484,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
             }
             
             mark.clear();
+            self.triggerChange();
         },
 
 


### PR DESCRIPTION
Modify the word count for rich text editor 2 to exclude areas that are marked DEL when using track changes.

Note this adds a bit of processing because now the word count has to convert the editor content to HTML and remove the deleted areas, instead of previous behavior getting just the text from the editor.
