### PR TITLE
RTE bugfix attributes not encoded for inline enh

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4006,18 +4006,18 @@ define([
 
                     if (styleObj.elementAttr) {
                         $.each(styleObj.elementAttr, function(attr, value) {
-                            html += ' ' + attr + '="' + value + '"';
+                            html += ' ' + attr + '="' + self.htmlEncode(value) + '"';
                         });
                     }
                     
                     if (styleObj.attributes) {
                         $.each(styleObj.attributes, function(attr, value) {
-                            html += ' ' + attr + '="' + value + '"';
+                            html += ' ' + attr + '="' + self.htmlEncode(value) + '"';
                         });
                     }
                     
                     $.each(attributes, function(attr, value) {
-                        html += ' ' + attr + '="' + value + '"';
+                        html += ' ' + attr + '="' + self.htmlEncode(value) + '"';
                     });
 
                     // For void elements add a closing slash when closing, like <br/>


### PR DESCRIPTION
When an inline enhancement contains JSON data (for example) the attribute values were not being encoded correctly, leading to incorrect HTML output. This commit adds encoding so things like double-quotes will not break the HTML.