### PR TITLE
RTE bugfix dropdown click after blur (BSP-1673 revisited)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2590,7 +2590,11 @@ define([
             });
             
             editor.on('blur', function() {
-                self.dropdownHide();
+                // Hide after a timeout in case user clicked link in the dropdown
+                // which caused a blur event that hid the dropdown
+                setTimeout(function(){
+                    self.dropdownHide();
+                }, 200);
             });
 
         },
@@ -4143,6 +4147,9 @@ define([
             var self;
             self = this;
             self.codeMirror.focus();
+            setTimeout(function(){
+                self.dropdownCheckCursor();
+            }, 200);
         },
 
 


### PR DESCRIPTION
Previous changes to hide the dropdown on blur caused a problem because clicking on the dropdown link (Edit/Clear) actually blurred the editor, which hid the dropdown, which prevented the click from being successful. This commit adds a timeout after the blur before hiding the dropdown, to give the click event time to register.