### PR TITLE
RTE fix enhancement image size dropdown menu

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -303,6 +303,9 @@ li.CodeMirror-hint-active {
 
 // For enhancements, let the enhancement toolbar overflow the codemirror widget,
 // and reset the z-index because it was causing problems with the submenu hover
+.CodeMirror, .CodeMirror-scroll {
+  overflow:visible !important;
+}
 .CodeMirror-linewidget {
   overflow:visible;
   z-index:inherit;

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -301,6 +301,13 @@ li.CodeMirror-hint-active {
   color: white;
 }
 
+// For enhancements, let the enhancement toolbar overflow the codemirror widget,
+// and reset the z-index because it was causing problems with the submenu hover
+.CodeMirror-linewidget {
+  overflow:visible;
+  z-index:inherit;
+}
+
 .rte2-wrapper {
 
   position:relative;


### PR DESCRIPTION
For a large list of image sizes that extended past the height of an enhancement, the dropdown menu of image sizes was being cut off.
This commit adjusts the CSS for CodeMirror line widgets to allow the dropdown menu to appear correctly.