### PR TITLE
RTE add support for attributes to line styles (BSP-1548)

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -21,6 +21,7 @@ public abstract class RichTextElement extends Record {
     public @interface Tag {
 
         String value();
+        boolean block() default false;
         boolean empty() default false;
         boolean root() default false;
         Class<?>[] children() default { };

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1998,6 +1998,7 @@ public class ToolPageContext extends WebPageContext {
                 ObjectType type = ObjectType.getInstance(c);
 
                 richTextElement.put("tag", tag.value());
+                richTextElement.put("line", tag.block());
                 richTextElement.put("void", tag.empty());
                 richTextElement.put("popup", type.getFields().stream()
                         .filter(f -> !f.as(ToolUi.class).isHidden())

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3574,6 +3574,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 element: tag,
                 elementAttrAny: true,
                 singleLine: true,
+                line: Boolean(rtElement.line),
                 "void": Boolean(rtElement.void),
                 popup: rtElement.popup === false ? false : true,
                 context: rtElement.context


### PR DESCRIPTION
Currently in the RTE only inline styles can have attributes (imported from the HTML or set via inline enhancements); however, we also have cases where "line" styles (block elements) need to have attributes.

Line styles in the RTE are implemented as a single class name on the line, so there is no built-in way to save attributes for each style.

This commit adds functionality to the RTE so line styles will create a data object that is stored within the CodeMirror lineHandle (which tracks the line even when the line moves). This data object is designed to mimic the functionality of a CodeMirror "mark" object - in such a way that the object can be passed to inline enhancement forms just as other marks are already passed - so the form can modify the attributes on the object.

In addition, the HTML input and output logic has been update to read and write attributes base don the line style data.