### PR TITLE
BSP-1614 - For a copied object, set the owner to current site

### DIFF
--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -25,6 +25,7 @@ com.psddev.cms.tool.CmsTool,
 com.psddev.cms.tool.ContentEditWidgetDisplay,
 com.psddev.cms.tool.ToolPageContext,
 com.psddev.cms.tool.Widget,
+com.psddev.dari.util.Settings,
 
 com.psddev.dari.db.ObjectField,
 com.psddev.dari.db.ObjectType,
@@ -172,7 +173,11 @@ if (copy != null) {
     for (Site consumer : editingState.as(Site.ObjectModification.class).getConsumers()) {
         editingState.as(Directory.ObjectModification.class).clearSitePaths(consumer);
     }
-    editingState.as(Site.ObjectModification.class).setOwner(site);
+    if (site != null && 
+            !Settings.get(boolean.class, "cms/tool/copiedObjectInheritsSourceObjectsSiteOwner")) {
+        // Only set the owner to current site if not on global and no setting to dictate otherwise.
+        editingState.as(Site.ObjectModification.class).setOwner(site);
+    }    
 }
 
 // Directory directory = Query.findById(Directory.class, wp.uuidParam("directoryId"));


### PR DESCRIPTION
NSP-1614 - For a copied object, only set the owner to current site if not on global and no context.xml setting to dictate otherwise.

JIRA is  https://perfectsense.atlassian.net/browse/BSP-1614