### PR TITLE
RTE bugfix position of table cell dropdown (BSP-1582)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3003,7 +3003,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          */
         tableShowContextMenu: function(el, row, col) {
 
-            var h, height, menu, offset, self, $td, width;
+            var h, height, menu, offset, self, $td;
 
             self = this;
             
@@ -3013,8 +3013,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 $td = $(h.getCell(row, col));
                 offset = $td.offset();
                 height = $td.height();
-                width = $td.width();
-                menu.open({top:offset.top + height, left:offset.left, width:width, height:height});
+                menu.open({pageY:offset.top + height, pageX:offset.left});
             }
         },
 


### PR DESCRIPTION
When we updated to the most recent version of handsontable, it broke the way we position the dropdown menu. We are using a "non-standard" way to display the context menu since handsontable does not provide an official API for that, and apparently they changed the arguments used for the menu.open() function we are using.