### PR TITLE
Changes method of getting types list for RecentActivityWidget to be c…

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/widget/RecentActivityWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/RecentActivityWidget.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableSet;
 import com.psddev.cms.db.Content;
 import com.psddev.cms.db.Directory;
 import com.psddev.cms.db.ToolRole;
+import com.psddev.cms.db.ToolUi;
 import com.psddev.cms.db.ToolUser;
 import com.psddev.cms.tool.Dashboard;
 import com.psddev.cms.tool.DefaultDashboardWidget;
@@ -114,7 +115,7 @@ public class RecentActivityWidget extends DefaultDashboardWidget {
                         "action", page.url(null));
 
                     page.writeTypeSelect(
-                            com.psddev.cms.db.Template.Static.findUsedTypes(page.getSite())
+                            ObjectType.getInstance(Content.class).as(ToolUi.class).findDisplayTypes()
                                     .stream()
                                     .filter(page.createTypeDisplayPredicate(ImmutableSet.of("read")))
                                     .collect(Collectors.toList()),


### PR DESCRIPTION
…onsistent with UnpublishedDraftsWidget
<img width="708" alt="recent-activity-widget-types-list" src="https://cloud.githubusercontent.com/assets/5446441/12630771/0ca15700-c51c-11e5-85c0-c6d8cbab0a69.png">
