### PR TITLE
RTE bugfix single lines styles breaking lines

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -1459,12 +1459,16 @@ define([
          */
         inlineSplitMarkAcrossLines: function(mark) {
 
-            var editor, to, lineNumber, pos, self, from;
+            var editor, to, lineNumber, pos, self, singleLine, styleObj, from;
 
             self = this;
             editor = self.codeMirror;
 
             mark = mark.marker ? mark.marker : mark;
+
+            // Get the style object for this mark so we can determine if this should be treated as a "singleLine" mark
+            styleObj = self.classes[mark.className] || {};
+            singleLine = Boolean(styleObj.singleLine);
             
             // Get the start and end positions for this mark
             pos = mark.find();
@@ -1496,6 +1500,11 @@ define([
 
                     // Copy any additional attributes that were attached to the old mark
                     newMark.attributes = mark.attributes;
+
+                    // Don't create other marks if this is a singleLine mark
+                    if (singleLine) {
+                        break;
+                    }
                 }
 
                 // Remove the old mark that went across multiple lines


### PR DESCRIPTION
If a style has the singleLine parameter set to true, then that style should not be allowed to span across multiple lines.  This was already being enforced when the style is added; however, if the user edited the style and pressed Enter then the style was expanding to the second line. This commit ensures that the style is not duplicated on the second line (as this was causing a problem if the user then pressed backspace to remove the extra line, and we were ending up with two style markers for inline enhancements).