### PR TITLE
RTE inline enhancement new functionality (popup, context, submenu, void)

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -11,8 +11,6 @@ import java.util.Map;
 
 public abstract class RichTextElement extends Record {
 
-    public static final String ROOT_CONTEXT = "rte.root.context";
-
     public abstract void fromAttributes(Map<String, String> attributes);
 
     public abstract Map<String, String> toAttributes();
@@ -23,7 +21,8 @@ public abstract class RichTextElement extends Record {
     public @interface Tag {
 
         String value();
-        String[] allowedContexts() default { };
+        boolean root() default true;
+        String[] parents() default { };
         String menu() default "";
     }
 }

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -23,7 +23,6 @@ public abstract class RichTextElement extends Record {
     public @interface Tag {
 
         String value();
-        boolean voidElement() default false;
         boolean editForm() default true;
         String[] allowedContexts() default { };
         String subMenu() default "";

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -23,7 +23,6 @@ public abstract class RichTextElement extends Record {
     public @interface Tag {
 
         String value();
-        boolean editForm() default true;
         String[] allowedContexts() default { };
         String menu() default "";
     }

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -26,5 +26,6 @@ public abstract class RichTextElement extends Record {
         String value();
         boolean isVoid() default false;
         String[] allowedParents() default { };
+        String subMenu() default "";
     }
 }

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -25,6 +25,6 @@ public abstract class RichTextElement extends Record {
         String value();
         boolean editForm() default true;
         String[] allowedContexts() default { };
-        String subMenu() default "";
+        String menu() default "";
     }
 }

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -25,6 +25,7 @@ public abstract class RichTextElement extends Record {
 
         String value();
         boolean voidElement() default false;
+        boolean editForm() default true;
         String[] allowedContexts() default { };
         String subMenu() default "";
     }

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -12,6 +12,8 @@ import java.util.Map;
 @RichTextElement.Embedded
 public abstract class RichTextElement extends Record {
 
+    public static final String ROOT_CONTEXT = "rte.root.context";
+
     public abstract void fromAttributes(Map<String, String> attributes);
 
     public abstract Map<String, String> toAttributes();
@@ -22,5 +24,7 @@ public abstract class RichTextElement extends Record {
     public @interface Tag {
 
         String value();
+        boolean isVoid() default false;
+        String[] allowedParents() default { };
     }
 }

--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -24,8 +24,8 @@ public abstract class RichTextElement extends Record {
     public @interface Tag {
 
         String value();
-        boolean isVoid() default false;
-        String[] allowedParents() default { };
+        boolean voidElement() default false;
+        String[] allowedContexts() default { };
         String subMenu() default "";
     }
 }

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -80,6 +80,7 @@ public class ToolUi extends Modification<Object> {
     private String tab;
     private String storageSetting;
     private String defaultSortField;
+    private List<String> hiddenWidgets;
 
     public boolean isBulkUpload() {
         return Boolean.TRUE.equals(bulkUpload);
@@ -628,6 +629,17 @@ public class ToolUi extends Modification<Object> {
 
     public void setDefaultSortField(String defaultSortField) {
         this.defaultSortField = defaultSortField;
+    }
+
+    public List<String> getHiddenWidgets() {
+        if (hiddenWidgets == null) {
+            hiddenWidgets = new ArrayList<>();
+        }
+        return hiddenWidgets;
+    }
+
+    public void setHiddenWidgets(List<String> hiddenWidgets) {
+        this.hiddenWidgets = hiddenWidgets;
     }
 
     /**
@@ -1794,6 +1806,24 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, DefaultSortField annotation) {
             type.as(ToolUi.class).setDefaultSortField(annotation.value());
+        }
+    }
+
+    /**
+     * Specifies which {@link com.psddev.cms.tool.Widget} should be hidden.
+     * {@code value} should be {@link com.psddev.cms.tool.Widget#internalName}
+     */
+    @ObjectType.AnnotationProcessorClass(HiddenWidgetsProcessor.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface HiddenWidgets {
+        String[] value();
+    }
+
+    private static class HiddenWidgetsProcessor implements ObjectType.AnnotationProcessor<HiddenWidgets> {
+        @Override
+        public void process(ObjectType type, HiddenWidgets annotation) {
+            Collections.addAll(type.as(ToolUi.class).getHiddenWidgets(), annotation.value());
         }
     }
 

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -80,7 +80,6 @@ public class ToolUi extends Modification<Object> {
     private String tab;
     private String storageSetting;
     private String defaultSortField;
-    private List<String> hiddenWidgets;
 
     public boolean isBulkUpload() {
         return Boolean.TRUE.equals(bulkUpload);
@@ -629,17 +628,6 @@ public class ToolUi extends Modification<Object> {
 
     public void setDefaultSortField(String defaultSortField) {
         this.defaultSortField = defaultSortField;
-    }
-
-    public List<String> getHiddenWidgets() {
-        if (hiddenWidgets == null) {
-            hiddenWidgets = new ArrayList<>();
-        }
-        return hiddenWidgets;
-    }
-
-    public void setHiddenWidgets(List<String> hiddenWidgets) {
-        this.hiddenWidgets = hiddenWidgets;
     }
 
     /**
@@ -1806,24 +1794,6 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, DefaultSortField annotation) {
             type.as(ToolUi.class).setDefaultSortField(annotation.value());
-        }
-    }
-
-    /**
-     * Specifies which {@link com.psddev.cms.tool.Widget} should be hidden.
-     * {@code value} should be {@link com.psddev.cms.tool.Widget#internalName}
-     */
-    @ObjectType.AnnotationProcessorClass(HiddenWidgetsProcessor.class)
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
-    public @interface HiddenWidgets {
-        String[] value();
-    }
-
-    private static class HiddenWidgetsProcessor implements ObjectType.AnnotationProcessor<HiddenWidgets> {
-        @Override
-        public void process(ObjectType type, HiddenWidgets annotation) {
-            Collections.addAll(type.as(ToolUi.class).getHiddenWidgets(), annotation.value());
         }
     }
 

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1956,25 +1956,19 @@ public class ToolPageContext extends WebPageContext {
                         .findFirst()
                         .isPresent());
 
-                List<String> allowedParents = new ArrayList<>();
+                List<String> context = new ArrayList<>();
 
-                if (tag.allowedContexts().length > 0) {
-                    for (String allowedParent : tag.allowedContexts()) {
-                        if (RichTextElement.ROOT_CONTEXT.equals(allowedParent) && !allowedParents.contains(null)) {
-                            allowedParents.add(0, null);
-
-                        } else {
-                            String trimmedParent = allowedParent.trim();
-
-                            if (!ObjectUtils.isBlank(trimmedParent)) {
-                                allowedParents.add(trimmedParent);
-                            }
-                        }
-                    }
+                if (tag.root()) {
+                    context.add(null);
                 }
 
-                if (allowedParents.size() > 0) {
-                    richTextElement.put("context", allowedParents);
+                Stream.of(tag.parents())
+                        .map(String::trim)
+                        .filter(p -> !ObjectUtils.isBlank(p))
+                        .forEach(p -> context.add(p));
+
+                if (!context.isEmpty()) {
+                    richTextElement.put("context", context);
                 }
 
                 String menu = tag.menu().trim();

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1951,7 +1951,10 @@ public class ToolPageContext extends WebPageContext {
                 ObjectType type = ObjectType.getInstance(c);
 
                 richTextElement.put("tag", tag.value());
-                richTextElement.put("popup", tag.editForm());
+                richTextElement.put("popup", type.getFields().stream()
+                        .filter(f -> !f.as(ToolUi.class).isHidden())
+                        .findFirst()
+                        .isPresent());
 
                 List<String> allowedParents = new ArrayList<>();
                 if (tag.allowedContexts().length > 0) {

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1939,9 +1939,9 @@ public class ToolPageContext extends WebPageContext {
                 ObjectType type = ObjectType.getInstance(c);
 
                 richTextElement.put("tag", tag.value());
-                if (tag.voidElement()) {
-                    richTextElement.put("popup", false);
-                }
+                richTextElement.put("popup", tag.editForm());
+
+                richTextElement.put("void", tag.voidElement());
 
                 List<String> allowedParents = new ArrayList<>();
                 if (tag.allowedContexts().length > 0) {

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1953,8 +1953,6 @@ public class ToolPageContext extends WebPageContext {
                 richTextElement.put("tag", tag.value());
                 richTextElement.put("popup", tag.editForm());
 
-                richTextElement.put("void", tag.voidElement());
-
                 List<String> allowedParents = new ArrayList<>();
                 if (tag.allowedContexts().length > 0) {
 

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1971,9 +1971,9 @@ public class ToolPageContext extends WebPageContext {
                     richTextElement.put("context", allowedParents);
                 }
 
-                String subMenu = tag.subMenu().trim();
-                if (!subMenu.isEmpty()) {
-                    richTextElement.put("submenu", subMenu);
+                String menu = tag.menu().trim();
+                if (!menu.isEmpty()) {
+                    richTextElement.put("submenu", menu);
                 }
                 richTextElement.put("styleName", type.getInternalName().replace(".", "-"));
                 richTextElement.put("typeId", type.getId().toString());

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1939,6 +1939,27 @@ public class ToolPageContext extends WebPageContext {
                 ObjectType type = ObjectType.getInstance(c);
 
                 richTextElement.put("tag", tag.value());
+                if (tag.isVoid()) {
+                    richTextElement.put("popup", false);
+                }
+
+                List<String> allowedParents = new ArrayList<>();
+                if (tag.allowedParents().length > 0) {
+
+                    for (String allowedParent : tag.allowedParents()) {
+                        if (RichTextElement.ROOT_CONTEXT.equals(allowedParent) && !allowedParents.contains(RichTextElement.ROOT_CONTEXT)) {
+                            allowedParents.add(0, RichTextElement.ROOT_CONTEXT);
+                        } else {
+                            String trimmedParent = allowedParent.trim();
+                            if (!ObjectUtils.isBlank(trimmedParent)) {
+                                allowedParents.add(trimmedParent);
+                            }
+                        }
+                    }
+                }
+                if (allowedParents.size() > 0) {
+                    richTextElement.put("context", allowedParents);
+                }
                 richTextElement.put("styleName", type.getInternalName().replace(".", "-"));
                 richTextElement.put("typeId", type.getId().toString());
                 richTextElement.put("displayName", type.getDisplayName());

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1960,6 +1960,11 @@ public class ToolPageContext extends WebPageContext {
                 if (allowedParents.size() > 0) {
                     richTextElement.put("context", allowedParents);
                 }
+
+                String subMenu = tag.subMenu().trim();
+                if (!subMenu.isEmpty()) {
+                    richTextElement.put("submenu", subMenu);
+                }
                 richTextElement.put("styleName", type.getInternalName().replace(".", "-"));
                 richTextElement.put("typeId", type.getId().toString());
                 richTextElement.put("displayName", type.getDisplayName());

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1957,27 +1957,32 @@ public class ToolPageContext extends WebPageContext {
                         .isPresent());
 
                 List<String> allowedParents = new ArrayList<>();
-                if (tag.allowedContexts().length > 0) {
 
+                if (tag.allowedContexts().length > 0) {
                     for (String allowedParent : tag.allowedContexts()) {
                         if (RichTextElement.ROOT_CONTEXT.equals(allowedParent) && !allowedParents.contains(null)) {
                             allowedParents.add(0, null);
+
                         } else {
                             String trimmedParent = allowedParent.trim();
+
                             if (!ObjectUtils.isBlank(trimmedParent)) {
                                 allowedParents.add(trimmedParent);
                             }
                         }
                     }
                 }
+
                 if (allowedParents.size() > 0) {
                     richTextElement.put("context", allowedParents);
                 }
 
                 String menu = tag.menu().trim();
+
                 if (!menu.isEmpty()) {
                     richTextElement.put("submenu", menu);
                 }
+
                 richTextElement.put("styleName", type.getInternalName().replace(".", "-"));
                 richTextElement.put("typeId", type.getId().toString());
                 richTextElement.put("displayName", type.getDisplayName());

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1939,16 +1939,16 @@ public class ToolPageContext extends WebPageContext {
                 ObjectType type = ObjectType.getInstance(c);
 
                 richTextElement.put("tag", tag.value());
-                if (tag.isVoid()) {
+                if (tag.voidElement()) {
                     richTextElement.put("popup", false);
                 }
 
                 List<String> allowedParents = new ArrayList<>();
-                if (tag.allowedParents().length > 0) {
+                if (tag.allowedContexts().length > 0) {
 
-                    for (String allowedParent : tag.allowedParents()) {
-                        if (RichTextElement.ROOT_CONTEXT.equals(allowedParent) && !allowedParents.contains(RichTextElement.ROOT_CONTEXT)) {
-                            allowedParents.add(0, RichTextElement.ROOT_CONTEXT);
+                    for (String allowedParent : tag.allowedContexts()) {
+                        if (RichTextElement.ROOT_CONTEXT.equals(allowedParent) && !allowedParents.contains(null)) {
+                            allowedParents.add(0, null);
                         } else {
                             String trimmedParent = allowedParent.trim();
                             if (!ObjectUtils.isBlank(trimmedParent)) {

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -1731,8 +1731,10 @@ private static void renderWidgets(ToolPageContext wp, Object object, String posi
         wp.write(wp.h(position));
         wp.write("\">");
 
+        List<String> hiddenWidgets = state.getType().as(ToolUi.class).getHiddenWidgets();
+
         for (Widget widget : widgets) {
-            if (wp.hasPermission(widget.getPermissionId())) {
+            if (wp.hasPermission(widget.getPermissionId()) && !hiddenWidgets.contains(widget.getInternalName())) {
 
                 wp.write("<input type=\"hidden\" name=\"");
                 wp.write(wp.h(state.getId()));

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -1731,10 +1731,8 @@ private static void renderWidgets(ToolPageContext wp, Object object, String posi
         wp.write(wp.h(position));
         wp.write("\">");
 
-        List<String> hiddenWidgets = state.getType().as(ToolUi.class).getHiddenWidgets();
-
         for (Widget widget : widgets) {
-            if (wp.hasPermission(widget.getPermissionId()) && !hiddenWidgets.contains(widget.getInternalName())) {
+            if (wp.hasPermission(widget.getPermissionId())) {
 
                 wp.write("<input type=\"hidden\" name=\"");
                 wp.write(wp.h(state.getId()));

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2717,6 +2717,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             if (!styleObj.enhancementType) {
                 return;
             }
+            if (styleObj.popup === false) {
+                return;
+            }
             
             // Stop the click from propagating up to the window
             // because if it did, it would close the popup we will be opening.
@@ -3418,9 +3421,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 enhancementName: rtElement.displayName,
                 element: tag,
                 elementAttrAny: true,
-                singleLine: true
+                singleLine: true,
+                popup: rtElement.popup === false ? false : true
             };
 
+            // Add to the toolbar submenu
             richTextElementsSubmenu.push({
                 className: 'rte2-toolbar-noicon',
                 style: styleName,


### PR DESCRIPTION
This pull request includes several changes on the backend and frontend for the RTE:

For inline enhancements, add capability to turn off the popup edit form. For example, for an inline enhancement that does not need to prompt for additional attributes. The FE has been updated to avoid popping up the form in these cases, plus the "Edit | Clear" drop-down has been updated to eliminate the "Edit" link in these cases.

For inline enhancements, add capability to restrict where it can be used. Each enhancement can be set with a "context" which lists the parent elements where the element can be used. Options are context:null which means the element can be used anywhere, or context:[Array] where the array lists the parent elements where the enhancement can be used (and null can be specified as a parent if the element can also appear as a root element). For the front end, the RTE toolbar is updated based on the cursor position, and the toolbar button gets a line-through style when an inline enhancement cannot be used based on the context.

For inline enhancements, add capability to specify an RTE toolbar submenu. This lets projects organize the inline enhancement into more logical groups, instead of having a single submenu for all inline enhancements. Note the FE behavior has also been modified so if an inline enhancement does not specify a submenu, the button will be placed directly into the toolbar (instead of in the "Inline" submenu as was previously done).

For inline enhancements, the backend has added capability to mark the element as a "void" element that cannot contain additional content; however, at this time the FE work has not been completed to support this.

One additional change is that the double-click handler for the RTE has been removed since it is no longer needed - the drop-down menu that shows "Edit | Clear" options for each style performs that function now.