### PR TITLE
Collection Item Toggle, Weight, and Progress

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -34,6 +34,8 @@ public class ToolUi extends Modification<Object> {
 
     private Boolean bulkUpload;
     private String codeType;
+    private Boolean collectionItemToggle;
+    private Boolean collectionItemWeight;
     private Boolean colorPicker;
     private String cssClass;
     private Set<String> displayAfter;
@@ -94,6 +96,22 @@ public class ToolUi extends Modification<Object> {
 
     public void setCodeType(String codeType) {
         this.codeType = codeType;
+    }
+
+    public Boolean isCollectionItemToggle() {
+        return Boolean.TRUE.equals(collectionItemToggle);
+    }
+
+    public void setCollectionItemToggle(Boolean collectionItemToggle) {
+        this.collectionItemToggle = collectionItemToggle ? Boolean.TRUE : null;
+    }
+
+    public Boolean isCollectionItemWeight() {
+        return Boolean.TRUE.equals(collectionItemWeight);
+    }
+
+    public void setCollectionItemWeight(Boolean collectionItemWeight) {
+        this.collectionItemWeight = collectionItemWeight ? Boolean.TRUE : null;
     }
 
     public boolean isColorPicker() {
@@ -714,6 +732,38 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, ObjectField field, CodeType annotation) {
             field.as(ToolUi.class).setCodeType(annotation.value());
+        }
+    }
+
+    @Documented
+    @ObjectField.AnnotationProcessorClass(CollectionItemToggleProcessor.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface CollectionItemToggle {
+        boolean value() default true;
+    }
+
+    private static class CollectionItemToggleProcessor implements ObjectField.AnnotationProcessor<CollectionItemToggle> {
+
+        @Override
+        public void process(ObjectType type, ObjectField field, CollectionItemToggle annotation) {
+            field.as(ToolUi.class).setCollectionItemToggle(annotation.value());
+        }
+    }
+
+    @Documented
+    @ObjectField.AnnotationProcessorClass(CollectionItemWeightProcessor.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface CollectionItemWeight {
+        boolean value() default true;
+    }
+
+    private static class CollectionItemWeightProcessor implements ObjectField.AnnotationProcessor<CollectionItemWeight> {
+
+        @Override
+        public void process(ObjectType type, ObjectField field, CollectionItemWeight annotation) {
+            field.as(ToolUi.class).setCollectionItemWeight(annotation.value());
         }
     }
 

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -34,6 +34,7 @@ public class ToolUi extends Modification<Object> {
 
     private Boolean bulkUpload;
     private String codeType;
+    private Boolean collectionItemProgress;
     private Boolean collectionItemToggle;
     private Boolean collectionItemWeight;
     private Boolean colorPicker;
@@ -96,6 +97,14 @@ public class ToolUi extends Modification<Object> {
 
     public void setCodeType(String codeType) {
         this.codeType = codeType;
+    }
+
+    public Boolean isCollectionItemProgress() {
+        return Boolean.TRUE.equals(collectionItemProgress);
+    }
+
+    public void setCollectionItemProgress(Boolean collectionItemProgress) {
+        this.collectionItemProgress = collectionItemProgress ? Boolean.TRUE : null;
     }
 
     public Boolean isCollectionItemToggle() {
@@ -732,6 +741,22 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, ObjectField field, CodeType annotation) {
             field.as(ToolUi.class).setCodeType(annotation.value());
+        }
+    }
+
+    @Documented
+    @ObjectField.AnnotationProcessorClass(CollectionItemProgressProcessor.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface CollectionItemProgress {
+        boolean value() default true;
+    }
+
+    private static class CollectionItemProgressProcessor implements ObjectField.AnnotationProcessor<CollectionItemProgress> {
+
+        @Override
+        public void process(ObjectType type, ObjectField field, CollectionItemProgress annotation) {
+            field.as(ToolUi.class).setCollectionItemProgress(annotation.value());
         }
     }
 

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -744,6 +744,10 @@ public class ToolUi extends Modification<Object> {
         }
     }
 
+    /**
+     * Specifies whether target field should be displayed using the progress bar and label.
+     * Expected field values are between 0.0 and 1.0.
+     */
     @Documented
     @ObjectField.AnnotationProcessorClass(CollectionItemProgressProcessor.class)
     @Retention(RetentionPolicy.RUNTIME)
@@ -760,6 +764,9 @@ public class ToolUi extends Modification<Object> {
         }
     }
 
+    /**
+     * Specifies whether the target field should be displayed using a toggle on the collection item.
+     */
     @Documented
     @ObjectField.AnnotationProcessorClass(CollectionItemToggleProcessor.class)
     @Retention(RetentionPolicy.RUNTIME)
@@ -776,6 +783,10 @@ public class ToolUi extends Modification<Object> {
         }
     }
 
+    /**
+     * Specifies whether the target field should be displayed using the weighted collection UI.
+     * Expected field values are between 0.0 and 1.0.
+     */
     @Documented
     @ObjectField.AnnotationProcessorClass(CollectionItemWeightProcessor.class)
     @Retention(RetentionPolicy.RUNTIME)

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -99,27 +99,27 @@ public class ToolUi extends Modification<Object> {
         this.codeType = codeType;
     }
 
-    public Boolean isCollectionItemProgress() {
+    public boolean isCollectionItemProgress() {
         return Boolean.TRUE.equals(collectionItemProgress);
     }
 
-    public void setCollectionItemProgress(Boolean collectionItemProgress) {
+    public void setCollectionItemProgress(boolean collectionItemProgress) {
         this.collectionItemProgress = collectionItemProgress ? Boolean.TRUE : null;
     }
 
-    public Boolean isCollectionItemToggle() {
+    public boolean isCollectionItemToggle() {
         return Boolean.TRUE.equals(collectionItemToggle);
     }
 
-    public void setCollectionItemToggle(Boolean collectionItemToggle) {
+    public void setCollectionItemToggle(boolean collectionItemToggle) {
         this.collectionItemToggle = collectionItemToggle ? Boolean.TRUE : null;
     }
 
-    public Boolean isCollectionItemWeight() {
+    public boolean isCollectionItemWeight() {
         return Boolean.TRUE.equals(collectionItemWeight);
     }
 
-    public void setCollectionItemWeight(Boolean collectionItemWeight) {
+    public void setCollectionItemWeight(boolean collectionItemWeight) {
         this.collectionItemWeight = collectionItemWeight ? Boolean.TRUE : null;
     }
 

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2751,8 +2751,10 @@ public class ToolPageContext extends WebPageContext {
                         fields.addAll(lasts);
                     }
 
-                    // Do not display fields with @ToolUi.CollectionItemWeight and @ToolUi.CollectionItemToggle
-                    fields.removeIf(f -> f.as(ToolUi.class).isCollectionItemToggle() || f.as(ToolUi.class).isCollectionItemWeight());
+                    // Do not display fields with @ToolUi.CollectionItemWeight, @ToolUi.CollectionItemToggle, or @ToolUiCollectionItemProgress
+                    fields.removeIf(f -> f.as(ToolUi.class).isCollectionItemToggle()
+                            || f.as(ToolUi.class).isCollectionItemWeight()
+                            || f.as(ToolUi.class).isCollectionItemProgress());
 
                     DependencyResolver<ObjectField> resolver = new DependencyResolver<>();
                     Map<String, ObjectField> fieldByName = fields.stream()

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2751,6 +2751,9 @@ public class ToolPageContext extends WebPageContext {
                         fields.addAll(lasts);
                     }
 
+                    // Do not display fields with @ToolUi.CollectionItemWeight and @ToolUi.CollectionItemToggle
+                    fields.removeIf(f -> f.as(ToolUi.class).isCollectionItemToggle() || f.as(ToolUi.class).isCollectionItemWeight());
+
                     DependencyResolver<ObjectField> resolver = new DependencyResolver<>();
                     Map<String, ObjectField> fieldByName = fields.stream()
                             .collect(Collectors.toMap(ObjectField::getInternalName, Function.identity()));

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -556,6 +556,7 @@ if (!isValueExternal) {
     Set<ObjectType> bulkUploadTypes = new HashSet<ObjectType>();
     Map<ObjectType, String> weightedTypesandFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> toggleTypesAndFieldsMap = new CompactMap<ObjectType, String>();
+    Map<ObjectType, String> progressTypesAndFieldsMap = new CompactMap<ObjectType, String>();
 
     for (ObjectType t : validTypes) {
         for (ObjectField f : t.getFields()) {
@@ -570,6 +571,9 @@ if (!isValueExternal) {
             }
             if (ui.isCollectionItemToggle()) {
                 toggleTypesAndFieldsMap.put(t, f.getInternalName());
+            }
+            if (ui.isCollectionItemProgress()) {
+                progressTypesAndFieldsMap.put(t, f.getInternalName());
             }
         }
     }
@@ -616,6 +620,7 @@ if (!isValueExternal) {
                 State itemState = State.getInstance(item);
                 ObjectType itemType = itemState.getType();
                 Date itemPublishDate = itemState.as(Content.ObjectModification.class).getPublishDate();
+                String progressFieldName = progressTypesAndFieldsMap.get(itemType);
                 String toggleFieldName = toggleTypesAndFieldsMap.get(itemType);
                 String weightFieldName = weightedTypesandFieldsMap.get(itemType);
 
@@ -628,10 +633,11 @@ if (!isValueExternal) {
                         // so if that field is changed the front-end knows that the thumbnail should also be updated
                         "data-preview", wp.getPreviewThumbnailUrl(item),
                         "data-preview-field", itemType.getPreviewField(),
-                        "data-toggle-field", !StringUtils.isBlank(toggleFieldName) ? toggleFieldName : "",
-                        "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : "",
-                        "data-toggle-field-value", !StringUtils.isBlank(toggleFieldName) ? ObjectUtils.to(boolean.class, itemState.get(toggleFieldName)) : "",
-                        "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? ObjectUtils.to(double.class, itemState.get(weightFieldName)) : ""
+                        "data-toggle-field", !StringUtils.isBlank(toggleFieldName) ? toggleFieldName : null,
+                        "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : null,
+                        "data-progress-field-value", !StringUtils.isBlank(progressFieldName) ? ObjectUtils.to(double.class, itemState.get(progressFieldName)) * 100 : null,
+                        "data-toggle-field-value", !StringUtils.isBlank(toggleFieldName) ? ObjectUtils.to(boolean.class, itemState.get(toggleFieldName)) : null,
+                        "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? ObjectUtils.to(double.class, itemState.get(weightFieldName)) : null
 
                         );
                     wp.writeElement("input",
@@ -674,6 +680,7 @@ if (!isValueExternal) {
 
             for (ObjectType type : validTypes) {
 
+                String progressFieldName = progressTypesAndFieldsMap.get(type);
                 String toggleFieldName = toggleTypesAndFieldsMap.get(type);
                 String weightFieldName = weightedTypesandFieldsMap.get(type);
 
@@ -685,10 +692,11 @@ if (!isValueExternal) {
                             // Add the name of the preview field so the front end knows
                             // if that field is updated it should update the thumbnail
                             "data-preview-field", type.getPreviewField(),
-                            "data-toggle-field", !StringUtils.isBlank(toggleFieldName) ? toggleFieldName : "",
-                            "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : "",
-                            "data-toggle-field-value", !StringUtils.isBlank(toggleFieldName) ? true : "",
-                            "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? "auto" : ""
+                            "data-toggle-field", !StringUtils.isBlank(toggleFieldName) ? toggleFieldName : null,
+                            "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : null,
+                            "data-progress-field-value", !StringUtils.isBlank(progressFieldName) ? 0.0 : null,
+                            "data-toggle-field-value", !StringUtils.isBlank(toggleFieldName) ? true : null,
+                            "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? "auto" : null
                     );
                         wp.writeStart("a",
                                 "href", wp.cmsUrl("/content/repeatableObject.jsp",

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -649,7 +649,9 @@ if (!isValueExternal) {
                             "name", publishDateName,
                             "value", itemPublishDate != null ? itemPublishDate.getTime() : null);
 
-                    if (!itemState.hasAnyErrors()) {
+                    if (!itemState.hasAnyErrors()
+                            && StringUtils.isBlank(toggleFieldName)
+                            && StringUtils.isBlank(weightFieldName)) {
                         wp.writeElement("input",
                                 "type", "hidden",
                                 "name", dataName,

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -635,7 +635,7 @@ if (!isValueExternal) {
                         "data-preview-field", itemType.getPreviewField(),
                         "data-toggle-field", !StringUtils.isBlank(toggleFieldName) ? toggleFieldName : null,
                         "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : null,
-                        "data-progress-field-value", !StringUtils.isBlank(progressFieldName) ? ObjectUtils.to(double.class, itemState.get(progressFieldName)) * 100 : null,
+                        "data-progress-field-value", !StringUtils.isBlank(progressFieldName) ? ObjectUtils.to(int.class, ObjectUtils.to(double.class, itemState.get(progressFieldName)) * 100) : null,
                         "data-toggle-field-value", !StringUtils.isBlank(toggleFieldName) ? ObjectUtils.to(boolean.class, itemState.get(toggleFieldName)) : null,
                         "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? ObjectUtils.to(double.class, itemState.get(weightFieldName)) : null
 

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -582,6 +582,7 @@ if (!isValueExternal) {
 
     // Only display weights if all valid types have a @ToolUi.CollectionItemWeight annotated field
     boolean displayWeights = weightedTypesandFieldsMap.size() == validTypes.size();
+    boolean displayAlternateListUi = displayWeights || toggleTypesAndFieldsMap.size() > 0 || progressTypesAndFieldsMap.size() > 0;
 
     StringBuilder genericArgumentsString = new StringBuilder();
     List<ObjectType> genericArguments = field.getGenericArguments();
@@ -598,7 +599,8 @@ if (!isValueExternal) {
     wp.writeStart("div",
             "class", "inputLarge repeatableForm"
                     + (displayGrid ? " repeatableForm-previewable" : "")
-                    + (displayWeights ? " repeatableForm-weighted" : ""),
+                    + (displayWeights ? " repeatableForm-weighted" : "")
+                    + (displayAlternateListUi ? " repeatableForm-alt" : ""),
             "foo", "bar",
             "data-generic-arguments", genericArgumentsString);
 

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -39,6 +39,7 @@ require([
   'v3/input/change',
   'input/code',
   'input/color',
+  'v3/color-utils',
   'v3/input/file',
   'input/focus',
   'input/grid',

--- a/tool-ui/src/main/webapp/script/v3/color-utils.js
+++ b/tool-ui/src/main/webapp/script/v3/color-utils.js
@@ -1,12 +1,46 @@
 define({
-  random: function() {
-    var color;
-    var fieldHue = Math.random();
+  
+  generateFromHue: function(hue) {
+    return 'hsl(' + (hue * 360) + ', 50%, 50%)';
+  },
+  
+  changeHue: function(hue) {
     var GOLDEN_RATIO = 0.618033988749895;
+    hue += GOLDEN_RATIO;
+    hue %= 1.0;
+    return hue;  
+  },
+  
+  /**
+   * Calculates the hue value for a given hex code.
+   */
+  getHue: function(hex) {
+    var r = parseInt(hex.substr(1,2), 16);
+    var g = parseInt(hex.substr(3,2), 16);
+    var b = parseInt(hex.substr(5,2), 16);
+    
+    return this.rgbToHsl(r, g, b)[0];
+  },
+  
+  // https://github.com/mjackson/mjijackson.github.com/blob/master/2008/02/rgb-to-hsl-and-rgb-to-hsv-color-model-conversion-algorithms-in-javascript.txt
+  rgbToHsl: function(r, g, b) {
+    r /= 255, g /= 255, b /= 255;
+    var max = Math.max(r, g, b), min = Math.min(r, g, b);
+    var h, s, l = (max + min) / 2;
 
-    fieldHue += GOLDEN_RATIO;
-    fieldHue %= 1.0;
-    color = 'hsl(' + (fieldHue * 360) + ', 50%, 50%)';
-    return color;
+    if(max == min){
+        h = s = 0; // achromatic
+    }else{
+        var d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch(max){
+            case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+            case g: h = (b - r) / d + 2; break;
+            case b: h = (r - g) / d + 4; break;
+        }
+        h /= 6;
+    }
+
+    return [h, s, l]; 
   }
 });

--- a/tool-ui/src/main/webapp/script/v3/color-utils.js
+++ b/tool-ui/src/main/webapp/script/v3/color-utils.js
@@ -1,0 +1,12 @@
+define({
+  random: function() {
+    var color;
+    var fieldHue = Math.random();
+    var GOLDEN_RATIO = 0.618033988749895;
+
+    fieldHue += GOLDEN_RATIO;
+    fieldHue %= 1.0;
+    color = 'hsl(' + (fieldHue * 360) + ', 50%, 50%)';
+    return color;
+  }
+});

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -671,7 +671,7 @@ The HTML within the repeatable element must conform to these standards:
                                 var newRightWeightPct = Math.round(newRightWeightDouble * 100);
                                 
                                 data.leftElement.css({
-                                    'flex': newLeftWeightDouble + '1 0%'
+                                    'flex': newLeftWeightDouble + ' 1 0%'
                                 }).data('weight', newLeftWeightDouble);
                                 
                                 data.rightElement.css({

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -691,9 +691,9 @@ The HTML within the repeatable element must conform to these standards:
                                 data.leftInput.val(newLeftWeightDouble);
                                 
                                 data.previousDelta = delta;
-
+                                
                             }, function(event) {
-                                console.log('end');
+                                // do nothing.
                             });
                         }
                     }

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -540,13 +540,23 @@ The HTML within the repeatable element must conform to these standards:
 
                 if (toggleField) {
                     // Add the remove button to the item
-                    $('<input/>', {
+                    var id = $item.find('> input[type="hidden"][name$=".id"]').val();
+                    
+                    var input = $('<input/>', {
+                        'id': id + '-toggle',
                         'class': 'repeatableLabel-toggle',
                         'type': 'checkbox',
-                        'name': $item.find('> input[type="hidden"][name$=".id"]').val() + '/' + toggleField,
+                        'name':  + '/' + toggleField,
                         'value': true,
                         'checked': toggleFieldValue
-                    }).appendTo($item);
+                    });
+                    
+                    input.after($('<label>', {
+                       'for': id + '-toggle',
+                       'class': 'repeatableLabel-toggleLabel' 
+                    }))
+                    
+                    input.appendTo($item);
                 }
 
             },
@@ -670,8 +680,8 @@ The HTML within the repeatable element must conform to these standards:
                                     return;
                                 }
                                 
-                                var newLeftWeightDouble = data.originalLeftWeight - (deltaDouble / 2);
-                                var newRightWeightDouble = data.originalRightWeight + (deltaDouble / 2);
+                                var newLeftWeightDouble = Math.max(data.originalLeftWeight - (deltaDouble / 2), 0);
+                                var newRightWeightDouble = Math.max(data.originalRightWeight + (deltaDouble / 2), 0);
                                 var newLeftWeightPct = Math.round(newLeftWeightDouble * 100);
                                 var newRightWeightPct = Math.round(newRightWeightDouble * 100);
                                 

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -429,6 +429,9 @@ The HTML within the repeatable element must conform to these standards:
                 // be shown to the user, so we hid it here
                 $item.find(':input[name$=".toggle"]').hide();
                 
+                // Add progress visual
+                self.initCollectionItemProgress($item);
+                
                 // Add toggle input for item
                 self.initCollectionItemToggle($item);
 
@@ -527,7 +530,30 @@ The HTML within the repeatable element must conform to these standards:
             },
             
             /**
-             * Conditionally nitializes the toggle button for an individual item.
+             * Conditionally initializes the progress information for an individual item.
+             *
+             * @param {Element|jquery object} item
+             * the item (LI element).
+             */
+            initCollectionItemProgress: function (item) {
+
+                var $item = $(item);
+                var progressFieldValue = $item.attr('data-progress-field-value');
+
+                if (progressFieldValue) {
+
+                    $('<div>', {
+                        'class' : 'repeatableLabel-progress'
+                    }).append($('<div>', {
+                        'class' : 'repeatableLabel-progressFill',
+                        'style' : 'width: ' + progressFieldValue + '%',
+                    })).appendTo($item);
+                }
+
+            },
+            
+            /**
+             * Conditionally initializes the toggle button for an individual item.
              *
              * @param {Element|jquery object} item
              * the item (LI element).
@@ -554,7 +580,7 @@ The HTML within the repeatable element must conform to these standards:
                     input.after($('<label>', {
                        'for': id + '-toggle',
                        'class': 'repeatableLabel-toggleLabel' 
-                    }))
+                    }));
                     
                     input.appendTo($item);
                 }

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -614,11 +614,11 @@ The HTML within the repeatable element must conform to these standards:
                             $itemWeight.css({ 'flex' :  newWeightDouble + '1 0%'});
                             $itemWeight.data('weight', newWeightDouble);
                             
-                            var $repeatableWeight = $($itemWeightContainer.next('ol').find('li').get(i)).find('.repeatableLabel-weight');
-                            $repeatableWeight.attr('data-weight', newWeightPercent + '%');
-                            $repeatableWeight.find('input').val(newWeightDouble);
+                            var $repeatableWeightDisplay = $($itemWeightContainer.next('ol').find('li').get(i)).find('.repeatableLabel-weightLabel');
+                            $repeatableWeightDisplay.attr('data-weight-label', newWeightPercent + '%');
+                            $repeatableWeightDisplay.find('input').val(newWeightDouble);
                             
-                            carryover = newWeightPercentUnrounded - newWeightPercent;
+                            carryover += newWeightPercentUnrounded - newWeightPercent;
                         });
                     }
                     
@@ -645,8 +645,8 @@ The HTML within the repeatable element must conform to these standards:
                                 data.rightListItem = $($listElements.get(data.rightIndex));
                                 data.leftListItem = $($listElements.get(data.leftIndex));
                                 
-                                data.rightLabel = data.rightListItem.find('.repeatableLabel-weight');
-                                data.leftLabel = data.leftListItem.find('.repeatableLabel-weight');
+                                data.rightLabel = data.rightListItem.find('.repeatableLabel-weightLabel');
+                                data.leftLabel = data.leftListItem.find('.repeatableLabel-weightLabel');
                                 
                                 data.rightInput = data.rightLabel.find('input');
                                 data.leftInput = data.leftLabel.find('input');
@@ -679,8 +679,8 @@ The HTML within the repeatable element must conform to these standards:
                                 }).data('weight', newRightWeightDouble);
                                 
                                 // Update input and numerical display
-                                data.rightLabel.attr('data-weight', newRightWeightPct + '%');
-                                data.leftLabel.attr('data-weight', newLeftWeightPct + '%');
+                                data.rightLabel.attr('data-weight-label', newRightWeightPct + '%');
+                                data.leftLabel.attr('data-weight-label', newLeftWeightPct + '%');
                                 
                                 data.rightInput.val(newRightWeightDouble);
                                 data.leftInput.val(newLeftWeightDouble);
@@ -696,8 +696,8 @@ The HTML within the repeatable element must conform to these standards:
 
                 // Add the remove button to the item
                 $('<div>', {
-                    'class': 'repeatableLabel-weight',
-                    'data-weight': percentageWeight + '%'
+                    'class': 'repeatableLabel-weightLabel',
+                    'data-weight-label': percentageWeight + '%'
                 }).append($('<span>', {
                     'class': 'repeatableLabel-color',
                     'style': 'background-color: ' + color

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -567,8 +567,18 @@ The HTML within the repeatable element must conform to these standards:
                 if (!$repeatableForm.hasClass('repeatableForm-weighted') || !weightFieldName) {
                     return false;
                 }
+                
+                var hue = $repeatableForm.data('lastHue');
+                
+                if (!hue) {
+                    hue = colors.getHue('#38b5dc');
+                } else {
+                    hue = colors.changeHue(hue);
+                }
+                
+                $repeatableForm.data('lastHue', hue);
+                var color = colors.generateFromHue(hue);
 
-                var color = colors.random();
                 var itemId = $item.find('> input[type="hidden"][name$=".id"]').val();
                 var inputName = itemId + '/' + weightFieldName;
                 var weightFieldValue = $item.data('weight-field-value');

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -619,6 +619,73 @@ The HTML within the repeatable element must conform to these standards:
                 var $itemWeightHandle = $(
                     '<div>', {
                         'class': 'repeatableForm-itemWeightHandle',
+                        'mousedown': function(event) {
+                            $.drag(this, event, function(event, data) {
+                                data.originX = event.clientX;
+                                data.rightElement = $(this).parent();
+                                data.leftElement = data.rightElement.prev();
+                                
+                                data.originalRightWeight = data.rightElement.data('weight');
+                                data.originalLeftWeight = data.leftElement.data('weight');
+                                
+                                data.rightIndex = data.rightElement.index();
+                                data.leftIndex = data.leftElement.index();
+                                
+                                var $listElements = data.rightElement.closest('.repeatableForm').find('ol').children();
+                                
+                                data.rightListItem = $($listElements.get(data.rightIndex));
+                                data.leftListItem = $($listElements.get(data.leftIndex));
+                                
+                                data.rightLabel = data.rightListItem.find('.repeatableLabel-weight');
+                                data.leftLabel = data.leftListItem.find('.repeatableLabel-weight');
+                                
+                                data.rightInput = data.rightLabel.find('input');
+                                data.leftInput = data.leftLabel.find('input');
+                                
+                                data.totalWidth = data.rightElement.outerWidth() + data.leftElement.outerWidth();
+
+                            }, function(event, data) {
+                                
+                                var delta = data.originX - event.clientX;
+                                var deltaDouble = Math.round((delta / data.totalWidth) * 100) / 100;
+                                var deltaPercent = deltaDouble * 100;
+                                
+                                // Only increment/decrement by full percentage point
+                                if (deltaPercent % 2 > 0) {
+                                    return;
+                                }
+                                
+                                // Avoids redundant manipulation
+                                if (delta === data.previousDelta) {
+                                    return;
+                                }
+                                
+                                var newLeftWeightDouble = data.originalLeftWeight - (deltaDouble / 2);
+                                var newRightWeightDouble = data.originalRightWeight + (deltaDouble / 2);
+                                var newLeftWeightPct = Math.round(newLeftWeightDouble * 100);
+                                var newRightWeightPct = Math.round(newRightWeightDouble * 100);
+                                
+                                data.leftElement.css({
+                                    'flex': newLeftWeightPct + '%'
+                                }).data('weight', newLeftWeightDouble);
+                                
+                                data.rightElement.css({
+                                    'flex': newRightWeightPct + '%'
+                                }).data('weight', newRightWeightDouble);
+                                
+                                // Update input and numerical display
+                                data.rightLabel.attr('data-weight', newRightWeightPct + '%');
+                                data.leftLabel.attr('data-weight', newLeftWeightPct + '%');
+                                
+                                data.rightInput.val(newRightWeightDouble);
+                                data.leftInput.val(newLeftWeightDouble);
+                                
+                                data.previousDelta = delta;
+
+                            }, function(event) {
+                                console.log('end');
+                            });
+                        }
                     }
                 );
 
@@ -629,7 +696,7 @@ The HTML within the repeatable element must conform to these standards:
                             'background-color: ' + color + ';' +
                             'flex:' + percentageWeight + '%',
                         'data-target': inputName,
-                        'data-weight': percentageWeight/100
+                        'data-weight': percentageWeight / 100
                     }).prepend(itemWeightsCount > 0 ? $itemWeightHandle : '')
                 );
 
@@ -1788,3 +1855,6 @@ The HTML within the repeatable element must conform to these standards:
     }); // END require
 
 }(jQuery, window));
+
+// Set filename for debugging tools to allow breakpoints even when using a cachebuster
+//# sourceURL=jquery.repeatable.js

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -546,7 +546,7 @@ The HTML within the repeatable element must conform to these standards:
                         'id': id + '-toggle',
                         'class': 'repeatableLabel-toggle',
                         'type': 'checkbox',
-                        'name':  + '/' + toggleField,
+                        'name':  id + '/' + toggleField,
                         'value': true,
                         'checked': toggleFieldValue
                     });

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -545,9 +545,16 @@ The HTML within the repeatable element must conform to these standards:
                     $('<div>', {
                         'class' : 'repeatableLabel-progress'
                     }).append($('<div>', {
-                        'class' : 'repeatableLabel-progressFill',
-                        'style' : 'width: ' + progressFieldValue + '%',
+                            'class': 'repeatableLabel-progressBar'
+                        }).append($('<div>', {
+                            'class': 'repeatableLabel-progressFill',
+                            'style': 'width: ' + progressFieldValue + '%'
+                        })
+                    )).prepend($('<div>', {
+                        'class': 'repeatableLabel-progressLabel',
+                        'text': progressFieldValue + '% of Target'
                     })).appendTo($item);
+
                 }
 
             },

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -981,14 +981,14 @@
     }
   }
 
-  .repeatableLabel-weight {
+  .repeatableLabel-weightLabel {
     position: absolute;
     top: 12px;
     left: 48px;
     z-index: 1;
     
     &:after {
-      content: attr(data-weight);
+      content: attr(data-weight-label);
       font-weight: bold;
       top: 2px;
       position: absolute;

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -960,6 +960,8 @@
     height: 50px;
     margin-bottom: 10px;
     display: flex;
+    max-width: 100%;
+    overflow: hidden;
     
     &:empty {
       display: none;

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -1047,4 +1047,44 @@
   position: absolute;
   top: 12px;
   right: 42px;
+  
+  display: none;
+  
+  + .repeatableLabel-toggleLabel {
+    position: absolute;
+    top: 8px;
+    right: 42px;
+      
+    outline: 0;
+    display: block;
+    width: 4em;
+    height: 2em;
+    cursor: pointer;
+    user-select: none;
+    background: @color-border;
+    border-radius: 2em;
+    padding: 2px;
+    transition: all .4s ease;
+     
+    &:after {
+      content: "";  
+      left: 0;
+      border-radius: 50%;
+      background: #fff;
+      transition: all .2s ease;
+      width: 22px;
+      height: 22px;
+      display: block;
+    }
+  }
+  
+  &:checked {
+    + .repeatableLabel-toggleLabel {
+      background: @color-publish;
+      
+      &:after {
+        margin-left: 26px;   
+      }
+    }
+  }
 }

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -962,13 +962,13 @@
   }    
 }
 
-.repeatableForm-weighted {
+.repeatableForm-alt {
 
   > ol > li {
     > .repeatableLabel {
       background: white;
       border-bottom: 1px solid #ededed;
-      padding: 12px 45px 12px 120px;
+      padding: 12px 45px 12px 45px;
       &:after {
         top: 12px;
       }
@@ -976,7 +976,16 @@
     > .removeButton {
       top: 10px;
     }  
-  }  
+  }   
+}
+
+.repeatableForm-weighted {
+
+  > ol > li {
+    > .repeatableLabel {
+      padding-left: 120px;
+    }
+  }
     
   .repeatableForm-itemWeights {
     width: 100%;

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -938,3 +938,113 @@
     top: -15px;
   }
 }
+
+.repeatableForm-weighted {
+
+  > ol > li {
+    > .repeatableLabel {
+      background: white;
+      border-bottom: 1px solid #ededed;
+      padding: 12px 45px 12px 120px;
+      &:after {
+        top: 12px;
+      }
+    }
+    > .removeButton {
+      top: 10px;
+    }  
+  }  
+    
+  .repeatableForm-itemWeights {
+    width: 100%;
+    height: 50px;
+    margin-bottom: 10px;
+    display: flex;
+    
+    &:empty {
+      display: none;
+    }
+  }
+  
+  .repeatableForm-itemWeight {
+    height: 100%;
+    position: relative;
+    
+    &:after {
+        content: ' ';
+        height: 100%;
+        display:inline-block;
+        background:white;
+        width: 1px;
+    }
+  }
+
+  .repeatableLabel-weight {
+    position: absolute;
+    top: 12px;
+    left: 48px;
+    z-index: 1;
+    
+    &:after {
+      content: attr(data-weight);
+      font-weight: bold;
+      top: 2px;
+      position: absolute;
+      margin-left: 10px;
+    }
+  }
+  
+  .repeatableForm-itemWeightHandle {
+    position: absolute;
+    left: -7px;
+    z-index: 2;
+    bottom: 0px;
+    top: 0px;
+    width: 14px;
+    height: 20px;
+    margin: auto;
+    background: white;
+    padding: 1px;
+    cursor: col-resize;
+    
+    &:before, &:after {
+      color: @color-border;
+      display:inline-block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+    
+    &:before {
+      content: '|';
+      width: 14px;
+      text-align: center;
+    }
+    &:after {
+      width: 16px; 
+      content: '||';
+    }
+  }
+
+  .repeatableLabel-color {
+    display: inline-block;
+    height: 20px;
+    width: 20px;
+  }
+  
+  .repeatableLabel-weightInput {
+    display: inline-block;
+    float: right;
+    margin-left: 8px;
+    font-weight: bold;
+  }
+    
+}
+
+.repeatableLabel-toggle {
+  position: absolute;
+  top: 12px;
+  right: 42px;
+}

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -939,6 +939,20 @@
   }
 }
 
+.repeatableLabel-progress {
+  position: absolute;
+  height: 4px;
+  width: 180px;
+  background: @color-border;
+  top: 18px;
+  right: 175px;
+
+  .repeatableLabel-progressFill {
+    background: @color-focus;
+    height: 100%;
+  }
+}
+
 .repeatableForm-weighted {
 
   > ol > li {

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -940,17 +940,26 @@
 }
 
 .repeatableLabel-progress {
-  position: absolute;
-  height: 4px;
-  width: 180px;
-  background: @color-border;
-  top: 18px;
-  right: 175px;
-
-  .repeatableLabel-progressFill {
-    background: @color-focus;
-    height: 100%;
+    
+    position: absolute;
+    top: 10px;
+    right: 175px;
+    
+  .repeatableLabel-progressLabel {
+      display: block;
+      text-align: center;
   }
+    
+  .repeatableLabel-progressBar {
+    height: 4px;
+    width: 180px;
+    background: @color-border;
+
+    .repeatableLabel-progressFill {
+      background: @color-focus;
+      height: 100%;
+    }
+  }    
 }
 
 .repeatableForm-weighted {


### PR DESCRIPTION
Adds new field annotations to be used for displaying an embedded List.

`@ToolUi.CollectionItemToggle`
* Hides actual field
* Only allows one per type
* Adds toggle switch to the right of `.repeatableLabel`

`@ToolUi.CollectionItemProgress`
* Hides actual field
* Only allows one per type
* Adds progress bar visual to the right side of `.repeatableLabel`
* Expected field values are between 0.0 and 1.0

`@ToolUi.CollectionItemWeight`
* Hides actual field
* Adds weight indicator to the left side of `.repeatableLabel`
* Expected field values are between 0.0 and 1.0
* If all valid types of items in the List have a field with this annotation, a colored bar will be visible allowing users to change "weights" by dragging the colored columns.

![image](https://cloud.githubusercontent.com/assets/1299507/13304469/ccc28e02-db22-11e5-94b3-2cf89e741dcc.png)