### PR TITLE
RTE bugfix allow single column tables

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2861,7 +2861,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Initialize the table.
             $placeholder.handsontable({
                 'data': data,
-                minCols:2,
+                minCols:1,
                 minRows:1,
                 stretchH: 'all',
                 contextMenu: {


### PR DESCRIPTION
Tables in the RTE were required to have at least two columns. This commit changes the settings to allow single-column tables.