### PR TITLE
RTE add -start and -end styles to improve mark styling within editor

### DIFF
--- a/tool-ui/bower.json
+++ b/tool-ui/bower.json
@@ -4,7 +4,7 @@
     "bsp-autoexpand": "1.0.2",
     "bsp-autosubmit": "1.0.0",
     "bsp-utils": "2.0.2",
-    "codemirror": "5.7.0",
+    "codemirror": "5.10.0",
     "css-element-queries": "4250c87c5ab2efd467f99d901252c73eb6bb80ea",
     "d3": "3.4.6",
     "evaporate": "ttlabs/evaporatejs",

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -600,6 +600,8 @@ define([
             
             markOptions = $.extend({
                 className: className,
+                startStyle: className + '-start',
+                endStyle: className + '-end',
                 inclusiveRight: true,
                 addToHistory: true
             }, options);

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -242,6 +242,10 @@
 .rte2-style-comment-start {
   padding-left:0.1em;
   border-left: @rte2-style-comment-border;
+
+  .icon;
+  .icon-comment-alt;
+
 }
 .rte2-style-comment-end {
   padding-right:0.1em;

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -229,10 +229,23 @@
 .rte2-style-align-right {
   text-align:right;
 }
+.rte2-style-spelling {
+  border-bottom:1px dotted red;
+}
+@rte2-style-comment-border: 1px solid rgba(0, 0, 0, 0.3);
 .rte2-style-comment {
   font-style:italic;
-  outline:1px solid #333;
-  padding:0.1em;
+  border-top: @rte2-style-comment-border;
+  border-bottom:@rte2-style-comment-border;
+  background-color: rgba(0,0,0,0.1);
+}
+.rte2-style-comment-start {
+  padding-left:0.1em;
+  border-left: @rte2-style-comment-border;
+}
+.rte2-style-comment-end {
+  padding-right:0.1em;
+  border-right:  @rte2-style-comment-border;
 }
 .rte2-style-collapsed {
   font-style:italic;
@@ -273,9 +286,6 @@
 .rte2-style-track-display .rte2-style-track-insert {
   background-color: rgba(125, 255, 125, 0.3);
   color:black;
-}
-.rte2-style-spelling {
-  border-bottom:1px dotted red;
 }
 
 .CodeMirror-hints {


### PR DESCRIPTION
When CodeMirror adds a mark, it renders it in the editor HTML as a SPAN element with a classname; however, when you have overlapping marks, it does not use overlapping SPAN elements. Instead it closes the SPAN element and opens a new one (using multiple class names for the overlapping marks). This causes problems when trying to style the marks, because a single mark might have multiple spans to represent it. For example, if you want to style the start of the mark, it is not possible because you would be adding a style to the start of multiple SPAN elements.

CodeMirror provides a way to add -start and -end classnames to the first and last span of a given mark; however, we found a bug that prevented that from working as expected. We submitted a bug report and that has since been fixed.

This pull request makes the following changes:

Updated CodeMirror version to get a bugfix to the startStyle and endStyle functionality.

Added startStyle and endStyle to all inline styles in the RTE. For example, if the mark is rte2-style-bold, then the classes rte2-style-bold-start and rte2-style-bold-end are now available.

Fixed some styling problems for RTE comments, using the new start and end classes.