### PR TITLE
Revert "BSP-1655: Updates bsp-utils to 2.0.3 to pick up performance optimization."

### DIFF
--- a/tool-ui/bower.json
+++ b/tool-ui/bower.json
@@ -3,7 +3,7 @@
     "atmosphere": "Atmosphere/atmosphere-javascript#javascript-project-2.2.11",
     "bsp-autoexpand": "1.0.2",
     "bsp-autosubmit": "1.0.0",
-    "bsp-utils": "2.0.3",
+    "bsp-utils": "2.0.2",
     "codemirror": "5.10.0",
     "css-element-queries": "4250c87c5ab2efd467f99d901252c73eb6bb80ea",
     "d3": "3.4.6",


### PR DESCRIPTION
Reverts perfectsense/brightspot-cms#569 for now while we look at some of the corner cases that doesn't work.