### PR TITLE
Bugfix for rte toolbar buttons reloading frame

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.frame.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.frame.js
@@ -31,6 +31,7 @@ $.plugin2('frame', {
     // Finds the target frame, creating one if necessary.
     findTargetFrame = function(element, callback) {
       var $element = $(element),
+          href = $element.attr('href') || '',
           target = $element.attr('data-frame-target') || $element.attr('target'),
           $frame;
 
@@ -54,7 +55,15 @@ $.plugin2('frame', {
           }
 
         } else {
+
+          // There is no target.
           $frame = $element.frame('container');
+
+          // Special case - if the HREF is not going to a new page, don't try to load the frame again
+          if (href.indexOf('#') === 0) {
+            return true;
+          }
+          
         }
 
         if ($frame.length > 0 && $frame[0] !== doc) {


### PR DESCRIPTION
Adjust the jquery.frame.js code so it does not attempt to load url fragments (#name) into a new frame.

This is meant to fix an issue where a rich text editor was within a popup, and clicking the toolbar button was reloading the frame. The toolbar buttons are A elements with HREF="#".