### PR TITLE
RTE bugfix table display comment styles

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -607,6 +607,12 @@ li.CodeMirror-hint-active {
   
   // Within the table do not let users click link or button elements
   a, button { pointer-events:none; }
+
+  .rte-comment {
+    &:extend(.rte2-style-comment);
+    &:extend(.rte2-style-comment-start all);
+    &:extend(.rte2-style-comment-end);
+  }
 }
 
 // Div that is used as a paste clipboard


### PR DESCRIPTION
When displaying a table cell, text marked as comments are not styled. This commit adds styles to the table placeholder so comments will be visible as such.

![rte-table-comment-style](https://cloud.githubusercontent.com/assets/185461/12433569/cb21e454-becf-11e5-9a8c-ccf1c1f21673.png)
