### PR TITLE
RTE bugfix image enhancement sizes popup z-index 3.1

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -36,7 +36,8 @@
       padding:0.5em;
       background-color: fade(white, 93%);
       border:1px solid @color-separator;
-
+      z-index:1;
+      
       li {
         display:block;
       }


### PR DESCRIPTION
In the rich text editor, when using an enhancement with an image, the image sizes dropdown menu appears behind the image. This commit adds a z-index to the image sizes dropdown menu so it appears on top of the image.