### PR TITLE
RTE remove extra space in enhancements

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -58,7 +58,10 @@
 
   // To leave room for the word count, make sure there is space after the last toolbar item
   > li:last-of-type {
-      margin-right: 7em;
+    margin-right: 7em;
+    .rte2-enhancement & {
+      margin-right:0;
+    }
   }
   
   a, span, .rte2-toolbar-separator {
@@ -503,18 +506,9 @@ li.CodeMirror-hint-active {
 
   .rte2-enhancement {
     box-sizing: border-box;
-    padding: 0 5px (@lineHeight-default + 5px) 5px;
+    padding: 0 5px 5px 5px;
     position: relative;
-
-    &:before {
-      .background-striped(@color-heading);
-      bottom: @lineHeight-default;
-      content: '';
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
+    .background-striped(@color-heading);
 
     .rte2-enhancement-label {
       overflow: hidden;


### PR DESCRIPTION
In the rich text editor, enhancement blocks were getting extra space at the bottom. This was due to styles that were copied over from the old RTE. This commit updates the styles to fit the way enhancements are implemented in the new RTE.

![enhancement-extra-space](https://cloud.githubusercontent.com/assets/185461/12596372/967e6456-c44d-11e5-9567-e0000fdbdb0f.png)
