### PR TITLE
RTE move rich text elements into toolbar submenu; update labels on the dropdown

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2962,6 +2962,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             Rte.styles[styleName] = {
                 className: 'rte2-style-' + styleName,
                 enhancementType: rtElement.typeId,
+                enhancementName: rtElement.displayName,
                 element: tag,
                 elementAttrAny: true,
                 singleLine: true

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2953,6 +2953,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             separator: true
         });
 
+        var richTextElementsSubmenu = [];
+        
         $.each(RICH_TEXT_ELEMENTS, function (index, rtElement) {
             var tag = rtElement.tag;
             var styleName = rtElement.styleName;
@@ -2965,11 +2967,16 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 singleLine: true
             };
 
-            Rte.toolbarConfig.push({
+            richTextElementsSubmenu.push({
                 className: 'rte2-toolbar-noicon',
                 style: styleName,
                 text: rtElement.displayName
             });
+        });
+
+        Rte.toolbarConfig.push({
+            text: 'Inline',
+            submenu: richTextElementsSubmenu
         });
     }
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2347,8 +2347,8 @@ define([
                 // It defaults to the className of the style.
                 // Of if the style definition has a getLabel() function
                 // call that and use the return value
-                styleObj = self.classes[mark.className];
-                label = mark.className;
+                styleObj = self.classes[mark.className] || {};
+                label = styleObj.enhancementName || mark.className;
                 if (styleObj.getLabel) {
                     label = styleObj.getLabel(mark);
                 }


### PR DESCRIPTION
For the RICH_TEXT_ELEMENTS inline enhancements, adding them individually to the toolbar will cause the toolbar to get too large. Instead adding them to an "Inline" toolbar submenu. Note we might want to change this in the future to allow the submenu name to be customized or multiple submenus to be used, but for now sticking with a single submenu.

Also when you double-click on nested enhancements you currently get a popup list of enhancements that are at the cursor. This list shows the RTE style name which is not very user friendly. This pull request updates the style config to contain an enhancementName parameter, so the name listed in the popup will be more user friendly and match with the toolbar button.