### PR TITLE
Improves CMS file preview for SVGs

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1284,7 +1284,10 @@ public class ToolPageContext extends WebPageContext {
      */
     public String getPreviewThumbnailUrl(Object object) {
         if (object != null) {
-            StorageItem preview = State.getInstance(object).getPreview();
+
+            StorageItem preview = object instanceof StorageItem
+                    ? (StorageItem) object
+                    : State.getInstance(object).getPreview();
 
             if (preview != null) {
 

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -45,6 +45,7 @@ import com.google.common.base.MoreObjects;
 import com.ibm.icu.text.MessageFormat;
 import com.psddev.cms.db.PageFilter;
 import com.psddev.cms.db.RichTextElement;
+import com.psddev.cms.tool.file.SvgFileType;
 import com.psddev.cms.view.PageViewClass;
 import com.psddev.cms.view.ViewCreator;
 import com.psddev.dari.db.Recordable;
@@ -1286,7 +1287,12 @@ public class ToolPageContext extends WebPageContext {
             StorageItem preview = State.getInstance(object).getPreview();
 
             if (preview != null) {
-                if (ImageEditor.Static.getDefault() != null) {
+
+                String contentType = preview.getContentType();
+
+                if (ImageEditor.Static.getDefault() != null
+                        && (contentType != null && !contentType.equals(SvgFileType.CONTENT_TYPE))) {
+
                     return new ImageTag.Builder(preview)
                             .setHeight(300)
                             .setResizeOption(ResizeOption.ONLY_SHRINK_LARGER)

--- a/db/src/main/java/com/psddev/cms/tool/file/SvgFileType.java
+++ b/db/src/main/java/com/psddev/cms/tool/file/SvgFileType.java
@@ -15,11 +15,13 @@ import com.psddev.dari.util.StringUtils;
  */
 public class SvgFileType implements FileContentType {
 
+    public static final String CONTENT_TYPE = "image/svg+xml";
+
     @Override
     public double getPriority(StorageItem storageItem) {
         String contentType = storageItem.getContentType();
 
-        if (StringUtils.isBlank(contentType) || !contentType.startsWith("image/svg")) {
+        if (StringUtils.isBlank(contentType) || !contentType.equals(CONTENT_TYPE)) {
             return DEFAULT_PRIORITY_LEVEL - 1;
         }
 

--- a/db/src/main/java/com/psddev/cms/tool/file/SvgFileType.java
+++ b/db/src/main/java/com/psddev/cms/tool/file/SvgFileType.java
@@ -1,0 +1,45 @@
+package com.psddev.cms.tool.file;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import com.psddev.cms.tool.FileContentType;
+import com.psddev.cms.tool.ToolPageContext;
+import com.psddev.dari.db.State;
+import com.psddev.dari.util.StorageItem;
+import com.psddev.dari.util.StringUtils;
+
+/**
+ * Adds support for rendering SVG file previews.
+ */
+public class SvgFileType implements FileContentType {
+
+    @Override
+    public double getPriority(StorageItem storageItem) {
+        String contentType = storageItem.getContentType();
+
+        if (StringUtils.isBlank(contentType) || !contentType.startsWith("image/svg")) {
+            return DEFAULT_PRIORITY_LEVEL - 1;
+        }
+
+        return DEFAULT_PRIORITY_LEVEL + 1;
+    }
+
+    @Override
+    public void writePreview(ToolPageContext page, State state, StorageItem fieldValue) throws IOException, ServletException {
+
+        page.writeStart("a",
+                "href", page.h(fieldValue.getPublicUrl()),
+                "target", "_blank");
+            page.write(page.h(fieldValue.getContentType()));
+            page.write(": ");
+            page.write(page.h(fieldValue.getPath()));
+        page.writeEnd();
+
+        page.writeTag("img",
+                "style", "display:block;",
+                "src", fieldValue.getPublicUrl(),
+                "width", "200");
+    }
+}

--- a/db/src/main/java/com/psddev/cms/tool/page/SearchCarousel.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/SearchCarousel.java
@@ -1,7 +1,5 @@
 package com.psddev.cms.tool.page;
 
-import com.psddev.cms.db.ImageTag;
-import com.psddev.cms.db.ResizeOption;
 import com.psddev.cms.db.Site;
 import com.psddev.cms.tool.CmsTool;
 import com.psddev.cms.tool.PageServlet;
@@ -9,7 +7,6 @@ import com.psddev.cms.tool.Search;
 import com.psddev.cms.tool.ToolPageContext;
 import com.psddev.dari.db.Query;
 import com.psddev.dari.db.State;
-import com.psddev.dari.util.ImageEditor;
 import com.psddev.dari.util.ObjectUtils;
 import com.psddev.dari.util.PaginatedResult;
 import com.psddev.dari.util.RoutingFilter;

--- a/db/src/main/java/com/psddev/cms/tool/page/SearchCarousel.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/SearchCarousel.java
@@ -97,18 +97,12 @@ public class SearchCarousel extends PageServlet {
                     }
 
                     if (itemPreviewImage) {
-                        String itemPreviewUrl = ImageEditor.Static.getDefault() != null
-                                ? new ImageTag.Builder(itemPreview)
-                                .setHeight(300)
-                                .setResizeOption(ResizeOption.ONLY_SHRINK_LARGER)
-                                .toUrl()
-                                : itemPreview.getPublicUrl();
 
                         Site owner = itemState.as(Site.ObjectModification.class).getOwner();
 
                         page.writeStart("figure");
                             page.writeElement("img",
-                                    "src", itemPreviewUrl,
+                                    "src", page.getPreviewThumbnailUrl(itemPreview),
                                     "alt", ((owner != null ? (page.getObjectLabel(owner) + ": ") : "")
                                             + (page.getTypeLabel(item) + ": ") + page.getObjectLabel(item)));
 


### PR DESCRIPTION
* Adds SvgFileType to render SVG previews (without the image editor).
* Fixes SVG rendering in Search Results (shows default image for storage, or broken image)
* Fixes SVG rendering in Search Result Carousel

**Search Results (Before)**
![image](https://cloud.githubusercontent.com/assets/1299507/12101872/114bb12a-b305-11e5-9cb9-15017f2e6d00.png)

**Search Results (After)**
![image](https://cloud.githubusercontent.com/assets/1299507/12102160/ff85e18e-b306-11e5-9eac-74cc84b08fdd.png)

**SVG StorageItem field preview**
![image](https://cloud.githubusercontent.com/assets/1299507/12101899/45279284-b305-11e5-9c0b-f329928d889f.png)

**SVG in Search Carousel**
![image](https://cloud.githubusercontent.com/assets/1299507/12102403/8ab20840-b308-11e5-8dc8-2fcb2c96d0f3.png)


