### PR TITLE
Localizes 'Save Initial Draft'

### DIFF
--- a/db/src/main/resources/com/psddev/cms/db/DraftDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/db/DraftDefault_en.properties
@@ -1,0 +1,1 @@
+action.saveInitialDraft=Save Initial Draft

--- a/db/src/main/resources/com/psddev/cms/db/DraftDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/db/DraftDefault_es.properties
@@ -1,0 +1,1 @@
+action.saveInitialDraft=Guardar primer borrador

--- a/db/src/main/resources/com/psddev/cms/db/DraftDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/db/DraftDefault_es.properties
@@ -1,1 +1,1 @@
-action.saveInitialDraft=Guardar primer borrador
+action.saveInitialDraft=Guardar Primer Borrador

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -1012,7 +1012,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                                     "value", "true");
 
                                 if (editingState.isNew()) {
-                                    wp.writeHtml("Save Initial Draft");
+                                    wp.writeHtml(wp.localize(Draft.class, "action.saveInitialDraft"));
 
                                 } else {
                                     wp.writeHtml(wp.localize(Draft.class, "action.newType"));

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -132,7 +132,7 @@ Map<String, Object> editingOldValues = Draft.findOldValues(editing);
 WorkStream workStream = Query.from(WorkStream.class).where("_id = ?", wp.param(UUID.class, "workStreamId")).first();
 
 if (workStream != null) {
-    
+
     Draft draft = wp.getOverlaidDraft(editing);
     Object workstreamObject = (draft != null) ? draft : editing;
 
@@ -1012,7 +1012,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                                     "value", "true");
 
                                 if (editingState.isNew()) {
-                                    wp.writeHtml(wp.localize(Draft.class, "action.saveInitialDraft"));
+                                    wp.writeHtml(wp.localize(editingState.getType(), "action.saveInitialDraft"));
 
                                 } else {
                                     wp.writeHtml(wp.localize(Draft.class, "action.newType"));


### PR DESCRIPTION
Localizes a string apparently overlooking in the initial I18n process.