### PR TITLE
Hotspot fix for embedded data

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -620,6 +620,13 @@ function() {
     var $frame = $(event.target);
     var $parent = $frame.popup('source').closest('.popup, .toolContent');
 
+    // Since the edit popup might contain other popups within it,
+    // only run this code when the edit popup is opened
+    // (not when the internal popups are opened)
+    if (!$frame.is('.popup[data-popup-source-class~="objectId-edit"]')) {
+      return;
+    }
+    
     $frame.popup('container').removeClass('popup-objectId-edit-hide');
     $parent.addClass('popup-objectId-edit popup-objectId-edit-loading');
     $win.resize();
@@ -710,11 +717,20 @@ function() {
   });
 
   $doc.on('close', '.popup[data-popup-source-class~="objectId-edit"]', function(event) {
-    scrollTops.pop();
-
+    
     var $frame = $(event.target);
+
+    // Since the edit popup might contain other popups within it,
+    // only run this code when the edit popup is opened
+    // (not when the internal popups are opened)
+    if (!$frame.is('.popup[data-popup-source-class~="objectId-edit"]')) {
+      return;
+    }
+
     var $source = $frame.popup('source');
     var $popup = $frame.popup('container');
+
+    scrollTops.pop();
 
     if ($.data($popup[0], 'popup-close-cancelled')) {
       return;

--- a/tool-ui/src/main/webapp/script/v3/input/image.js
+++ b/tool-ui/src/main/webapp/script/v3/input/image.js
@@ -3277,21 +3277,27 @@ define([
             self.hotspotOverlayRemoveAll();
 
             // Loop through all the hotspot inputs that have not yet been moved into popups
-            self.dom.$hotspots.find('.objectInputs').each(function(){
+            //
+            // Note there is a possibility that the .objectInputs div might have nested
+            // within it more .objectInputs divs, so we need to be sure only to get the
+            // parent div for the entire hotspot and not any internal divs
+            self.dom.$hotspots.find('> ul > li > .objectInputs').each(function(){
                 
                 var $hotspot, $objectInput;
                 
                 $objectInput = $(this);
 
                 // Hide the width, height, x, y inputs
-                $objectInput.find(':input[name$=".x"], :input[name$=".y"], :input[name$=".width"], :input[name$=".height"]').closest('.inputContainer').hide();
-                
+                $objectInput.find(':input[name$="cms.image.x"], :input[name$="cms.image.y"], :input[name$="cms.image.width"], :input[name$="cms.image.height"]')
+                    .closest('.inputContainer').hide();
+
+                // Create a new list for the hotspot LI and move it into a popup
                 $hotspot = $('<ul/>').append( $objectInput.closest('li') );
                 $hotspot.popup({parent:self.dom.$hotspotPopups}).popup('close');
             });
 
             // Loop through all the hotspot data in the popups
-            self.dom.$hotspotPopups.find('.objectInputs').each(function(){
+            self.dom.$hotspotPopups.find('ul > li > .objectInputs').each(function(){
 
                 var data, $objectInput;
 

--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -56,6 +56,7 @@
       });
 
       $container.bind('close.popup', function() {
+
         if ($container.is(':visible') &&
             $container.find('.enhancementForm, .contentForm').find('.inputContainer.state-changed').length > 0 &&
             !confirm('Are you sure you want to close this popup and discard the unsaved changes?')) {
@@ -64,15 +65,24 @@
         }
 
         $.removeData($container[0], 'popup-close-cancelled');
+          
         var $original = $(this);
-        $original.removeClass('popup-show');
-        $('.popup').each(function() {
-          var $popup = $(this);
-          var $source = $popup.popup('source');
-          if ($source && $.contains($original[0], $source[0])) {
-            $popup.popup('close');
-          }
-        });
+
+        // Prevent infinite looping for nested popups
+        if ($original.hasClass('popup-show')) {
+
+          $original.removeClass('popup-show');
+          $('.popup').each(function() {
+            var $popup = $(this);
+            var $source = $popup.popup('source');
+
+            // If the popup we are closing ($original) contains the link that opened a different popup,
+            // then also close that different popup
+            if ($source && $.contains($original[0], $source[0])) {
+              $popup.popup('close');
+            }
+          });
+        }
       });
 
       $closeButton.bind('click.popup', function() {


### PR DESCRIPTION
For a hotspot with embeded objectinputs, creating a new hotspot was not working, and was creating multiple hotspot boxes. This fix ensures that embeded elements do not cause problems.