### PR TITLE
Improves UI performance by optimizing DOM selectors passed to bsp_utils.onDomInsert 

### DIFF
--- a/tool-ui/src/main/webapp/script/content/lock.js
+++ b/tool-ui/src/main/webapp/script/content/lock.js
@@ -4,7 +4,11 @@ define([
 
 function($, bsp_utils) {
   $(window).load(function() {
-    bsp_utils.onDomInsert(document, '.contentLock[data-content-locked-out = "true"] :input', {
+    bsp_utils.onDomInsert(document,
+        '.contentLock[data-content-locked-out="true"] input, '
+        + '.contentLock[data-content-locked-out="true"] select, '
+        + '.contentLock[data-content-locked-out="true"] textarea, '
+        + '.contentLock[data-content-locked-out="true"] button', {
       'insert': function (input) {
         $(input).trigger('input-disable', [ true ]);
       }

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -108,7 +108,7 @@ function() {
     'restoreButtonText': ''
   });
 
-  bsp_autoExpand.live(document, ':text.expandable, textarea');
+  bsp_autoExpand.live(document, 'input[type="text"].expandable, input:not([type]).expandable, textarea');
   bsp_autoSubmit.live(document, '.autoSubmit');
 
   $doc.calendar('live', ':text.date');

--- a/tool-ui/src/main/webapp/script/v3/content/state.js
+++ b/tool-ui/src/main/webapp/script/v3/content/state.js
@@ -43,10 +43,10 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
         var questionAt = action.indexOf('?');
         var end = +new Date() + 1000;
         var $dynamicTexts = $form.find(
-            '[data-dynamic-text][data-dynamic-text != ""],' +
-            '[data-dynamic-html][data-dynamic-html != ""],' +
-            '[data-dynamic-placeholder][data-dynamic-placeholder != ""],' +
-            '[data-dynamic-predicate][data-dynamic-predicate != ""]');
+            '[data-dynamic-text]:not([data-dynamic-text=""]),' +
+            '[data-dynamic-html]:not([data-dynamic-html=""]),' +
+            '[data-dynamic-placeholder]:not([data-dynamic-placeholder=""]),' +
+            '[data-dynamic-predicate]:not([data-dynamic-predicate=""])');
 
         $dynamicTexts = $dynamicTexts.filter(function() {
           return $(this).closest('.collapsed').length === 0
@@ -54,7 +54,7 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
         });
 
         if (!idle) {
-          $form.find('[data-dynamic-predicate][data-dynamic-predicate != ""]').each(function () {
+          $form.find('[data-dynamic-predicate]:not([data-dynamic-predicate = ""])').each(function () {
             $(this).removeClass('state-loaded');
           });
         }

--- a/tool-ui/src/main/webapp/script/v3/input/read-only.js
+++ b/tool-ui/src/main/webapp/script/v3/input/read-only.js
@@ -1,5 +1,5 @@
 define([ 'bsp-utils' ], function (bsp_utils) {
-  bsp_utils.onDomInsert(document, '.inputContainer-readOnly :text, .inputContainer-readOnly textarea', {
+  bsp_utils.onDomInsert(document, '.inputContainer-readOnly input[type="text"], .inputContainer-readonly textarea, .inputContainer-readOnly input:not([type])', {
     'insert': function (input) {
       input.readOnly = true;
     }


### PR DESCRIPTION
Replaces usage of implicit universal selection through pseudo-selectors with optimized selector expressions toward remedy of BSP-1655.  The CPU consumption numbers below are specific to a single application of Brightspot, but the relative performance gains are applicable to all.

After optimization of selectors passed to bsp_utils.onDomInsert, CPU consumption by the redoAllDomInserts JavaScript method decreased from 33% to 12% when typing a single character into a RichText field.

<img width="1440" alt="screen shot 2016-02-28 at 1 18 34 am" src="https://cloud.githubusercontent.com/assets/400882/13377817/e2f86b12-ddb9-11e5-8ba9-df7de4e159fe.png">

<img width="1435" alt="screen shot 2016-02-28 at 1 21 20 am" src="https://cloud.githubusercontent.com/assets/400882/13377818/e7626bf8-ddb9-11e5-9214-b51583f16baa.png">

CPU consumption by redoAllDomInserts during sustained typing into a RichText field also decreased by half (from 80% to 40%).

<img width="1436" alt="screen shot 2016-02-28 at 1 26 02 am" src="https://cloud.githubusercontent.com/assets/400882/13377827/7a8f3bf4-ddba-11e5-9cc2-92913b5e94f9.png">

<img width="1438" alt="screen shot 2016-02-28 at 1 24 10 am" src="https://cloud.githubusercontent.com/assets/400882/13377828/7e76bed6-ddba-11e5-8b79-2b14a9094684.png">

This PR also includes optimization of selectors used to update dynamic placeholders and predicates upon AJAX response from the /contentState servlet.