### PR TITLE
Changes ContentRevisions live label to be contextual to the content to reduce user confusion.

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/page/ContentRevisions.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/ContentRevisions.java
@@ -126,7 +126,9 @@ public class ContentRevisions extends Widget {
             page.writeStart("ul", "class", "links");
                 page.writeStart("li", "class", object.equals(selected) ? "selected" : null);
                     page.writeStart("a", "href", page.originalUrl(null, object));
-                        page.writeHtml(page.localize(ContentRevisions.class, "action.viewLive"));
+                        page.writeHtml(ObjectUtils.firstNonNull(
+                                state.getVisibilityLabel(),
+                                page.localize(ContentRevisions.class, "action.viewLive")));
                     page.writeEnd();
                 page.writeEnd();
             page.writeEnd();


### PR DESCRIPTION
BSP-1604