### PR TITLE
RTE table cell popup editor add save/cancel button

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3251,7 +3251,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.$tableEditSave = $('<button/>', {
                 'class': 'rte2-table-editor-save',
                 text: 'Set',
-                click: function() {
+                click: function(event) {
+                    event.preventDefault();
                     $(this).popup('close');
                 }
             }).appendTo($controls);
@@ -3259,7 +3260,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.$tableEditSave = $('<button/>', {
                 'class': 'rte2-table-editor-cancel',
                 text: 'Cancel',
-                click: function() {
+                click: function(event) {
+                    event.preventDefault();
                     self.tableEditCancel = true;
                     $(this).popup('close');
                 }

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3195,7 +3195,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          */
         tableEditInit: function() {
             
-            var self;
+            var $controls, self;
 
             self = this;
 
@@ -3205,10 +3205,35 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             
             // Create popup used to display the editor
             self.$tableEditDiv = $('<div>', {'class':'rte2-table-editor'}).appendTo(document.body);
+            
+            $('<h1/>', {
+                'class': 'widget-heading',
+                text: 'Edit Table Cell'
+            }).appendTo(self.$tableEditDiv);
+
             self.$tableEditTextarea = $('<textarea>').appendTo(self.$tableEditDiv);
             self.tableEditRte = Object.create(Rte);
             self.tableEditRte.init(self.$tableEditTextarea);
+
+            $controls = $('<div/>', {'class': 'rte2-table-editor-controls'}).appendTo(self.$tableEditDiv);
+
+            self.$tableEditSave = $('<button/>', {
+                'class': 'rte2-table-editor-save',
+                text: 'Set',
+                click: function() {
+                    $(this).popup('close');
+                }
+            }).appendTo($controls);
             
+            self.$tableEditSave = $('<button/>', {
+                'class': 'rte2-table-editor-cancel',
+                text: 'Cancel',
+                click: function() {
+                    self.tableEditCancel = true;
+                    $(this).popup('close');
+                }
+            }).appendTo($controls);
+
             self.$tableEditDiv.popup().popup('close');
             
             // Give the popup a name so we can control the width
@@ -3233,6 +3258,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // (but only do this once)
             self.tableEditInit();
 
+            // Set a flag so we only update the table cell if user clicks the save button
+            self.tableEditCancel = false;
+            
             value = $el.handsontable('getValue') || '';
 
             self.$tableEditDiv.popup('open');
@@ -3243,10 +3271,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Due to a bug in handsontable, it steals the arrow keys even when it does not have focus.
             // So until that bug is fixed we must deselect the current cell to allow the editor to get the arrow keys.
             $el.handsontable('deselectCell');
-            
+
             self.$tableEditDiv.popup('container').one('closed', function(){
-                value = self.tableEditRte.toHTML();
-                $el.handsontable('setDataAtCell', range[0], range[1], value);
+                 if (self.tableEditCancel) {
+                     self.tableEditCancel = false;
+                 } else {
+                     value = self.tableEditRte.toHTML();
+                     $el.handsontable('setDataAtCell', range[0], range[1], value);
+                 }
             });
 
         },

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -589,15 +589,27 @@ li.CodeMirror-hint-active {
 .popup[name=rte2-frame-enhancement-inline] {
   max-width:1000px;
   width:70%;
+
 }
 
 .popup[name=rte2-frame-table-editor] {
+  
   max-width:1000px;
   width: 60%;
   margin-left:-40%;
+  
+  .closeButton {
+    display:none;
+  }
+  
 }
 
 .rte2-table-editor {
+}
+.rte2-table-editor-save {
+  margin-right: 0.5em;
+}
+.rte2-table-editor-controls {
   margin-top:1em;
 }
 


### PR DESCRIPTION
Add a heading to the popup table cell editor, plus add save/cancel buttons to make it more obvious how to save the table cell changes.

Note to prevent the user from typing content and accidentally losing it, should the popup be closed by other means (such as pressing escape or clicking outside the popup) the behavior in that case will still be to save the table cell.

![table-cell-editor](https://cloud.githubusercontent.com/assets/185461/12430704/060aa706-bebf-11e5-9e9b-6cafa384d340.png)
