### PR TITLE
Repeatable gallery view should edit first tile (BSP-962)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1596,6 +1596,13 @@ The HTML within the repeatable element must conform to these standards:
                 // it is displaying everything correctly
                 self.carousel.update();
 
+                // If no tile is active in the carousel, make the first one active
+                // so there will be an edit form underneath
+                if (self.carousel.getActive() === 0) {
+                    // Make the first tile active and show the edit form
+                    self.modePreviewEditNext();
+                }
+                
                 // After showing the carousel update the next/previous buttons on the edit form
                 // This might be needed in case the tiles were reordered or something like that
                 self.modePreviewUpdateEditContainer();


### PR DESCRIPTION
When switching to "gallery view", if no tiles are selected, automatically select the first tile so the edit form for that tile will appear.