### PR TITLE
3.1 Nested popups: closing child popup should not close parent popup

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -55,7 +55,12 @@
         }
       });
 
-      $container.bind('close.popup', function() {
+      $container.bind('close.popup', function(event) {
+
+        // If a popup has another popup within it, stop the close event in the child from bubbling up to the parent
+        // (closing the child should not also close the parent)
+        event.stopPropagation();
+          
         if ($container.is(':visible') &&
             $container.find('.enhancementForm, .contentForm').find('.inputContainer.state-changed').length > 0 &&
             !confirm('Are you sure you want to close this popup and discard the unsaved changes?')) {


### PR DESCRIPTION
In the case of nested popups, closing the child popup is also causing the parent popup to close. This is causing a problem when the image editor appears in a popup, and the image contains hotspots (which also use hotspots). When the hotspot popup initializes it causes the image editor popup to close because the 'close' event propagates up through the DOM. The fix involves stopping the propagation so the close event does not bubble up to the parent.
