### PR TITLE
RTE bugfix for word count comments

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -339,7 +339,7 @@ function() {
         
         html = rte.toHTML();
         $html = $(new DOMParser().parseFromString(html, "text/html").body);
-        $html.find('del').remove();
+        $html.find('del,.rte-comment').remove();
         $html.find('br,p,div,ul,ol,li').after('\n');
         text = $html.text();
 


### PR DESCRIPTION
Comments were being counted when generating the word count.
This commit adjusts the word count code to remove .rte-comment spans.