### PR TITLE
After scheduling, display 'Scheduled' workflow state

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/Content.java
+++ b/db/src/main/java/com/psddev/cms/db/Content.java
@@ -215,7 +215,7 @@ public abstract class Content extends Record {
         @Override
         public String createVisibilityLabel(ObjectField field) {
             if (field.getInternalName().equals("cms.content.draft")) {
-                return isDraft() ? "Initial Draft" : null;
+                return isDraft() ? (getScheduleDate() != null ? "Scheduled" : "Initial Draft") : null;
             } else {
                 return isTrash() ? "Archived" : null;
             }


### PR DESCRIPTION
Once workflowed content is scheduled, its workflow status is removed. This makes sense because it can no longer move around through workflow after it is set as scheduled; scheduling is the last transition a piece takes before it goes live. However, this causes the workflow state label of the piece to revert back to "Initial Draft", which is confusing for the editorial staff. Instead, the workflow state label should more accurately indicate that the piece is no longer in workflow because it is scheduled to go live. This commit makes that change by modifying the workflow label for drafts to display "Scheduled" instead of "Initial Draft" when a schedule date is present. That date is present if and only if the content has been scheduled, so it seems like the right indicator to use.