### PR TITLE
Feature/copied object inherits source object site owner

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/CmsTool.java
+++ b/db/src/main/java/com/psddev/cms/tool/CmsTool.java
@@ -115,7 +115,7 @@ public class CmsTool extends Tool {
     @ToolUi.Tab("Debug")
     private boolean disableAutomaticallySavingDrafts;
 
-    @ToolUi.Tab("Debug")
+    @ToolUi.Tab("UI")
     private boolean enableFrontEndUploader;
 
     @ToolUi.Tab("Debug")
@@ -168,10 +168,10 @@ public class CmsTool extends Tool {
 
     private boolean enableCrossDomainInlineEditing;
 
-    @ToolUi.Tab("Debug")
+    @ToolUi.Tab("UI")
     private boolean enablePaddedCrop;
 
-    @ToolUi.Tab("Debug")
+    @ToolUi.Tab("RTE")
     private boolean disableCodeMirrorRichTextEditor;
 
     @ToolUi.Tab("Debug")

--- a/db/src/main/java/com/psddev/cms/tool/CmsTool.java
+++ b/db/src/main/java/com/psddev/cms/tool/CmsTool.java
@@ -127,10 +127,12 @@ public class CmsTool extends Tool {
     @ToolUi.Tab("RTE")
     private boolean enableAnnotations;
 
-    @ToolUi.Tab("Debug")
+    @ToolUi.Tab("UI")
     private boolean disableContentLocking;
 
-    @ToolUi.Tab("Debug")
+    @ToolUi.DisplayName("Manual Content Locking?")
+    @ToolUi.NoteHtml("<span data-dynamic-text='${content.createManualContentLockingNoteText()}'></span>")
+    @ToolUi.Tab("UI")
     private boolean optInContentLocking;
 
     @ToolUi.Tab("Debug")
@@ -782,6 +784,12 @@ public class CmsTool extends Tool {
 
     public void setDisableRtc(boolean disableRtc) {
         this.disableRtc = disableRtc;
+    }
+
+    public String createManualContentLockingNoteText() {
+        return isDisableContentLocking()
+                ? "Content locking is completely disabled, so this setting has no effect."
+                : "If checked, user must lock each content manually.";
     }
 
     /** Returns the preview URL. */

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -36,6 +36,7 @@ com.psddev.dari.util.JspUtils,
 com.psddev.dari.util.ObjectUtils,
 com.psddev.dari.util.StringUtils,
 com.psddev.cms.tool.ContentEditable,
+com.psddev.dari.util.Settings,
 
 java.io.StringWriter,
 java.util.ArrayList,
@@ -172,7 +173,11 @@ if (copy != null) {
     for (Site consumer : editingState.as(Site.ObjectModification.class).getConsumers()) {
         editingState.as(Directory.ObjectModification.class).clearSitePaths(consumer);
     }
-    editingState.as(Site.ObjectModification.class).setOwner(site);
+    if (site != null && 
+            !Settings.get(boolean.class, "cms/tool/copiedObjectInheritsSourceObjectsSiteOwner")) {
+        // Only set the owner to current site if not on global and no setting to dictate otherwise.
+        editingState.as(Site.ObjectModification.class).setOwner(site);
+    }    
 }
 
 // Directory directory = Query.findById(Directory.class, wp.uuidParam("directoryId"));


### PR DESCRIPTION
Hallmark are asking for a copied object to get the same site owner as the source object.

This code change sets the site owner to the source object's site owner if 
a) user is on global (where site will be null anyway) or 
b) the context.xml setting "cms/tool/copiedObjectInheritsSourceObjectsSiteOwner" is true