### PR TITLE
Filters ViewMap's bean props to only include those with read methods.

### DIFF
--- a/db/src/main/java/com/psddev/cms/view/ViewMap.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewMap.java
@@ -85,6 +85,7 @@ class ViewMap implements Map<String, Object> {
         try {
             Arrays.stream(Introspector.getBeanInfo(view.getClass()).getPropertyDescriptors())
                     .filter((prop) -> includeClassName || !"class".equals(prop.getName()))
+                    .filter((prop) -> prop.getReadMethod() != null)
                     .forEach(prop -> unresolved.put(prop.getName(), () -> invoke(prop.getReadMethod(), view)));
 
         } catch (IntrospectionException e) {


### PR DESCRIPTION
BSP-1626
Prevents potential NPE downstream on calls to entrySet() or values().