### PR TITLE
RTE fix spacing of toolbar submenu items

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -50,9 +50,11 @@
       }
     }
 
-    &:last-of-type {
+  }
+
+  // To leave room for the word count, make sure there is space after the last toolbar item
+  > li:last-of-type {
       margin-right: 7em;
-    }
   }
   
   a, span, .rte2-toolbar-separator {


### PR DESCRIPTION
A previous CSS change added a right margin to the last toolbar item, to leave room for the word count to be displayed. However, the rule was also applying to list items within toolbar submenus and causing those items to wrap in some cases.

This change makes the CSS more specific so it only applies to top-level toolbar items and not to submenu items.