### PR TITLE
RTE enhancement paste position bugfix (BSP-1597)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -5521,9 +5521,9 @@ define([
             });
 
             $.each(enhancements, function(i, enhancementObj) {
-                
+
                 // Pass off control to a user-defined function for adding enhancements
-                self.enhancementFromHTML(enhancementObj.$content, enhancementObj.line);
+                self.enhancementFromHTML(enhancementObj.$content, enhancementObj.line + range.from.line);
                 
             });
 


### PR DESCRIPTION
Copying a line with an enhancement or a table, then pasting it somewhere else was always adding the enhancement to the first line of the editor. This commit fixes the case and ensures the enhancement is created relative to the line where it was pasted in.