### PR TITLE
@RichTextElement.Exclusive 

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/RichTextElement.java
+++ b/db/src/main/java/com/psddev/cms/db/RichTextElement.java
@@ -27,4 +27,11 @@ public abstract class RichTextElement extends Record {
         Class<?>[] children() default { };
         String menu() default "";
     }
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface Exclusive {
+
+    }
 }

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2137,7 +2137,6 @@ public class ToolPageContext extends WebPageContext {
                 richTextElement.put("clear", clearStyles);
             }
 
-
             if (!ObjectUtils.isBlank(context)) {
 
                 if (!ObjectUtils.isBlank(clearContext)) {

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1978,6 +1978,7 @@ public class ToolPageContext extends WebPageContext {
 
         Map<String, Set<String>> contextMap = new HashMap<>();
         Map<String, Set<String>> clearContextMap = new HashMap<>();
+        Map<String, String> tagNameToStyleNameMap = new HashMap<>();
 
         LoadingCache<Class<?>, Set<Class<?>>> concreteClassMap = CacheBuilder.newBuilder()
                 .build(new CacheLoader<Class<?>, Set<Class<?>>>() {
@@ -2060,8 +2061,6 @@ public class ToolPageContext extends WebPageContext {
                 if (!exclusiveTags.isEmpty()) {
 
                     clearContextMap.put(tagName, exclusiveTags);
-
-                    richTextElement.put("clear", exclusiveTags);
                 }
 
                 String menu = tag.menu().trim();
@@ -2070,7 +2069,10 @@ public class ToolPageContext extends WebPageContext {
                     richTextElement.put("submenu", menu);
                 }
 
-                richTextElement.put("styleName", type.getInternalName().replace(".", "-"));
+                String styleName = type.getInternalName().replace(".", "-");
+                tagNameToStyleNameMap.put(tagName, styleName);
+
+                richTextElement.put("styleName", styleName);
                 richTextElement.put("typeId", type.getId().toString());
                 richTextElement.put("displayName", type.getDisplayName());
                 richTextElements.add(richTextElement);
@@ -2080,15 +2082,26 @@ public class ToolPageContext extends WebPageContext {
         for (Map<String, Object> richTextElement : richTextElements) {
 
             String tagName = (String) richTextElement.get("tag");
+
             Set<String> context = contextMap.get(tagName);
+            Set<String> clearContext = clearContextMap.get(tagName);
+
+            if (!ObjectUtils.isBlank(clearContext)) {
+
+                Set<String> clearStyles = clearContext.stream()
+                        .map(tagNameToStyleNameMap::get)
+                        .collect(Collectors.toSet());
+
+                richTextElement.put("clear", clearStyles);
+            }
+
 
             if (!ObjectUtils.isBlank(context)) {
-
-                Set<String> clearContext = clearContextMap.get(tagName);
 
                 if (!ObjectUtils.isBlank(clearContext)) {
                     context.addAll(clearContext);
                 }
+
                 richTextElement.put("context", context);
             }
         }

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3583,7 +3583,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 line: Boolean(rtElement.line),
                 "void": Boolean(rtElement.void),
                 popup: rtElement.popup === false ? false : true,
-                context: rtElement.context
+                context: rtElement.context,
+                clear: rtElement.clear
             };
 
             toolbarButton = {

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2067,7 +2067,12 @@ define([
             range = range || self.getRange();
 
             if (styleKey) {
-                className = self.styles[styleKey].className;
+                if (self.styles[styleKey]) {
+                    className = self.styles[styleKey].className;
+                } else {
+                    // A style key was provided but there is no such style
+                    return;
+                }
             }
 
             for (lineNumber = range.from.line; lineNumber <= range.to.line; lineNumber++) {


### PR DESCRIPTION
This PR adds a @RichTextElement.Exclusive annotation to allow designation that a group of RichTextElement classes implementing an interface marked with @RichTextElement.Exclusive are intended to be applied exclusively.  If any of the group of elements already exists where a second element from the same group is applied, the first will be removed.

Example:

Model defines two tags to be used in the RTE, <style.one> and <style.two> and both are designated as exclusive of each other.

```
@DisplayName("Style 1")
@RichTextElement.Tag("style.one")
class StyleOneRichTextElement extends RichTextElement implements ExclusiveStyleGroup { ... }

@DisplayName("Style 2")
@RichTextElement.Tag("style.two")
class StyleTwoRichTextElement extends RichTextElement implements ExclusiveStyleGroup { ... }

@RichTextElement.Exclusive
interface MyExclusiveStyleGroup extends Recordable { }
```

In the RTE, selecting text "my styled text" and clicking the "Style 1" button will apply a <style.one> tag around the selected text:

```
<style.one>my styled text</style.one>
```

On the same selection, clicking the "Style 2" button will remove the <style.one> tag and apply the <style.two> tag:

```
<style.two>my styled text</style.two>
```