### PR TITLE
Redirects to doubly-wildcarded URLs remove both asterisks

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/PageFilter.java
+++ b/db/src/main/java/com/psddev/cms/db/PageFilter.java
@@ -484,7 +484,7 @@ public class PageFilter extends AbstractFilter {
             }
 
             if (isRedirect && redirectPath != null) {
-                String rp = StringUtils.removeEnd(redirectPath.getPath(), "*");
+                String rp = StringUtils.removeEnd(StringUtils.removeEnd(redirectPath.getPath(), "*"), "*");
 
                 JspUtils.redirectPermanently(request, response, site != null
                         ? site.getPrimaryUrl() + rp


### PR DESCRIPTION
Redirects to a doubly-wildcarded permalink (e.g. /foo/**) weren't removing both asterisks, so the browser ended at /foo/* instead of /foo/.