### PR TITLE
Adds "Reset Crop" button to image editor

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/image.js
+++ b/tool-ui/src/main/webapp/script/v3/input/image.js
@@ -1466,9 +1466,11 @@ define([
 
             // Show the text overlays for this group
             self.textSelectGroup(groupName);
+
+            // Create the "Reset Crop" button within the group
+            self.resetCropShow(groupName);
         },
 
-        
         /**
          * Unselect the currently selected size.
          */
@@ -1484,6 +1486,9 @@ define([
 
             // Remove the "Add Text" button
             self.textUnselect();
+
+            // Remove the "Reset Crop" button
+            self.resetCropHide();
         },
 
         
@@ -2037,6 +2042,16 @@ define([
             });
         },
 
+        /**
+         * Refreshes the sizebox to display updated bounds.
+         */
+        sizeBoxRefresh: function(groupName) {
+            var self;
+            self = this;
+            self.sizeBoxHide();
+            self.sizeBoxShow(groupName);
+        },
+
         
         /**
          * Create a mousedown handler function that lets the user drag the size box
@@ -2515,6 +2530,33 @@ define([
             }
 
             return crop;
+        },
+
+        //--------------------------------------------------
+        // SIZES - RESET CROP
+        //--------------------------------------------------
+
+        resetCropShow: function (groupName) {
+            var self;
+
+            self = this;
+
+            $('<a/>', {
+                'class': 'imageEditor-resetCrop',
+                'text': 'Reset Crop',
+                'click': function () {
+                    self.sizesResetGroup(groupName);
+                    self.sizesUpdatePreview(groupName);
+                    self.sizeBoxRefresh(groupName);
+                    return false;
+                }
+            }).insertAfter(self.sizeGroups[groupName].$groupLabel);
+        },
+
+        resetCropHide: function () {
+            var self;
+            self = this;
+            self.$element.find('.imageEditor-resetCrop').remove();
         },
 
         //--------------------------------------------------

--- a/tool-ui/src/main/webapp/style/v3/image-editor.less
+++ b/tool-ui/src/main/webapp/style/v3/image-editor.less
@@ -191,6 +191,19 @@
   right: -5px;
 }
 
+.imageEditor-resetCrop {
+  .icon;
+  .icon-action-cancel;
+
+  display: none;
+
+  font-size: 11px;
+
+  .imageEditor-sizeSelected & {
+    display: block;
+  }
+}
+
 .imageEditor-addTextOverlay {
   .icon;
   .icon-plus;


### PR DESCRIPTION
Adds a new button to the image editor for editors to reset a crop:

![image](https://cloud.githubusercontent.com/assets/1299507/10734661/bc3c06f0-7bda-11e5-96ad-33b57c9efbbc.png)
