### PR TITLE
Fix for NPE when publishing Tables since handsOnTable 'onChange' was deprecated

### DIFF
--- a/tool-ui/src/main/webapp/script/input/table.js
+++ b/tool-ui/src/main/webapp/script/input/table.js
@@ -46,7 +46,7 @@ function($, bsp_utils) {
                 'minSpareCols': 1,
                 'fillHandle': false,
                 'contextMenu': true,
-                'onChange': function() {
+                'afterChange': function() {
                     $jsonInput.val(JSON.stringify(data));
                 }
             });


### PR DESCRIPTION
We’re seeing Tables are throwing NPE when trying to publish them in the CMS with 3.x.   

onChange event has been replaced with an afterChange event. 