### PR TITLE
RTE update handsontable to fix null problem

### DIFF
--- a/tool-ui/bower.json
+++ b/tool-ui/bower.json
@@ -7,7 +7,7 @@
     "codemirror": "5.10.0",
     "css-element-queries": "4250c87c5ab2efd467f99d901252c73eb6bb80ea",
     "d3": "3.4.6",
-    "handsontable": "0.20.2",
+    "handsontable": "0.21.0",
     "husl": "4.0.0",
     "jquery": "1.8.3+1",
     "jsdiff": "2.0.2",

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2972,9 +2972,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                  
             });
 
-            // Problem with "null" appearing in new rows, might be fixed soon with this issue
-            // https://github.com/handsontable/handsontable/issues/2816
-            
             // Add the div to the editor
             mark = self.rte.enhancementAdd($div[0], line, {
                 block:true,


### PR DESCRIPTION
The handsontable code had a bug that was causing "null" to display in new table cells. Updating handsontable to get a bugfix.

JIRA ticket: https://perfectsense.atlassian.net/browse/BSP-1442
