### PR TITLE
RTE bugfix position of inline enhancement popup (BSP-1376)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2776,7 +2776,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
         inlineEnhancementHandleClick: function(event, mark) {
 
-            var enhancementEditUrl, $div, $divLink, html, self, styleObj;
+            var enhancementEditUrl, $div, $divLink, html, offset, self, styleObj;
 
             self = this;
 
@@ -2814,11 +2814,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     text: '.'
                 })
                 
-            }).appendTo('body').css({
-                'top': event.pageY,
-                'left': event.pageX
-            });
+            }).appendTo('body');
 
+            // Set the position of the popup
+            offset = self.rte.getOffset(range);
+            $div.css({
+                'top': offset.top,
+                'left': offset.left
+            });
             $divLink = $div.find('a');
 
             // Add data to the link with the rte and the mark,

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4001,6 +4001,22 @@ define([
 
         
         /**
+         * For a given range, returns the starting offset in pixels.
+         *
+         * @param {Object} range
+         * @returns {Object}
+         * Offset object {left, right, top, bottom }
+         * Use left,top to represent the point below the first character.
+         */
+        getOffset: function(range) {
+            var self;
+            self = this;
+            range = range || self.getRange();
+            return self.codeMirror.charCoords({line:range.from.line, ch:range.from.ch});
+        },
+
+        
+        /**
          * Given a CodeMirror mark, replace the text within it
          * without destroying the mark.
          * Normally if you were to use the CodeMirror functions to replace a range,


### PR DESCRIPTION
Changes the position of the inline enhancement popup so it appears pointing to the text where the inline enhancement will appear.