### PR TITLE
BSP-1556; Fixes NullPointerException when trying to render a null object.

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/PageFilter.java
+++ b/db/src/main/java/com/psddev/cms/db/PageFilter.java
@@ -1124,6 +1124,10 @@ public class PageFilter extends AbstractFilter {
             T object)
             throws IOException, ServletException {
 
+        if (object == null) {
+            return false;
+        }
+
         String selectedViewType = null;
 
         // 1. Find ViewModel class (check the different view types, etc.)


### PR DESCRIPTION
Short circuits out of PageFilter#tryProcessView if the object is null.