### PR TITLE
Add inline enhancements to the rich text editor

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -274,6 +274,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     }
 
                     return html;
+                },
+
+                // Function to return a label for the enhancement
+                // This lets the user identify and select between multiple enhancements
+                getLabel: function(mark) {
+                    var label;
+                    label = mark.className;
+                    if (mark.reference) {
+                        label = mark.reference.label;
+                    }
+                    return label;
                 }
             }
         },
@@ -1343,7 +1354,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 // Get the toolbar config object (added to the link when the link was created in toolbarInit()
                 config = $link.data('toolbarConfig');
 
-                if (config.action) {
+                // For toolbar actions we need special logic to determine if the button should be "active"
+                // One exception is for inline enhancements, which are treated as a normal style
+                if (config.action && config.action !== 'enhancementInline') {
 
                     switch (config.action) {
 
@@ -1377,7 +1390,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                         $link.toggleClass('active', mode === 'plain');
                         $link.parent().show();
                         break;
-                    }
+                        
+                    } // switch
 
                 } else {
 
@@ -2733,7 +2747,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Add onclick function to each style that is marked for inline enhancements
             $.each(self.rte.styles, function(styleKey, styleObj) {
                 if (styleObj.enhancementInline && !styleObj.onClick) {
-                    styleObj.onClick = self.inlineEnhancementHandleClick;
+                    styleObj.onClick = function(event, mark){
+                        self.inlineEnhancementHandleClick(event, mark);
+                    };
                 }
             });
         },

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -228,67 +228,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     'class': 'cms-textAlign-right'
                 },
                 clear: ['alignLeft', 'alignCenter', 'ol', 'ul']
