### PR TITLE
RTE scroll window on enhancement move

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2124,7 +2124,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
         enhancementMove: function(el, direction) {
 
-            var mark, self;
+            var $el, mark, self, topNew, topOriginal, topWindow;
 
             self = this;
 
@@ -2134,7 +2134,20 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             }
 
             if (direction === 1 || direction === -1) {
+
+                $el = self.enhancementGetWrapper(el);
+                
+                topOriginal = $el.offset().top;
+                    
                 mark = self.rte.enhancementMove(mark, direction);
+
+                topNew = $el.offset().top;
+
+                // Adjust the scroll position of the window so the enhancement stays in the same position relative to the mouse.
+                // This is to let the user repeatedly click the Up/Down button to move the enhancement multiple lines.
+                topWindow = $(window).scrollTop();
+                $(window).scrollTop(topWindow + topNew - topOriginal);
+
             }
         },
 


### PR DESCRIPTION
To make it easier for the user to repeatedly move an enhancement up or down, adjust the window scroll position after moving the enhancement, so the up/down button will remain under the user's mouse cursor.