### PR TITLE
RTE bugfix inline enhancements clear button (BSP-1414)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -739,10 +739,10 @@ define([
                     
                     // Check if we should remove the class
                     matchesClass = false;
+                    styleObj = self.classes[mark.marker.className] || {};
                     if (className) {
                         matchesClass = Boolean(mark.marker.className === className);
                     } else {
-                        styleObj = self.classes[mark.marker.className] || {};
                         
                         // Do not remove the track changes classes unless specifically named
                         matchesClass = Boolean(options.includeTrack || styleObj.internal !== true);
@@ -874,6 +874,11 @@ define([
                         //        rrr        <-- range
                         //      nn   nn      <-- new marks
                         //        xxx        <-- text to delete (if deleteText is true)
+
+                        // Do not allow inline enhancement styles to be split in the middle
+                        if (styleObj.enhancementType) {
+                            return;
+                        }
                         
                         editor.markText(
                             { line: lineNumber, ch: toCh },


### PR DESCRIPTION
For inline enhancements, if you click the "Clear" button for characters in the middle of the enhancement, it will split the mark into two marks. We need to prevent that, so this commit modifies the clear function so it will not split inline enhancement marks. You can clear one side or the other, or clear the entire mark, but you cannot clear just a few characters in the middle of the mark.