### PR TITLE
Bugfix sortables to handle nested elements

### DIFF
--- a/tool-ui/src/main/webapp/script/jquery.extra.js
+++ b/tool-ui/src/main/webapp/script/jquery.extra.js
@@ -269,6 +269,27 @@ $.throttle = function(interval, throttledFunction) {
     });
 }());
 
+// In some cases we need to handle nested elements and
+// need to access the children before the parents
+// (for example, nested drag-and-drop targets)    
+$.fn.sortDepthFirst = function() {
+    var ar = this.map(function() {
+            return {length: $(this).parents().length, elt: this}
+        }).get(),
+        result = [],
+        i = ar.length;
+
+
+    ar.sort(function(a, b) {
+        return a.length - b.length;
+    });
+
+    while (i--) {
+        result.push(ar[i].elt);
+    }
+    return $(result);
+};
+
 // Returns true if the element should be in fixed CSS position.
 $.fn.isFixedPosition = function() {
     var $parent = this,

--- a/tool-ui/src/main/webapp/script/jquery.sortable.js
+++ b/tool-ui/src/main/webapp/script/jquery.sortable.js
@@ -6,7 +6,7 @@ var $doc = $(win.document);
 function findRelatedContainers($selected) {
     var itemType = $selected.attr('data-sortable-item-type');
 
-    return itemType ? $('[data-sortable-valid-item-types~="' + itemType + '"') : $();
+    return itemType ? $('[data-sortable-valid-item-types~="' + itemType + '"]') : $();
 }
 
 $.plugin2('sortable', {

--- a/tool-ui/src/main/webapp/script/jquery.sortable.js
+++ b/tool-ui/src/main/webapp/script/jquery.sortable.js
@@ -81,58 +81,85 @@ $.plugin2('sortable', {
                     'left': event.pageX - $win.scrollLeft() + data.adjustX,
                     'top': event.pageY - $win.scrollTop() + data.adjustY
                 });
-
+                
                 $selected.hide();
                 data.$dragCover.hide();
 
+                // Get the top-most element under the current mouse position
                 var dropPoint = $.elementFromPoint(event.clientX, event.clientY)[0];
-
+                
                 if (dropPoint) {
-                    $container.find(options.itemSelector).each(function() {
-                        if ($.contains(this, dropPoint)) {
-                            $dropContainer = $container;
-                            $drop = $(this);
-                            return false;
-                        }
-                    });
 
-                    if (!$drop) {
-                        findRelatedContainers($selected).each(function() {
-                            var $container = $(this);
-                            var $items = $container.find(options.itemSelector).not($selected);
+                    // Find all the drop zones for this type.
+                    // Sort the drop zones by depth in the DOM so we can guarantee we check
+                    // a child before we check the parent.
+                    // This will ensure nested drop zones are handled reasonably.
+                    findRelatedContainers($selected).sortDepthFirst().each(function() {
+                        
+                        var $container = $(this);
 
-                            if ($items.length === 0) {
-                                if (this === dropPoint || $.contains(this, dropPoint)) {
-                                    $dropContainer = $container;
-                                }
+                        // Get all the children elements of the container (except the selected item if any)
+                        var $items = $container.find(options.itemSelector).not($selected);
 
-                            } else {
-                                $items.each(function () {
-                                    if ($.contains(this, dropPoint)) {
-                                        $dropContainer = $container;
-                                        $drop = $(this);
-                                        return false;
-                                    }
-                                });
-                            }
-
-                            if ($dropContainer) {
+                        // There are children elements.
+                        $items.each(function () {
+                                
+                            // Check if the drop point is inside the element
+                            if ($.contains(this, dropPoint)) {
+                                $dropContainer = $container;
+                                $drop = $(this);
                                 return false;
                             }
                         });
-                    }
+
+                        // If the drop point was not on one of the child elements,
+                        // lets double check to see if it was on the container element itself.
+                        // This will handle cases like an empty list, or when there is padding
+                        // on the container.
+                        if ($container.is(dropPoint) || $.contains($container[0], dropPoint)) {
+                            $dropContainer = $container;
+                        }
+
+                        // We can stop searching if we found a drop container
+                        if ($dropContainer) {
+                            return false;
+                        }
+                    });
                 }
 
                 if ($dropContainer) {
+
+                    // Determine where to put the drop-target placeholder
+
+                    // Is mouse over another draggable element?
                     if ($drop && $drop.length > 0 && $drop[0] !== data.$placeholder[0]) {
-                        var $items = $container.find(options.itemSelector);
+                        
+                        var $items = $dropContainer.find(options.itemSelector);
                         var placeholderIndex = Array.prototype.indexOf.call($items, data.$placeholder[0]);
                         var dropIndex = Array.prototype.indexOf.call($items, $drop[0]);
+                        var position;
 
-                        $drop[placeholderIndex > dropIndex ? 'before' : 'after'](data.$placeholder);
+                        if (placeholderIndex === -1) {
+                            position = 'after';
+                        } else if (placeholderIndex > dropIndex) {
+                            position =  'before';
+                        } else {
+                            position = 'after';
+                        }
+
+                        // TODO: this does not correctly handle when placeholder is already before or after the current element
+                        // and causes the UI to bounce around.
+                        
+                        // Move the placeholder into position (before or after the element)
+                        $drop[position](data.$placeholder);
 
                     } else {
-                        $dropContainer.append(data.$placeholder);
+                        // Mouse is not over a draggable element.
+                        // Note it might be in a margin between elements so we need to ensure
+                        // we don't make the placeholder jump around.
+                        if (!$.contains($dropContainer[0], data.$placeholder[0])) {
+                            $dropContainer.append(data.$placeholder);
+                        }
                     }
                 }
 


### PR DESCRIPTION
When a sortable list contains nested sortable lists of the same type, drag and drop was not possible.

This commit adds logic to allow drag and drop in the nested sortable (by performing a depth-first search of elements).

However, there still appears to be some faulty logic in positioning the drop placeholder, so the placeholder jumps around in some cases. This will be addressed in another commit.