### PR TITLE
RTE prevent nested child popup from closing parent

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -55,7 +55,17 @@
         }
       });
 
-      $container.bind('close.popup', function() {
+      $container.bind('close.popup', function(event) {
+        
+        // In the case of nested popups, the close event from the child popup
+        // might propagate up to the parent popup, in which case we do not
+        // want to close the parent popup.
+        // Check for a flag that will be added to the event to indicate a child
+        // popup was already closed.
+        // Note: we can't just stop event propagation because there is other
+        // code relying on popup close events bubbling up to the top.
+        if (event.popupClosed) { return; }
+        
         if ($container.is(':visible') &&
             $container.find('.enhancementForm, .contentForm').find('.inputContainer.state-changed').length > 0 &&
             !confirm('Are you sure you want to close this popup and discard the unsaved changes?')) {
@@ -65,6 +75,11 @@
 
         $.removeData($container[0], 'popup-close-cancelled');
         var $original = $(this);
+        
+        // Set a flag to indicate this event has already closed a popup,
+        // so we can avoid closing a parent popup in case popups are nested.
+        event.popupClosed = true;
+        
         $original.removeClass('popup-show');
         $('.popup').each(function() {
           var $popup = $(this);


### PR DESCRIPTION
In the case where one popup is nested within another, added some logic to the close event to prevent a child popup from closing the parent popup. We tried this previously by stopping event propagation, but that ended up breaking something else, so this solution still lets the event propagate.

This is intended to fix an issue with the image editor inside a popup, where the image also has hotspots (which are displayed in nested popups).