### PR TITLE
RTE bugfix for table editor, link popup does not display

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1513,7 +1513,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     return false;
                 }
             }).appendTo(document.body)
-                .popup() // turn it into a popup
+                .popup({parent:self.$container}) // turn it into a popup
                 .popup('close') // but initially close the popup
                 .popup('container').on('close', function() {
                     // If the popup is canceled with Esc or otherwise,
@@ -3209,7 +3209,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.tableEditRte = Object.create(Rte);
             self.tableEditRte.init(self.$tableEditTextarea);
             
-            self.$tableEditDiv.popup().popup('close');
+            self.$tableEditDiv.popup({parent:self.$container}).popup('close');
             
             // Give the popup a name so we can control the width
             self.$tableEditDiv.popup('container').attr('name', 'rte2-frame-table-editor');

--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -55,8 +55,12 @@
         }
       });
 
-      $container.bind('close.popup', function() {
+      $container.bind('close.popup', function(event) {
 
+        // If a popup has another popup within it, stop the close event in the child from bubbling up to the parent
+        // (closing the child should not also close the parent)
+        event.stopPropagation();
+          
         if ($container.is(':visible') &&
             $container.find('.enhancementForm, .contentForm').find('.inputContainer.state-changed').length > 0 &&
             !confirm('Are you sure you want to close this popup and discard the unsaved changes?')) {

--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -55,7 +55,17 @@
         }
       });
 
-      $container.bind('close.popup', function() {
+      $container.bind('close.popup', function(event) {
+
+        // In the case of nested popups, the close event from the child popup
+        // might propagate up to the parent popup, in which case we do not
+        // want to close the parent popup.
+        // Check for a flag that will be added to the event to indicate a child
+        // popup was already closed.
+        // Note: we can't just stop event propagation because there is other
+        // code relying on popup close events bubbling up to the top.
+        if (event.popupClosed) { return; }
+        
         if ($container.is(':visible') &&
             $container.find('.enhancementForm, .contentForm').find('.inputContainer.state-changed').length > 0 &&
             !confirm('Are you sure you want to close this popup and discard the unsaved changes?')) {
@@ -70,6 +80,10 @@
         // Prevent infinite looping for nested popups
         if ($original.hasClass('popup-show')) {
 
+          // Set a flag to indicate this event has already closed a popup,
+          // so we can avoid closing a parent popup in case popups are nested.
+          event.popupClosed = true;
+          
           $original.removeClass('popup-show');
           $original.trigger('closed');  
           $('.popup').each(function() {


### PR DESCRIPTION
When editing a table cell, a pop-up editor appears. If you try to create a link in the pop-up editor, the link form does not appear. This commit fixes the link form by creating its popup inside the popup editor (instead of at the bottom of the page DOM) - this allows the link form to layer on top of the pop-up editor as desired.

Note this pull request also contains a small change to plugin/popup.js:

In the case of nested popups, closing the child popup is also causing the parent popup to close. This is causing a problem in the rich text editor: when editing tables we popup another editor, which then can pop up a form to edit links. When the link popup is closed, it is automatically closes the parent popup as well, because the 'close' event propagates up through the DOM. The fix involves stopping the propagation so the close event does not bubble up to the parent.