### PR TITLE
RTE links and inline enhancement dropdown menu controls

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -101,6 +101,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 
                 // Do not allow links to span multiple lines
                 singleLine: true,
+
+                // Label to use for the dropdown
+                enhancementName: 'Link',
                 
                 onClick: function(event, mark) {
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -279,6 +279,7 @@ define([
 
             self.enhancementInit();
             self.initListListeners();
+            self.dropdownInit();
             self.onClickInit();
             self.initEvents();
             self.clipboardInit();
@@ -2212,6 +2213,189 @@ define([
         },
 
 
+        //==================================================
+        // Dropdown Handlers
+        //==================================================
+
+        dropdownInit: function() {
+            
+            var editor, self;
+
+            self = this;
+            
+            editor = self.codeMirror;
+
+            self.$dropdown = $('<div/>', {
+                'class': 'rte2-dropdown'
+            }).hide().appendTo( editor.getWrapperElement() );
+            
+            editor.on('cursorActivity', $.debounce(250, function(instance, event) {
+                self.dropdownCheckCursor();
+            }));
+        },
+
+
+        dropdownCheckCursor: function() {
+
+            var marks, self;
+            self = this;
+
+            // Get all the marks from the selected range that have onclick handlers
+            marks = self.dropdownGetMarks();
+            
+            if (marks.length === 0) {
+                self.dropdownHide();
+            } else {
+                self.dropdownShow(marks);
+            }
+        },
+
+        
+        /**
+         * Get all the marks in the current range that have click events.
+         */
+        dropdownGetMarks: function() {
+            var editor, marks, range, self;
+
+            self = this;
+            editor = self.codeMirror;
+            range = self.getRange();
+
+            // Do not return marks if a range of characters is selected
+            if (!(range.from.line === range.to.line && range.from.ch === range.to.ch)) {
+                return [];
+            }
+            
+            // Find all the marks for the clicked position
+            marks = editor.findMarks(range.from, range.to);
+
+            // Only keep the marks that have onClick configs
+            marks = $.map(marks, function(mark, i) {
+                var styleObj;
+                styleObj = self.classes[mark.className];
+                if (styleObj && styleObj.onClick) {
+                    // Keep in the array
+                    return mark;
+                } else {
+                    // Remove from the array
+                    return null;
+                }
+            });
+
+            return marks;
+        },
+
+        
+        /**
+         * @param {Array} marks 
+         */
+        dropdownShow: function(marks) {
+            var self;
+            self = this;
+
+            self.$dropdown.empty();
+            
+            $.each(marks, function(i, mark) {
+                
+                var $div, label, $li, styleObj;
+
+                // Get the label to display for this mark.
+                // It defaults to the className of the style.
+                // Of if the style definition has a getLabel() function
+                // call that and use the return value
+                styleObj = self.classes[mark.className] || {};
+                label = styleObj.enhancementName || mark.className;
+                if (styleObj.getLabel) {
+                    label = styleObj.getLabel(mark);
+                }
+
+                $div = $('<div/>', {
+                    'class': 'rte2-dropdown-item'
+                }).appendTo(self.$dropdown);
+
+                $('<span/>', {
+                    'class':'rte2-dropdown-label',
+                    text: label
+                }).appendTo($div);
+                
+                $('<a/>', {
+                    'class': 'rte2-dropdown-edit',
+                    text: 'Edit'
+                }).on('click', function(event){
+                    event.preventDefault();
+                    self.onClickDoMark(event, mark);
+                    return false;
+                }).appendTo($div);
+                
+                $('<a/>', {
+                    'class': 'rte2-dropdown-clear',
+                    text: 'Clear'
+                }).on('click', function(event){
+                    event.preventDefault();
+                    mark.clear();
+                    self.focus();
+                    self.dropdownCheckCursor();
+                    self.triggerChange();
+                    return false;
+                }).appendTo($div);
+                
+            });
+
+            // Set position of the dropdown
+            self.dropdownSetPosition(marks);
+            
+            self.$dropdown.show();
+        },
+
+        dropdownSetPosition: function(marks) {
+
+            var ch, chMin, editor, left, line, self, top;
+            self = this;
+
+            editor = self.codeMirror;
+
+            line = 0;
+            ch = undefined;
+            
+            // Find the largest line number and the left-most character in all the marks.
+            // If any of the marks extends across multiple lines, use character 0
+            $.each(marks, function(i, mark) {
+                var pos;
+
+                pos = mark.find();
+                
+                if (pos) {
+
+                    if (pos.to.line > line) {
+                        line = pos.to.line;
+                    }
+
+                    if (ch === undefined || pos.from.ch < ch) {
+                        ch = pos.from.ch;
+                    }
+                    
+                    if (pos.from.line !== pos.to.line) {
+                        ch = 0;
+                    }
+                }
+            });
+
+            // Get the position for the line and ch
+            pos = editor.cursorCoords({line:line, ch:(ch||0)}, 'local');
+
+            self.$dropdown.css({
+                left: pos.left,
+                top: pos.bottom
+            });
+        },
+        
+        dropdownHide: function() {
+            var self;
+            self = this;
+            self.$dropdown.hide();
+        },
+
+        
         //==================================================
         // OnClick Handlers
         //==================================================

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -593,3 +593,36 @@ li.CodeMirror-hint-active {
     margin:0 1em;
   }
 }
+
+.rte2-dropdown {
+  z-index:2;
+  position:absolute;
+  background-color:rgba(255, 255, 255, 0.9);
+  padding:0.25em;
+  border:1px solid rgba(0, 0, 0, 0.5);
+  border-radius:2px;
+  top:0;
+  left:0;
+  display:table;
+
+  .rte2-dropdown-item {
+    display:table-row;
+  }
+  
+  .rte2-dropdown-label {
+    padding-right:0.25em;
+    border-right:1px solid #aaa;
+    display:table-cell;
+  }
+  .rte2-dropdown-edit {
+    padding-left:0.25em;
+    padding-right:0.25em;
+    border-right:1px solid #aaa;
+    margin-right:0.25em;
+    display:table-cell;
+  }
+  .rte2-dropdown-clear {
+    display:table-cell;
+    padding-left:0.25em;
+  }
+}


### PR DESCRIPTION
For links and inline enhancements, when the mouse is clicked on the mark, or the cursor moves into the mark, display a dropdown that lists the marks at that point, and gives options to edit or clear the mark.