### PR TITLE
RTE after inline enhancement popup closes, set focus back to editor (BSP-1487)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2790,7 +2790,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // but first wait for the current click to finish so it doesn't interfere
             // with any popups
             setTimeout(function(){
+                
                 $divLink.click();
+
+                // When the popup is closed put focus back on the editor
+                $(document).one('closed', '[name=rte2-frame-enhancement-inline]', function(){
+                        self.focus();
+                });
+
             }, 100);
 
         },


### PR DESCRIPTION
After user edits inline enhancement in poup form, put focus back on the editor.