### PR TITLE
RTE bugfix to maintain order of elements

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4946,7 +4946,10 @@ define([
             history = editor.getHistory();
             
             // Set up all the annotations
-            $.each(annotations, function(i, annotation) {
+            // We reverse the order of the annotations because the parsing was done
+            // depth first, and we want to create the marks for parent elements before
+            // the marks for child elements (so elements can later be created in the same order)
+            $.each(annotations.reverse(), function(i, annotation) {
 
                 var styleObj;
 


### PR DESCRIPTION
There was a problem in the RTE if you created overlapping styles like <b><i></i></b> then published the page, the next time the HTML was imported and exported again the elements would be reversed like <i><b></b></i>.
This commit changes the HTML input so it creates the parent element marks before creating the child element marks, which seems to fix the problem.