### PR TITLE
RTE bugfix readonly mode hide toolbars + no click

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -627,6 +627,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Initialize the editor
             self.rte.init(self.$editor);
 
+            // Set to read only mode if necessary
+            self.rte.readOnlySet( self.$el.closest('.inputContainer-readOnly').length );
+            
             // Override the rich text editor to tell it how enhancements should be imported from HTML
             self.rte.enhancementFromHTML = function($content, line) {
 
@@ -842,6 +845,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 $toolbar.insertBefore(self.$editor);
             }
             self.$toolbar = $toolbar;
+
+            // If in read only mode hide the toolbar.
+            // Note there is no way to switch from read only to editable at this time.
+            if (self.rte.readOnlyGet()) {
+                self.$toolbar.hide();
+            }
 
             // Recursive function for setting up toolbar menu and submenus
             function toolbarProcess(config, $toolbar) {
@@ -1786,7 +1795,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Create wrapper element for the enhancement and add the toolbar
             $enhancement = $('<div/>', {
                 'class': 'rte2-enhancement'
-            }).append( self.enhancementToolbarCreate(config) );
+            });
+
+            // If in read only mode do not create toolbar.
+            // Note there is no way to switch from read only to editable at this time.
+            if (!self.rte.readOnlyGet()) {
+                $enhancement.append( self.enhancementToolbarCreate(config) );
+            }
 
             if (config.marker) {
                 $enhancement.addClass('rte2-marker');

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -260,7 +260,6 @@ define([
             self.$el = $(element).first();
 
             codeMirrorOptions = {
-                readOnly: $(element).closest('.inputContainer-readOnly').length,
                 lineWrapping: true,
                 dragDrop: false,
                 mode:null,
@@ -2233,6 +2232,11 @@ define([
 
                 var $el, marks, now, pos;
 
+                // Don't do clicks if the editor is in read only mode
+                if (self.readOnlyGet()) {
+                    return;
+                }
+                
                 // Generate timestamp
                 now = Date.now();
 
@@ -3848,7 +3852,18 @@ define([
             self.codeMirror.setCursor(line, ch);
         },
 
+        readOnlyGet: function() {
+            var self;
+            self = this;
+            return self.codeMirror.isReadOnly();
+        },
 
+        readOnlySet: function(readOnly) {
+            var self;
+            self = this;
+            self.codeMirror.setOption('readOnly', readOnly);
+        },
+        
         /**
          * Returns the range for a mark.
          * @returns {Object}


### PR DESCRIPTION
When the editor is in read only mode, it was possible to use the toolbar to modify the content. Also if there was a link in the content, it was possible to double click and modify the link. Also if there was an enhancement, it was possible to move, change, or remove the enhancement.
This commit removes the toolbar (from the editor and from enhancements), plus it prevents click events for links.