### PR TITLE
Improves UI performance by ignoring mutations on CodeMirror elements.

### DIFF
--- a/tool-ui/bower.json
+++ b/tool-ui/bower.json
@@ -3,7 +3,7 @@
     "atmosphere": "Atmosphere/atmosphere-javascript#javascript-project-2.2.11",
     "bsp-autoexpand": "1.0.2",
     "bsp-autosubmit": "1.0.0",
-    "bsp-utils": "2.0.2",
+    "bsp-utils": "2.0.4",
     "codemirror": "5.10.0",
     "css-element-queries": "4250c87c5ab2efd467f99d901252c73eb6bb80ea",
     "d3": "3.4.6",

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -123,6 +123,12 @@ function() {
     'loadedClassName': 'loaded'
   });
 
+  bsp_utils.onDomInsert(document, '.CodeMirror', {
+    'insert': function(cm) {
+      bsp_utils.addDomInsertBlacklist(cm);
+    }
+  });
+
   bsp_utils.onDomInsert(document, '[data-bsp-autosubmit], .autoSubmit', {
     'insert': function(item) {
       var $form = $(item).closest('form');


### PR DESCRIPTION
**DO NOT MERGE UNTIL** 

1) https://github.com/perfectsense/brightspot-js-utils/tree/feature/filter-mutations-take-2 has been merged and tagged, and

2) the Brightspot dependency for bsp_utils has been updated in this branch, consistent with 1)

This PR uses bsp_utils.onDomInsert to add all elements with class "CodeMirror" to the blacklist for mutation observation.  During RTE interaction, a large number of DOM mutations are triggered by CodeMirror, causing repeated calls to _redoAllDomInserts_.  By ignoring mutations inside CodeMirror's structures, the throughput to _redoAllDomInserts_ is greatly reduced.

Before addition of CodeMirror elements to the domInsert blacklist, _redoAllDomInserts_ accounts for almost 40% of all CPU consumption during sustained typing into the RTE.

<img width="1439" alt="screen shot 2016-03-01 at 1 44 56 am" src="https://cloud.githubusercontent.com/assets/400882/13420054/e2efd400-df50-11e5-9ff2-cb1f7475cf49.png">

Once the CodeMirror elements are used to filter out mutation events, _redoAllDomInserts_ accounts for just over 1% of all CPU consumption during sustained typing into the RTE.

<img width="1438" alt="screen shot 2016-03-01 at 1 45 36 am" src="https://cloud.githubusercontent.com/assets/400882/13420086/1cf7c23e-df51-11e5-83b1-696fb5095e0c.png">
