### PR TITLE
RTE improve paste from Google Docs lists (BSP-1593)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -199,11 +199,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          * {String} a style name that defines how element should be styled (refer to the "styles" parameter)
          */
         clipboardSanitizeRules: {
-
+            
+            // Note: Google docs encloses the entire document in a 'b' element so we must exclude that one
+            'b[id^=docs-internal-guid]': '',
+            
             // Any <b> or '<strong>' element should be treated as bold even if it has extra attributes
             // Example MSWord:  <b style="mso-bidi-font-weight:normal">
-            // Note: Google docs encloses the entire document in a 'b' element so we must exclude that one
-            'b:not([id^=docs-internal-guid])': 'bold',
+            'b': 'bold',
             'strong': 'bold',
 
             // Any '<i>' or '<em>' element should be treated as italic even if it has extra attributes
@@ -219,8 +221,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             'span[style*="text-decoration:underline"]': 'underline',
             'span[style*="vertical-align:super"]': 'superscript',
             'span[style*="vertical-align:sub"]': 'subscript',
-            'li[style*="list-style-type:disc"] > p': 'ul',
-            'li[style*="list-style-type:decimal"] > p': 'ol',
+
+            // Google docs puts paragraph within list items, so eliminate it
+            'li > p': '',
+            
+            'li[style*="list-style-type:disc"]': 'ul',
+            'li[style*="list-style-type:decimal"]': 'ol',
 
             'p[style*="text-align: right"]': 'alignRight',
             'p[style*="text-align: center"]': 'alignCenter',

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3497,10 +3497,15 @@ define([
 
             // Apply the clipboard sanitize rules (if any)
             if (self.clipboardSanitizeRules) {
-                $el.find('p').after('<br/>');
                 $.each(self.clipboardSanitizeRules, function(selector, style) {
-                    $el.find(selector).wrapInner( $('<span>', {'data-rte2-sanitize': style}) );
+                    $el.find(selector).each(function(){
+                        var $match = $(this);
+                        var $replacement = $('<span>', {'data-rte2-sanitize': style});
+                        $replacement.append( $match.contents() );
+                        $match.replaceWith( $replacement );
+                    });
                 });
+                $el.find('[data-rte2-sanitize=linebreak]').after('<br/>');
             }
 
             // Run it through the clipboard sanitize function (if it exists)
@@ -5169,7 +5174,7 @@ define([
                             matchStyleObj = false;
 
                             // If a data-rte2-sanitize attribute is found on the element, then we are getting this
-                            // html as pasted data from another source. Our sanitzie rules have marked this element
+                            // html as pasted data from another source. Our sanitize rules have marked this element
                             // as being a particular style, so we should force that style to be used.
                             matchStyleObj = self.styles[ $(next).attr('data-rte2-sanitize') ];
                             


### PR DESCRIPTION
When pasting a list from Google Docs, the RTE ends up with multiple extra lines and blank list items. This commit changes the clipboardSanitize rules to improve handling such issues.