### PR TITLE
RTE tables track changes improvements and bugfixes

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3199,7 +3199,15 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             self = this;
 
+            // Check if editor already exists
             if (self.$tableEditDiv) {
+                
+                // Empty the editor
+                self.tableEditRte.rte.empty();
+                
+                // Turn off track changes before we add content to the editor
+                self.tableEditRte.rte.trackSet(false);
+            
                 return;
             }
             
@@ -3232,11 +3240,16 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Set up a nested rich text editor in a popup
             // (but only do this once)
             self.tableEditInit();
-
+            
             value = $el.handsontable('getValue') || '';
-
+            
             self.$tableEditDiv.popup('open');
+
             self.tableEditRte.fromHTML(value);
+
+            // Turn on or off track changes in the table editor, based on the track changes setting in the main editor
+            self.tableEditRte.rte.trackSet( self.rte.trackIsOn() );
+
             self.tableEditRte.focus();
             self.tableEditRte.refresh();
 
@@ -3245,6 +3258,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             $el.handsontable('deselectCell');
             
             self.$tableEditDiv.popup('container').one('closed', function(){
+                var value;
                 value = self.tableEditRte.toHTML();
                 $el.handsontable('setDataAtCell', range[0], range[1], value);
             });

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4027,8 +4027,9 @@ define([
             $.each(self.enhancementCache, function(i, mark) {
                 self.enhancementRemove(mark);
             });
-            
-            self.codeMirror.setValue('');
+
+            // Kill any remaining marks
+            self.codeMirror.swapDoc(CodeMirror.Doc(''));
         },
 
 

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -293,14 +293,22 @@
   margin:0 0 0 1em;
   width:400px;
 }
-.rte2-style-track-delete {
+.rte2-style-track-delete, .rte2-table-placeholder del {
   background-color: rgba(255, 0, 0, 0.3);
   color:white;
   text-decoration: line-through;
 }
-.rte2-style-track-display .rte2-style-track-insert {
-  background-color: rgba(125, 255, 125, 0.3);
-  color:black;
+.rte2-table-placeholder del {
+  display:none;
+}
+.rte2-style-track-display {
+  .rte2-style-track-insert, .rte2-table-placeholder ins {
+    background-color: rgba(125, 255, 125, 0.3);
+    color:black;
+  }
+  .rte2-table-placeholder del {
+    display:inline;
+  }
 }
 
 .CodeMirror-hints {


### PR DESCRIPTION
Improve support for track changes within tables:

Fixed a bug where clearing the editor content was not necessarily clearing all marks. This had the effect of marking all the content in the table cell as "new" because a stray track-changes-insert mark was left in the editor.

Added style to the table display in the main editor, so track changes styles will appear in the table (before user clicks to edit the cell).

Added some logic when user clicks to edit the cell, on the popup editor maintain the same track-changes setting as the main editor. So if the user is marking changes in the main editor, then when editing a table cell track changes will still be on and changes will be marked there as well.