### PR TITLE
Adds PageFilter.PREVIEW_VIEW_TYPE to allow for preview specific views.

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -612,10 +612,11 @@ public class ToolPageContext extends WebPageContext {
 
                 PageViewClass pageViewClass = object.getClass().getAnnotation(PageViewClass.class);
 
-                // would be better if there was a separate API to just "find" the creator class
+                // TODO: would be better if there was a separate API to just "find" the creator class
                 // rather than incurring the overhead of also creating it.
                 if ((pageViewClass != null && ViewCreator.createCreator(object, pageViewClass.value()) != null)
-                        || ViewCreator.createCreator(object, PageFilter.PAGE_VIEW_TYPE) != null) {
+                        || ViewCreator.createCreator(object, PageFilter.PAGE_VIEW_TYPE) != null
+                        || ViewCreator.createCreator(object, PageFilter.PREVIEW_VIEW_TYPE) != null) {
                     return true;
                 }
             }


### PR DESCRIPTION
This enables preview of content that does not have a permalink, specifically for content rendered using the view system.
Also, moves the "_viewType" parameter out to a static variable instead of hardcoded String.