### PR TITLE
Bugfix clicking popup content div closes popup

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -226,7 +226,9 @@
     if ($targetPopup.length > 0) {
       var $targetPopupContent = $targetPopup.find('> .content');
 
-      if ($targetPopupContent.length === 0 || !$.contains($targetPopupContent[0], target)) {
+      // Close the popup if we couldn't find the "content" div within it,
+      // Or if the clicked target is outside the content div.
+      if ($targetPopupContent.length === 0 || $target.closest($targetPopupContent).length === 0) {
         $targetPopup.popup('close');
       }
 


### PR DESCRIPTION
Clicking directly on the popup "content" div is causing the popup to close when it should not. The logic that detects clicks was checking if the click was on a child of the "content" div, but it was not accounting for clicks that were directly on the div. This commit adjusts the logic so clicks inside the div, or directly on the div, will be considering inside the popup and will not close the popup.

![popup-click](https://cloud.githubusercontent.com/assets/185461/12433034/cba73c4c-becc-11e5-8fc6-12f973188663.png)