### PR TITLE
RTE link toolbar should edit existing link (BSP-1419)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1081,7 +1081,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          */
         toolbarHandleClick: function(item, event) {
 
-            var $button, mark, rte, self, styleObj, value;
+            var $button, mark, marks, rte, self, styleObj, value;
 
             self = this;
 
@@ -1209,10 +1209,26 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
                 if (styleObj.onClick) {
 
-                    // Create a new mark then call the onclick function on it
-                    mark = rte.setStyle(item.style);
-                    if (mark) {
-                        styleObj.onClick(event, mark);
+                    // Find all the marks in the current selection that have onclick
+                    marks = self.rte.dropdownGetMarks(true);
+
+                    // Exclude marks that are not for the style we are currently examining
+                    marks = $.map(marks, function(mark){
+                        if (mark.className === styleObj.className) {
+                            return mark;
+                        } else {
+                            return null;
+                        }
+                    });
+
+                    if (marks.length) {
+                        styleObj.onClick(event, marks[0]);
+                    } else {
+                        // Create a new mark then call the onclick function on it
+                        mark = rte.setStyle(item.style);
+                        if (mark) {
+                            styleObj.onClick(event, mark);
+                        }
                     }
 
                 } else {

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2455,8 +2455,12 @@ define([
         
         /**
          * Get all the marks in the current range that have click events.
+         *
+         * @param {Boolean} [allowRange=false]
+         * Set to true if you want the marks across a range of characters.
+         * Defaults to false, which means it will only return marks if the selection range is a cursor position.
          */
-        dropdownGetMarks: function() {
+        dropdownGetMarks: function(allowRange) {
             var editor, marks, range, self;
 
             self = this;
@@ -2464,7 +2468,7 @@ define([
             range = self.getRange();
 
             // Do not return marks if a range of characters is selected
-            if (!(range.from.line === range.to.line && range.from.ch === range.to.ch)) {
+            if (allowRange !== true && !(range.from.line === range.to.line && range.from.ch === range.to.ch)) {
                 return [];
             }
             


### PR DESCRIPTION
When user clicks the Link button in the toolbar while the cursor is within an existing link, edit the existing link instead of creating a new link.