### PR TITLE
Bugfix/nested popups in objectid edit 3.1

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -628,6 +628,13 @@ function() {
     var $frame = $(event.target);
     var $parent = $frame.popup('source').closest('.popup, .toolContent');
 
+    // Since the edit popup might contain other popups within it,
+    // only run this code when the edit popup is opened
+    // (not when the internal popups are opened)
+    if (!$frame.is('.popup[data-popup-source-class~="objectId-edit"]')) {
+      return;
+    }
+    
     $frame.popup('container').removeClass('popup-objectId-edit-hide');
     $parent.addClass('popup-objectId-edit popup-objectId-edit-loading');
     $win.resize();
@@ -717,6 +724,14 @@ function() {
 
   $doc.on('close', '.popup[data-popup-source-class~="objectId-edit"]', function(event) {
     var $frame = $(event.target);
+
+    // Since the edit popup might contain other popups within it,
+    // only run this code when the edit popup is opened
+    // (not when the internal popups are opened)
+    if (!$frame.is('.popup[data-popup-source-class~="objectId-edit"]')) {
+      return;
+    }
+
     var $source = $frame.popup('source');
     var $popup = $frame.popup('container');
 

--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -74,20 +74,28 @@
         }
 
         $.removeData($container[0], 'popup-close-cancelled');
+          
         var $original = $(this);
-        
-        // Set a flag to indicate this event has already closed a popup,
-        // so we can avoid closing a parent popup in case popups are nested.
-        event.popupClosed = true;
-        
-        $original.removeClass('popup-show');
-        $('.popup').each(function() {
-          var $popup = $(this);
-          var $source = $popup.popup('source');
-          if ($source && $.contains($original[0], $source[0])) {
-            $popup.popup('close');
-          }
-        });
+
+        // Prevent infinite looping for nested popups
+        if ($original.hasClass('popup-show')) {
+
+          // Set a flag to indicate this event has already closed a popup,
+          // so we can avoid closing a parent popup in case popups are nested.
+          event.popupClosed = true;
+
+          $original.removeClass('popup-show');
+          $('.popup').each(function() {
+            var $popup = $(this);
+            var $source = $popup.popup('source');
+
+            // If the popup we are closing ($original) contains the link that opened a different popup,
+            // then also close that different popup
+            if ($source && $.contains($original[0], $source[0])) {
+              $popup.popup('close');
+            }
+          });
+        }
       });
 
       $closeButton.bind('click.popup', function() {

--- a/tool-ui/src/main/webapp/script/v3/plugin/popup.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/popup.js
@@ -77,12 +77,12 @@
           
         var $original = $(this);
 
+        // Set a flag to indicate this event has already closed a popup,
+        // so we can avoid closing a parent popup in case popups are nested.
+        event.popupClosed = true;
+
         // Prevent infinite looping for nested popups
         if ($original.hasClass('popup-show')) {
-
-          // Set a flag to indicate this event has already closed a popup,
-          // so we can avoid closing a parent popup in case popups are nested.
-          event.popupClosed = true;
 
           $original.removeClass('popup-show');
           $('.popup').each(function() {


### PR DESCRIPTION
There were some fixes made to 3.2 for supporting popups nested within other popups (especially within a "frame" popup). This pull request implements some of those fixes in 3.1.

The affected area was the image editor in a popup, when an image contained hotspot information. For example, an image editor created from within an RTE enhancement, or an image editor created from clicking "Edit" next to a lead image. In those cases, the hotspot popup would interfere with the parent popup.
