### PR TITLE
Bugfix for repeatable upload files

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -590,6 +590,16 @@ The HTML within the repeatable element must conform to these standards:
                     self.dom.$list.append($addedItem);
                     
                     // Initialize stuff on the new item
+                    // If there was a custom callback provided, call it now.
+                    // This is used for example, in Image Upload.
+                    // After the image is uploaded a new repeatable item is added,
+                    // then the callback inserts values into the template.
+                    if (customCallback) {
+                        
+                        // Call the customcallback funtion, setting "this" to be the element for the new item
+                        customCallback.call( $addedItem[0] );
+                    }
+
                     // Note this will collapse the item as well so we will uncollapse it below
                     self.initItem($addedItem);
                     
@@ -621,16 +631,6 @@ The HTML within the repeatable element must conform to these standards:
                         
                         return newAttr;
                     });
-
-                    // If there was a custom callback provided, call it now.
-                    // This is used for example, in Image Upload.
-                    // After the image is uploaded a new repeatable item is added,
-                    // then the callback inserts values into the template.
-                    if (customCallback) {
-                        
-                        // Call the customcallback funtion, setting "this" to be the element for the new item
-                        customCallback.call( $addedItem[0] );
-                    }
 
                     // Trigger a custom "create" event for the item
                     // So other code can act on this if necessary


### PR DESCRIPTION
For repeatables such as slideshow, the "Upload Files" functionality was not working since we implemented the grid / gallery views. This occurred because the hidden inputs for each slide were being moved, and a callback function was no longer able to find them.

Moved the callback function so it would occur before the hidden inputs were moved.