### PR TITLE
Don't run localize on content fields with ContentField override.

### DIFF
--- a/tool-ui/src/main/webapp/WEB-INF/field.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field.jsp
@@ -62,6 +62,12 @@ if (ct != null) {
 if (ObjectUtils.isBlank(tab)) {
     tab = ui.getTab();
     localizeTab = true;
+} else {
+    if (ui.getTab() != null) {
+        if (tab.equals(ui.getTab())) {
+            localizeTab = true;
+        }
+    }
 }
 
 if (!isHidden && (!ObjectUtils.isBlank(tab) && !ContentField.DEFAULT_TAB_VALUE.equals(tab)) && !wp.hasPermission("tab/" + StringUtils.toNormalized(tab))) {

--- a/tool-ui/src/main/webapp/WEB-INF/field.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field.jsp
@@ -46,6 +46,7 @@ boolean isHidden = ui.isHidden();
 
 String tab = null;
 String label = null;
+boolean runLocalize = false;
 ContentType ct = type != null ? Query.from(ContentType.class).where("internalName = ?", type.getInternalName()).first() : null;
 
 if (ct != null) {
@@ -60,6 +61,7 @@ if (ct != null) {
 
 if (ObjectUtils.isBlank(tab)) {
     tab = ui.getTab();
+    runLocalize = true;
 }
 
 if (!isHidden && (!ObjectUtils.isBlank(tab) && !ContentField.DEFAULT_TAB_VALUE.equals(tab)) && !wp.hasPermission("tab/" + StringUtils.toNormalized(tab))) {
@@ -68,9 +70,12 @@ if (!isHidden && (!ObjectUtils.isBlank(tab) && !ContentField.DEFAULT_TAB_VALUE.e
 
 if (ObjectUtils.isBlank(tab)) {
     tab = "Main";
+    runLocalize = true;
 }
 
-tab = wp.localize(field, "tab." + tab);
+if (runLocalize) {
+    tab = wp.localize(field, "tab." + tab);
+}
 
 if (ObjectUtils.isBlank(label)) {
     label = wp.localize(field, "field." + field.getInternalName());

--- a/tool-ui/src/main/webapp/WEB-INF/field.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field.jsp
@@ -63,10 +63,8 @@ if (ObjectUtils.isBlank(tab)) {
     tab = ui.getTab();
     localizeTab = true;
 } else {
-    if (ui.getTab() != null) {
-        if (tab.equals(ui.getTab())) {
-            localizeTab = true;
-        }
+    if (tab.equals(ui.getTab())) {
+        localizeTab = true;
     }
 }
 

--- a/tool-ui/src/main/webapp/WEB-INF/field.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field.jsp
@@ -46,7 +46,7 @@ boolean isHidden = ui.isHidden();
 
 String tab = null;
 String label = null;
-boolean runLocalize = false;
+boolean localizeTab = false;
 ContentType ct = type != null ? Query.from(ContentType.class).where("internalName = ?", type.getInternalName()).first() : null;
 
 if (ct != null) {
@@ -61,7 +61,7 @@ if (ct != null) {
 
 if (ObjectUtils.isBlank(tab)) {
     tab = ui.getTab();
-    runLocalize = true;
+    localizeTab = true;
 }
 
 if (!isHidden && (!ObjectUtils.isBlank(tab) && !ContentField.DEFAULT_TAB_VALUE.equals(tab)) && !wp.hasPermission("tab/" + StringUtils.toNormalized(tab))) {
@@ -70,10 +70,10 @@ if (!isHidden && (!ObjectUtils.isBlank(tab) && !ContentField.DEFAULT_TAB_VALUE.e
 
 if (ObjectUtils.isBlank(tab)) {
     tab = "Main";
-    runLocalize = true;
+    localizeTab = true;
 }
 
-if (runLocalize) {
+if (localizeTab) {
     tab = wp.localize(field, "tab." + tab);
 }
 


### PR DESCRIPTION
Method throws exception for findBundleString on overridden tabs