-            },
-
-            enhancementInline: {
-                
-                className: 'rte2-style-enhancement-inline',
-                element: 'cms-inline-enhancement',
-                elementAttrAny: true, // Allow any attributes for this element
-                singleLine: true, // Do not span multiple lines
-
-                // Indicate this is an inline enhancement style
-                // so we can handle clicks on the mark and allow editing
-                enhancementInline: true,
-
-                // Optional:
-                // If you provide the enhancement type, then the user will be asked to create a new enhancement of that type.
-                // If you do not provide the enhancement type then the user can search all types of enhancements
-                // to find an existing enhancement or create a new enhancement of any type.
-                // enhancementType: '00000150-67bb-d6a8-a555-ffbb2fca0029',
-                
-                // Function to read attributes from the element and save them on the mark
-                fromHTML: function($el, mark) {
-                    // Get the data-reference attribute, parse it as JSON, then store the
-                    // resulting object on the mark so it can be used later
-                    mark.reference = $el.data('reference');
-                },
-
-                // Function to return the opening HTML element for the inline enhancement
-                toHTML: function(mark) {
-
-                    var href, html, rel, target, title, cmsId;
-
-                    function htmlEncode(s) {
-                        return String(s)
-                            .replace(/&/g, '&amp;')
-                            .replace(/"/g, '&quot;')
-                            .replace(/'/g, '&#39;')
-                            .replace(/</g, '&lt;')
-                            .replace(/>/g, '&gt;');
-                    }
-
-                    html = '';
-                    if (mark.reference) {
-                        html = '<cms-inline-enhancement data-reference="' + htmlEncode(JSON.stringify(mark.reference)) + '"/>';
-                    }
-
-                    return html;
-                },
-
-                // Function to return a label for the enhancement
-                // This lets the user identify and select between multiple enhancements
-                getLabel: function(mark) {
-                    var label;
-                    label = mark.className;
-                    if (mark.reference) {
-                        label = mark.reference.label;
-                    }
-                    return label;
-                }
             }
         },
-
         
         /**
          * Rules for cleaning up the clipboard data when content is pasted
@@ -439,7 +380,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             { separator:true, inline:false },
             { action:'enhancement', text: 'Enhancement', className: 'rte2-toolbar-enhancement', tooltip: 'Add Block Enhancement', inline:false },
-            { action:'enhancementInline', style: 'enhancementInline', text: 'Inline', className: 'rte2-toolbar-noicon', tooltip: 'Add Inline Enhancement', inline:false },
             { action:'marker', text: 'Marker', className: 'rte2-toolbar-marker', tooltip: 'Add Marker', inline:false },
 
             { separator:true },
@@ -1224,15 +1164,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     self.enhancementCreate();
                     break;
 
-                case 'enhancementInline':
-                    
-                    // Stop the event from propagating, otherwise it will close the enhancement popup
-                    event.stopPropagation();
-                    event.preventDefault();
-
-                    self.inlineEnhancementCreate(event, item.style);
-                    break;
-                    
                 case 'fullscreen':
                     self.fullscreenToggle();
                     break;
@@ -1287,6 +1218,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     break;
                 }
 
+            } else if (styleObj.enhancementType) {
+
+                // Stop the event from propagating, otherwise it will close the enhancement popup
+                event.stopPropagation();
+                event.preventDefault();
+
+                self.inlineEnhancementCreate(event, item.style);
 
             } else if (item.style) {
 
@@ -2746,7 +2684,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             // Add onclick function to each style that is marked for inline enhancements
             $.each(self.rte.styles, function(styleKey, styleObj) {
-                if (styleObj.enhancementInline && !styleObj.onClick) {
+                if (styleObj.enhancementType && !styleObj.onClick) {
                     styleObj.onClick = function(event, mark){
                         self.inlineEnhancementHandleClick(event, mark);
                     };

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -228,8 +228,54 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     'class': 'cms-textAlign-right'
                 },
                 clear: ['alignLeft', 'alignCenter', 'ol', 'ul']
-            }
+            },
 
+            enhancementInline: {
+                
+                className: 'rte2-style-enhancement-inline',
+                element: 'cms-inline-enhancement',
+                elementAttrAny: true, // Allow any attributes for this element
+                singleLine: true, // Do not span multiple lines
+
+                // Indicate this is an inline enhancement style
+                // so we can handle clicks on the mark and allow editing
+                enhancementInline: true,
+
+                // Optional:
+                // If you provide the enhancement type, then the user will be asked to create a new enhancement of that type.
+                // If you do not provide the enhancement type then the user can search all types of enhancements
+                // to find an existing enhancement or create a new enhancement of any type.
+                // enhancementType: '00000150-67bb-d6a8-a555-ffbb2fca0029',
+                
+                // Function to read attributes from the element and save them on the mark
+                fromHTML: function($el, mark) {
+                    // Get the data-reference attribute, parse it as JSON, then store the
+                    // resulting object on the mark so it can be used later
+                    mark.reference = $el.data('reference');
+                },
+
+                // Function to return the opening HTML element for the inline enhancement
+                toHTML: function(mark) {
+
+                    var href, html, rel, target, title, cmsId;
+
+                    function htmlEncode(s) {
+                        return String(s)
+                            .replace(/&/g, '&amp;')
+                            .replace(/"/g, '&quot;')
+                            .replace(/'/g, '&#39;')
+                            .replace(/</g, '&lt;')
+                            .replace(/>/g, '&gt;');
+                    }
+
+                    html = '';
+                    if (mark.reference) {
+                        html = '<cms-inline-enhancement data-reference="' + htmlEncode(JSON.stringify(mark.reference)) + '"/>';
+                    }
+
+                    return html;
+                }
+            }
         },
 
         
@@ -381,7 +427,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             { custom:true }, // If custom styles exist, insert a separator and custom styles here
 
             { separator:true, inline:false },
-            { action:'enhancement', text: 'Enhancement', className: 'rte2-toolbar-enhancement', tooltip: 'Add Enhancement', inline:false },
+            { action:'enhancement', text: 'Enhancement', className: 'rte2-toolbar-enhancement', tooltip: 'Add Block Enhancement', inline:false },
+            { action:'enhancementInline', style: 'enhancementInline', text: 'Inline', className: 'rte2-toolbar-noicon', tooltip: 'Add Inline Enhancement', inline:false },
             { action:'marker', text: 'Marker', className: 'rte2-toolbar-marker', tooltip: 'Add Marker', inline:false },
 
             { separator:true },
@@ -476,6 +523,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.toolbarInit();
             self.linkInit();
             self.enhancementInit();
+            self.inlineEnhancementInit();
             self.trackChangesInit();
             self.placeholderInit();
             self.modeInit();
@@ -1165,6 +1213,15 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     self.enhancementCreate();
                     break;
 
+                case 'enhancementInline':
+                    
+                    // Stop the event from propagating, otherwise it will close the enhancement popup
+                    event.stopPropagation();
+                    event.preventDefault();
+
+                    self.inlineEnhancementCreate(event, item.style);
+                    break;
+                    
                 case 'fullscreen':
                     self.fullscreenToggle();
                     break;
@@ -2664,6 +2721,268 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         },
 
 
+        /*==================================================
+         * Inline Enhancements
+         *==================================================*/
+
+        inlineEnhancementInit: function() {
+            
+            var self;
+            self = this;
+
+            // Add onclick function to each style that is marked for inline enhancements
+            $.each(self.rte.styles, function(styleKey, styleObj) {
+                if (styleObj.enhancementInline && !styleObj.onClick) {
+                    styleObj.onClick = self.inlineEnhancementHandleClick;
+                }
+            });
+        },
+
+        
+        inlineEnhancementCreate: function(event, style) {
+
+            var mark, self, styleObj;
+            
+            self = this;
+
+            styleObj = self.rte.styles[style] || {};
+            
+            // Create a new mark then call the onclick function on it
+            mark = self.rte.setStyle(style);
+            if (mark) {
+
+                // In case the style was designed to support only a single enhancement type,
+                // save it on the mark so that enhancement will be created instead of searching
+                // all enhancements
+                mark.enhancementType = styleObj.enhancementType;
+                
+                self.inlineEnhancementHandleClick(event, mark);
+            }
+
+        },
+
+        inlineEnhancementHandleClick: function(event, mark) {
+
+            var enhancementEditUrl, enhancementSelectUrl, $div, $divLink, formAction, formId, formTypeId, text, self;
+
+            self = this;
+
+            // Stop the click from propagating up to the window
+            // because if it did, it would close the popup we will be opening.
+            if (event) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+
+            // Helper function to update the mark after
+            // an enhancement is selected or edited
+            function updateMark(mark, reference) {
+                
+                var range;
+
+                // When creating a new enhancement object, initially a temp object is created
+                // where the label is a similar to the ID of the object; however, we do not
+                // want to use this temporary enhancmeent until it is saved.
+                if (reference.label.substring(0,8) !== reference._id.substring(0,8)) {
+                    
+                    // Save the data on the mark
+                    mark.reference = reference;
+
+                    // If a range of text was not selected, then add text to the label
+                    range = self.rte.markGetRange(mark);
+                    if (range.from &&
+                        range.from.line === range.to.line &&
+                        range.from.ch === range.to.ch &&
+                        reference.label.substring(0,8) !== reference._id.substring(0,8)) {
+                    
+                        self.rte.replaceMarkText(mark, reference.label || 'Enhancement');
+                    }
+                }
+            }
+
+            // Check to see if this mark already has an enhancement selected.
+            // If so let the user edit the enhancement.
+            if (mark.enhancementType || (mark.reference && mark.reference.record)) {
+
+                if (mark.reference && mark.reference.record) {
+                    // Get the URL to edit an existing enhancement
+                    enhancementEditUrl = $.addQueryParameters(window.CONTEXT_PATH + '/content/enhancement.jsp',
+                                                              'id', mark.reference.record._ref,
+                                                              'reference', JSON.stringify(mark.reference));
+                } else {
+                    enhancementEditUrl = $.addQueryParameters(window.CONTEXT_PATH + '/content/enhancement.jsp',
+                                                              'typeId', mark.enhancementType);
+                }
+
+                // Create a link for editing the enhancement and position it at the click event
+                $div = $('<div/>', {
+                    'class': 'rte2-frame-enhancement-inline',
+                    'style': 'position:absolute;top:0;left:0;height:1px;overflow:hidden;',
+                    html: $('<a/>', {
+                        target: 'rte2-frame-enhancement-inline',
+                        href: enhancementEditUrl,
+                        style: 'width:100%;display:block;',
+                        text: '.'
+                    })
+                    
+                }).appendTo('body').css({
+                    'top': event.pageY,
+                    'left': event.pageX
+                });
+
+                $divLink = $div.find('a');
+
+                // Listen for an 'enhancementUpdate' event that will be triggered on
+                // the edit link, so we can tell when the enhancement is updated.
+                // The enhancement edit form will trigger this event.
+                $divLink.on('enhancementUpdate', function(event, reference){
+                    updateMark(mark, reference);
+                });
+                
+                // Do a fake "click" on the link so it will trigger the popup
+                // but first wait for the current click to finish so it doesn't interfere
+                // with any popups
+                setTimeout(function(){
+                    $divLink.click();
+                }, 100);
+
+            } else {
+
+                // The mark is not attached to an enhancement, so
+                // let the user choose one.
+                
+                // For the select enhancement popup, include parameters for the form id and typeId
+                formAction = self.$el.closest('form').attr('action') || '';
+                formId = (/id=([^&]+)/.exec(formAction) || [ ])[1] || '';
+                formTypeId = (/typeId=([^&]+)/.exec(formAction) || [ ])[1] || '';
+
+                // Get the URL to select an enhancement
+                enhancementSelectUrl = window.CONTEXT_PATH + '/enhancementSelect' + '?pt=' + encodeURIComponent(formId) + '&py=' + encodeURIComponent(formTypeId);
+
+                // Create a link to trigger the enhancement select to appear in a popup frame
+                self.$container.find('.rte2-frame-enhancement-inline').remove();
+
+                $div = $('<div/>', {
+                    'class': 'rte2-frame-enhancement-inline',
+                    'style': 'position:absolute;top:0;left:0;height:1px;overflow:hidden;',
+                    html: $('<a/>', {
+                        target: 'rte2-frame-enhancement-inline',
+                        href: enhancementSelectUrl,
+                        style: 'width:100%;display:block;',
+                        text: '.'
+                    })
+                }).appendTo('body');
+
+                // Position the div at the point of the click
+                $div.css({
+                    'top': event.pageY,
+                    'left': event.pageX
+                });
+
+                // Do a fake "click" on the link so it will trigger the popup
+                $divLink = $div.find('a');
+
+                // In case the user creates a new enhancement,
+                // the "enhancementUpdate" event will occur
+                // so we can get the enhancement info
+                $divLink.on('enhancementUpdate', function(event, reference){
+                    updateMark(mark, reference);
+                });
+
+                // We use a timeout before we click the link because of the way we're using mousedown event
+                // to detect the double click. The timeout gives time for the original click event to complete
+                // so it will not interfere with things like popups.
+                setTimeout(function(){
+                    $divLink.click();
+                }, 100);
+
+                // Okay, this is a hack so prepare yourself.
+                // Set up a global click event to detect when user clicks on an enhancement in the popup.
+                // However, since there can be multiple enhancements in the editor,
+                // (and multiple rich text editors on the page) we must determine where the popup originated.
+                // If the popup did not originate in our rich text editor, we will ignore the event and let
+                // somebody else deal with it.
+                // We use .one() so we'll handle the event only once then get rid of the event handler.
+                $(document.body).one('click', '[data-enhancement]', function(event) {
+
+                    var data, $enhancement, $popupTrigger, $target;
+
+                    // The enhancement link that the user clicked
+                    $target = $(this);
+
+                    // Get the link that triggered the popup to appear.
+                    // This link will be inside the enhancement that is being changed.
+                    $popupTrigger = $target.popup('source');
+
+                    // Determine if that link is inside our rich text editor
+                    if (! $popupTrigger.is($divLink)) {
+                        // Not our popup!
+                        return;
+                    }
+
+                    // Get the data for the selected enhancement
+                    // Note the .data() function will automatically convert from JSON string to a javacript object.
+                    // For example, the link might look like this:
+                    // <a data-enhancement='{"label":"Test Raw HTML","record":{"_ref":"0000014d-018f-da9a-a5cf-4fef59b30000",
+                    // "_type":"0000014b-75ea-d559-a95f-fdffd32f005f"},"_id":"0000014d-590f-d32d-abed-fdef3ad50001",
+                    // "_type":"0000014b-75ea-d559-a95f-fdffd3300055"}' href="#">Test Raw HTML</a>
+                    data = $target.data('enhancement');
+
+                    // Save the data on the mark
+                    mark.reference = data;
+
+                    // Update the label for the mark
+                    updateMark(mark, data);
+
+                    // Close the popup
+                    $target.popup('close');
+                    
+                    // Put focus back on the editor
+                    self.focus();
+
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                    
+                    return false;
+                    
+                }); // click event
+
+                // Set up a global close event to determine when the enhancement popup is closed
+                // so we can update the enhancement display (or remove the enhancement)
+                $(document.body).one('closed', '.popup[name="rte2-frame-enhancement-inline"]', function() {
+                    
+                    var $enhancement, $popupTrigger, $popup;
+
+                    // The popup that was closed
+                    $popup = $(this);
+
+                    // Get the link that triggered the popup to appear.
+                    // This link will be inside the enhancement that is being changed.
+                    $popupTrigger = $popup.popup('source');
+
+                    // Determine if that link is ours
+                    if (!$divLink.is($popupTrigger)) {
+                        // Not in our editor - must be from some other editor so we will ignore
+                        return;
+                    }
+
+                    // Clear the mark if a reference was not selected
+                    if (!mark.reference || !mark.reference.record) {
+                        mark.clear();
+                    }
+
+                    // Remove the popup
+                    $popup.remove();
+
+                    self.focus();
+                    
+                }); // on popup closed
+                
+            } // else mark does not have an enhancment
+
+        },
+
+        
         /*==================================================
          * Placeholder
          *==================================================*/

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -101,50 +101,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 
                 // Do not allow links to span multiple lines
                 singleLine: true,
-
-                // Function to read attributes from a link and save them on the mark
-                fromHTML: function($el, mark) {
-
-                    mark.attributes = {
-                        href: $el.attr('href'),
-                        target: $el.attr('target'),
-                        rel: $el.attr('rel'),
-                        title: $el.attr('title'),
-                        cmsId: $el.attr('data-cms-id'),
-                        cmsHref: $el.attr('data-cms-href')
-                    };
-                },
-
-                // Function to return the opening HTML element for a link
-                toHTML: function(mark) {
-
-                    var href, html, rel, target, title, cmsId;
-
-                    // For a link set the attributes on the element that were set on the mark
-                    html = '<a';
-
-                    if (mark.attributes) {
-                        href = mark.attributes.href || '';
-                        title = mark.attributes.title || '';
-                        target = mark.attributes.target || '';
-                        rel = mark.attributes.rel || '';
-                        cmsId = mark.attributes.cmsId || '';
-                    }
-
-                    if (href) { html += ' href="' + href + '"'; }
-                    if (title) { html += ' title="' + title + '"'; }
-                    if (target) { html += ' target="' + target + '"'; }
-                    if (rel) { html += ' rel="' + rel + '"'; }
-                    if (cmsId) {
-                        html += ' data-cms-id="' + cmsId + '"';
-                        html += ' data-cms-href="' + href + '"';
-                    }
-
-                    html += '>';
-
-                    return html;
-                },
-
+                
                 onClick: function(event, mark) {
 
                     var self;
@@ -172,8 +129,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                                 mark.clear();
                             } else {
                                 // Update the link attributes
-                                mark.attributes = mark.attributes || {};
-                                $.extend(mark.attributes, attributes);
+                                mark.attributes = attributes;
                             }
                         }).fail(function(){
 
@@ -1614,17 +1570,32 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         linkSave: function() {
 
             var attributes, $linkDialog, self;
+            var href, rel, target, title, cmsId;
 
             self = this;
 
             $linkDialog = self.$linkDialog;
 
-            attributes = {
-                href: $linkDialog.find('.rte2-dialogLinkHref').val() || '',
-                target: $linkDialog.find('.rte2-dialogLinkTarget').val() || '',
-                rel: $linkDialog.find('.rte2-dialogLinkRel').val() || '',
-                cmsId: $linkDialog.find('.rte2-dialogLinkId').val() || ''
-            };
+            href = $linkDialog.find('.rte2-dialogLinkHref').val() || '';
+            target = $linkDialog.find('.rte2-dialogLinkTarget').val() || '';
+            rel = $linkDialog.find('.rte2-dialogLinkRel').val() || '';
+            cmsId = $linkDialog.find('.rte2-dialogLinkId').val() || '';
+            
+            attributes = {};
+            attributes.href = href;
+
+            if (target) {
+                attributes.target = $linkDialog.find('.rte2-dialogLinkTarget').val() || '';
+            }
+
+            if (rel) {
+                attributes.rel = $linkDialog.find('.rte2-dialogLinkRel').val() || '';
+            }
+
+            if (cmsId) {
+                attributes['data-cms-id'] = cmsId;
+                attributes['data-cms-href'] = href;
+            }
 
             // Resolve the deferred object with the new attributes,
             // so whoever called linkEdit will be notified with the final results.

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2763,6 +2763,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 $divLink.on('enhancementUpdate', function(event, reference){
                     updateMark(mark, reference);
                 });
+
+                // Listen for an 'enhancementRead' event that will be triggered on
+                // the edit link, so we can communicate the mark back to the popup
+                // form. The enhancement edit form can trigger this event.
+                $divLink.on('enhancementRead', function(event, callback){
+                    // Call the callback, passing it the mark.
+                    // Also within the callback ensure that "this" refers to this instance of the rte.
+                    if (callback) {
+                        callback.call(self, mark)
+                    }
+                });
                 
                 // Do a fake "click" on the link so it will trigger the popup
                 // but first wait for the current click to finish so it doesn't interfere

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3993,10 +3993,12 @@ define([
              * An object containing additional attributes to add to the element.
              * For example: {'style': 'font-weight:bold'}
              */
-            function openElement(styleObj) {
+            function openElement(styleObj, attributes) {
                 
                 var html = '';
 
+                attributes = attributes || {};
+                
                 if (styleObj.markToHTML) {
                     html = styleObj.markToHTML();
                 } else if (styleObj.element) {
@@ -4007,6 +4009,16 @@ define([
                             html += ' ' + attr + '="' + value + '"';
                         });
                     }
+                    
+                    if (styleObj.attributes) {
+                        $.each(styleObj.attributes, function(attr, value) {
+                            html += ' ' + attr + '="' + value + '"';
+                        });
+                    }
+                    
+                    $.each(attributes, function(attr, value) {
+                        html += ' ' + attr + '="' + value + '"';
+                    });
 
                     // For void elements add a closing slash when closing, like <br/>
                     if (self.voidElements[ styleObj.element ]) {
@@ -4253,8 +4265,10 @@ define([
                         } else {
 
                             // There is no custom toHTML function for this
-                            // style, so we'll just use the style object
-                            annotationStart[startCh].push(styleObj);
+                            // style, so we'll just use the style object,
+                            // but we'll also include any attributes that
+                            // were stored on the mark
+                            annotationStart[startCh].push( $.extend(true, {}, styleObj, {attributes:mark.attributes}) );
                         }
                         
                         // Add the element to the start and end annotations for this character
@@ -4538,6 +4552,8 @@ define([
 
                 while (next) {
 
+                    elementAttributes = {};
+
                     // Check if we got a text node or an element
                     if (next.nodeType === 3) {
 
@@ -4682,6 +4698,12 @@ define([
                                         matchStyleObj = styleObj;
                                     }
 
+                                    /***
+
+                                        // Not needed anymore (?) since we assume that rules are set up to match elements with specified
+                                        // attribues. You can match <span myattr1> and <span myattr2> but if you tried to match
+                                        // just <span> then that might match in a different order so it might cause problems.
+
                                     // Check if the element has other attributes that are unexpected
                                     if (matchStyleObj && !styleObj.elementAttrAny) {
                                         $.each(elementAttributes, function(attr, value) {
@@ -4693,6 +4715,7 @@ define([
                                             }
                                         });
                                     }
+                                    ***/
 
 
                                     // Stop after the first style that matches
@@ -4846,7 +4869,8 @@ define([
                                 annotations.push({
                                     styleObj:matchStyleObj,
                                     from:from,
-                                    to:to
+                                    to:to,
+                                    attributes: elementAttributes
                                 });
                             }
                         }
@@ -4958,7 +4982,7 @@ define([
                 if (styleObj.line) {
                     self.blockSetStyle(styleObj, annotation, {triggerChange:false});
                 } else {
-                    self.inlineSetStyle(styleObj, annotation, {addToHistory:false, triggerChange:false});
+                    self.inlineSetStyle(styleObj, annotation, {addToHistory:false, triggerChange:false, attributes:annotation.attributes});
                 }
             });
 

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -119,6 +119,8 @@
   .rte2-toolbar-enhancement { width:auto; padding-left:0.5em; padding-right:0.5em; }
   .rte2-toolbar-marker { width:auto; padding-left:0.5em; padding-right:0.5em; }
 
+  .rte2-toolbar-enhancement-inline { width:auto; padding-left:0.5em; padding-right:0.5em; }
+
   .rte2-toolbar-track-changes { width:auto; padding-left:0.5em; padding-right:0.5em; }
   .rte2-toolbar-track-changes-accept { .icon; .icon-ok; }
   .rte2-toolbar-track-changes-reject { .icon; .icon-remove; }
@@ -234,6 +236,11 @@
   display:inline-block;
   padding:0.1em 0.5em;
   background-color:#ddd;
+}
+.rte2-style-enhancement-inline {
+  padding:0;
+  background-color:rgba(180, 180, 180, 0.3);
+  outline:1px solid rgba(100, 100, 100, 0.5);
 }
 .rte2-style-enhancement {
   display:inline-block;
@@ -526,9 +533,21 @@ li.CodeMirror-hint-active {
   float: right;
 }
 
+.popup[name=rte2-frame-enhancement-inline] {
+  max-width:1000px;
+  width:70%;
+}
+  
+
 // Div that is used as a paste clipboard
 // Note this cannot be hidden because it needs to get focus
 .rte2-clipboard {
   max-height:1px;
   overflow:hidden;
+}
+
+.rte2-onclick-selector {
+  ul {
+    margin:0 1em;
+  }
 }


### PR DESCRIPTION
Added functionality to the rich text editor to support "inline enhancements":
* Added support for creating new HTML elements that are inline enhancements, including a default style configuration for inline enhancements, which uses the cms-inline-enhancement element.
* Added support to the toolbar configuration for creating either a generic "add inline enhancement" button (which lets you search for an insert any available enhancement) or a specific "add inline enhancement of this type" button (which always creates a new enhancement for the specified type id)
* Added an "Inline" toolbar button. Clicking this lets you select an enhancement to insert into the document.
* Modified the RTE onclick handler to support nested styles (for example, one enhancement inside another). When multiple enhancements exist at the point of clicking, a popup appears to let you choose which of the marks you want to edit.

![enhancemnts](https://cloud.githubusercontent.com/assets/185461/11574959/a2f8bd30-99dc-11e5-9a6e-c2c892932e04.png)
