### PR TITLE
RTE bugfix for toolbar within embedded edit

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1026,6 +1026,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             $button.on('click', function(event) {
                 event.preventDefault();
+                event.stopPropagation();
                 self.toolbarHandleClick(item, event);
             });
 


### PR DESCRIPTION
In some cases where the rich text editor appears within an embedded edit popup, clickin a toolbar icon cause the popup to reload.

If the toolbar button prevents the click from propagating, that seems to fix the problem; however, I think that just works around the problem.

In general I don't think stopping propagation on clicks is a good practice unless there is a functional reason to do so, because that limits future development (you might need the event to propagate), plus it requires every widget to stop clicks from propagating.

It appears that after the link propagates, the edit.jsp page is fetched again but without an "id" parameter, so you end up with a bunch of search results instead of the item you were previously editing. I haven't determined why edit.jsp is being fetched again in this case.

In the interest of fixing this issue quickly, I will go ahead and stop propagation on the toolbar links, since it's not likely that doing so will cause any problems; however, there is a chance that this problem could reoccur.