### PR TITLE
RTE hide dropdown when editor not focused or read-only (BSP-1673, BSP-1592)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2601,7 +2601,7 @@ define([
             var marks, self;
             self = this;
 
-            if (! self.codeMirror.hasFocus()) {
+            if (self.readOnlyGet() || !self.codeMirror.hasFocus()) {
                 self.dropdownHide();
                 return;
             }

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2584,6 +2584,15 @@ define([
             editor.on('cursorActivity', $.debounce(250, function(instance, event) {
                 self.dropdownCheckCursor();
             }));
+
+            editor.on('focus', function() {
+                self.dropdownCheckCursor();
+            });
+            
+            editor.on('blur', function() {
+                self.dropdownHide();
+            });
+
         },
 
 
@@ -2592,9 +2601,14 @@ define([
             var marks, self;
             self = this;
 
+            if (! self.codeMirror.hasFocus()) {
+                self.dropdownHide();
+                return;
+            }
+            
             // Get all the marks from the selected range that have onclick handlers
             marks = self.dropdownGetMarks();
-            
+
             if (marks.length === 0) {
                 self.dropdownHide();
             } else {


### PR DESCRIPTION
For inline enhancements that show a dropdown when the cursor is over the mark, the dropdown is appearing on page load, or when the editor loses focus. This commit hides the dropdown when the editor loses focus. (BSP-1673)

Also hides the dropdown when in read-only mode (to prevent user from clearing or editing the mark) (BSP-1592)