### PR TITLE
Convert image editor text overlays to use new rich text editor

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/image.js
+++ b/tool-ui/src/main/webapp/script/v3/input/image.js
@@ -2713,12 +2713,13 @@ define([
                 // Loop  through all the text blocks within this group
                 $.each(self.sizeGroups[groupName].textInfos, function(textInfoKey, textInfo) {
 
-                    var fontSize, $rteInput;
+                    var fontSize, $rteInput, rte;
 
                     // Update the text from the rich text editor
                     $rteInput = textInfo.$textOverlay.find('.imageEditor-textOverlayInput');
                     if ($rteInput.length) {
-                        textInfo.text = $rteInput.val();
+                        rte = $rteInput.data('rte2');
+                        textInfo.text = rte ? rte.toHTML() : $rteInput.val();
                     }
 
                     texts += self.textDelimiter + textInfo.text;

--- a/tool-ui/src/main/webapp/script/v3/input/image.js
+++ b/tool-ui/src/main/webapp/script/v3/input/image.js
@@ -2880,8 +2880,9 @@ define([
 
             // Create a div below the image to hold the rich text toolbar
             $textOverlayToolbar = $('<div/>', {'class':'imageEditor-text-toolbar'})
-                .hide()
-                .appendTo(self.dom.tabs.sizes);
+                .hide();
+
+            self.dom.tabs.sizes.before($textOverlayToolbar);
             
             $textOverlayInput.on('rteFocus', function(){
                 self.$element.find('.imageEditor-text-toolbar').hide();

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2726,6 +2726,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.rte.refresh();
         },
 
+        refresh: function() {
+            var self;
+            self = this;
+            self.rte.refresh();
+        },
+        
         setCursor: function(line, ch) {
             var self;
             self.rte.setCursor(line, ch);

--- a/tool-ui/src/main/webapp/style/v3/image-editor.less
+++ b/tool-ui/src/main/webapp/style/v3/image-editor.less
@@ -125,10 +125,6 @@
   }
 }
 
-.imageEditor-text-toolbar {
-  margin-right:@imageEditor-margin-right;
-}
-
 .imageEditor-cover {
   background-color: rgba(0, 0, 0, 0.5);
 }

--- a/tool-ui/src/main/webapp/style/v3/image-editor.less
+++ b/tool-ui/src/main/webapp/style/v3/image-editor.less
@@ -248,6 +248,8 @@
   top: -15px;
   user-select: none;
 
+  font-size:1rem;
+  
   &:before {
     padding-left: 3px;
   }


### PR DESCRIPTION
Resubmitting pull request since original had extra commits.
Also found and fix one additional problem.
This could use some testing in a project that actually uses the text overlays.
The logic for the text sizing remains unchanged, I don't totally understand the desired functionality so if it could be verified that would be helpful.
