### PR TITLE
Filters out ViewModel classes that aren't assignable to the view class.

### DIFF
--- a/db/src/main/java/com/psddev/cms/view/ViewModel.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewModel.java
@@ -188,7 +188,8 @@ public abstract class ViewModel<M> {
 
                 Class<?> declaredModelClass = typeDef.getInferredGenericTypeArgumentClass(ViewModel.class, 0);
 
-                if (declaredModelClass != null && declaredModelClass.isAssignableFrom(modelClass)) {
+                if (declaredModelClass != null && declaredModelClass.isAssignableFrom(modelClass)
+                        && (viewClass == null || viewClass.isAssignableFrom(viewModelClass))) {
 
                     List<Class<? extends ViewModel>> viewModelClasses = modelToViewModelClassMap.get(declaredModelClass);
                     if (viewModelClasses == null) {


### PR DESCRIPTION
Fixes issue where ViewModel#findViewModelClass could return null with a warning that multiple valid view model classes were found and therefore the result is ambiguous, when in fact certain view model classes were being included when they shouldn't be. Specifically, when a view class was passed as an argument, there was no check that the view model class and the view class were compatible. This commit adds that check.