### PR TITLE
Richtext bugfix for enhancement on first line

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3289,7 +3289,7 @@ define(['jquery', 'codemirror/lib/codemirror'], function($, CodeMirror) {
 
                         // Only include the enhancement if the first character of this line is within the selected range
                         charInRange = (lineNo >= range.from.line) && (lineNo <= range.to.line);
-                        if (lineNo === range.from.line && 0 <= range.from.ch) {
+                        if (lineNo === range.from.line && range.from.ch > 0) {
                             charInRange = false;
                         }
                         if (!charInRange) {


### PR DESCRIPTION
If enhancement is on the first line it is not being saved. This commit adjusts the toHTML() logic so it includes enhancements on the first line.