### PR TITLE
Wrap jquery.dropdown in a requirejs define (BSP-1638)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.dropdown.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.dropdown.js
@@ -1,3 +1,5 @@
+define(['string'], function (S) {
+    
 /** Better drop-down list than standard SELECT. */
 (function($, win, undef) {
 
@@ -7,8 +9,6 @@
       $openOriginal,
       $openList;
   
-  require(['string'], function (S) {    
-
   $.plugin2('dropDown', {
     '_defaultOptions': {
       'classPrefix': 'dropDown-'
@@ -451,6 +451,10 @@
     return true;
   });
   
-  });
-
 }(jQuery, window));
+
+    // Return an empty object just for the benefit of the AMD module.
+    // Not expected to be used since we just set up a jquery plugin.
+    return {};
+    
+}); // define()


### PR DESCRIPTION
The jquery.dropdown.js file is being loaded as a requirejs AMD module, but it does not define() itself as a module, even though it has a dependency and requires another module. This is causing timing issues in other code that is using dropdown as a dependency.

This commit removes the require() statement and instead wraps all the code in a define() using a dependency.