### PR TITLE
RTE remove rawCleanup for performance

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4232,7 +4232,9 @@ define([
             self.inlineCleanup();
 
             // Clean up any "raw html" areas so they do not allow styles inside
-            self.rawCleanup();
+            // Removing this for now as it causes performance problems when there are many raw marks.
+            // However, that means user might be able to mark up raw areas and produce invalid HTML.
+            // self.rawCleanup();
             
             doc = self.codeMirror.getDoc();
 


### PR DESCRIPTION
To improve performance in the RTE when man raw marks are used, remove the rawCleanup() function. This also fixes an issue where a single element is split into multiple elements if raw marks exist within it. Note this could have a side effect of allowing the user to create invalid HTML if the user attempts to add styles to the middle of an area marked as raw HTML.