### PR TITLE
Improves UI performance through replacement of jQuery.filter + callback usage in state.js during ContentState servlet response handling.

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/content/state.js
+++ b/tool-ui/src/main/webapp/script/v3/content/state.js
@@ -67,9 +67,7 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
 
           // If we are looking at a content update, then the current state (for viewing the diff) resides in the form
           // as well. We need to remove that from the form post or it messes up the dynamic values that return.
-          'data': $form.find('[name]').filter(function() {
-            return $(this).closest('.contentDiffCurrent').length === 0;
-          }).serialize() + $dynamicTexts.map(function() {
+          'data': $form.find('[name]').not($form.find('.contentDiffCurrent [name]')).serialize() + $dynamicTexts.map(function() {
             var $element = $(this);
 
             return '&_dti=' + ($element.closest('[data-object-id]').attr('data-object-id') || '') +


### PR DESCRIPTION
Replaces usage jQuery.filter + callback with jQuery.not and two selectors toward remedy of BSP-1655. The CPU consumption numbers below are specific to a single application of Brightspot, but the relative performance gains are applicable to all.

The ContentState servlet is polled on change of any input element on the edit page.  Prior to the polling, all input elements' values are assembled, except those determined to be within a content-diff container.  The jQuery filter for determining which elements to include uses a callback method.

Prior to optimization of the input selection refinement, this element selection in state.js used over 33% CPU when adding a single Dashboard Column on the Users & Roles -> ToolRole edit screen.

<img width="1128" alt="screen shot 2016-02-28 at 4 20 15 pm" src="https://cloud.githubusercontent.com/assets/400882/13381996/3e6fd6d2-de38-11e5-92b3-6c720b2c0d5c.png">

After replacement of the filter callback with usage of jQuery.not, CPU usage dropped to less than 5%:

<img width="1131" alt="screen shot 2016-02-28 at 4 18 15 pm" src="https://cloud.githubusercontent.com/assets/400882/13382003/57630dc6-de38-11e5-9954-736536ddd1ee.png">
