### PR TITLE
Enables environment-specific login cookie name

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/AuthenticationFilter.java
+++ b/db/src/main/java/com/psddev/cms/tool/AuthenticationFilter.java
@@ -120,6 +120,22 @@ public class AuthenticationFilter extends AbstractFilter {
      */
     public static final class Static {
 
+        private static String getEnvironmentName() {
+            return Settings.getOrDefault(String.class, "cms/tool/environmentName", "");
+        }
+
+        private static String getToolUserCookieName() {
+            return TOOL_USER_COOKIE + getEnvironmentName();
+        }
+
+        private static String getInsecureToolUserCookieName() {
+            return INSECURE_TOOL_USER_COOKIE + getEnvironmentName();
+        }
+
+        private static String getPreviewCookieName() {
+            return PREVIEW_COOKIE + getEnvironmentName();
+        }
+
         private static void setSignedCookie(
                 HttpServletRequest request,
                 HttpServletResponse response,
@@ -178,8 +194,8 @@ public class AuthenticationFilter extends AbstractFilter {
                 logIn(request, response, user);
 
             } else {
-                setSignedCookie(request, response, TOOL_USER_COOKIE, token, -1, true);
-                setSignedCookie(request, response, INSECURE_TOOL_USER_COOKIE, token, -1, false);
+                setSignedCookie(request, response, getToolUserCookieName(), token, -1, true);
+                setSignedCookie(request, response, getInsecureToolUserCookieName(), token, -1, false);
                 request.setAttribute(USER_ATTRIBUTE, user);
                 request.setAttribute(USER_TOKEN, token);
                 request.setAttribute(USER_CHECKED_ATTRIBUTE, Boolean.TRUE);
@@ -228,8 +244,8 @@ public class AuthenticationFilter extends AbstractFilter {
                 }
             }
 
-            setSignedCookie(request, response, TOOL_USER_COOKIE, token, -1, true);
-            setSignedCookie(request, response, INSECURE_TOOL_USER_COOKIE, token, -1, false);
+            setSignedCookie(request, response, getToolUserCookieName(), token, -1, true);
+            setSignedCookie(request, response, getInsecureToolUserCookieName(), token, -1, false);
             request.setAttribute(USER_ATTRIBUTE, user);
             request.setAttribute(USER_TOKEN, token);
             request.setAttribute(USER_CHECKED_ATTRIBUTE, Boolean.TRUE);
@@ -251,8 +267,8 @@ public class AuthenticationFilter extends AbstractFilter {
                 }
             }
 
-            setSignedCookie(request, response, TOOL_USER_COOKIE, "", 0, true);
-            setSignedCookie(request, response, INSECURE_TOOL_USER_COOKIE, "", 0, false);
+            setSignedCookie(request, response, getToolUserCookieName(), "", 0, true);
+            setSignedCookie(request, response, getInsecureToolUserCookieName(), "", 0, false);
         }
 
         /**
@@ -405,7 +421,7 @@ public class AuthenticationFilter extends AbstractFilter {
         public static ToolUser getUser(HttpServletRequest request) {
             return getToolUserByCookieName(
                     request,
-                    TOOL_USER_COOKIE,
+                    getToolUserCookieName(),
                     TOOL_USER_ATTRIBUTE,
                     TOOL_USER_CHECKED_ATTRIBUTE);
         }
@@ -419,7 +435,7 @@ public class AuthenticationFilter extends AbstractFilter {
         public static ToolUser getInsecureToolUser(HttpServletRequest request) {
             return getToolUserByCookieName(
                     request,
-                    INSECURE_TOOL_USER_COOKIE,
+                    getInsecureToolUserCookieName(),
                     INSECURE_TOOL_USER_ATTRIBUTE,
                     INSECURE_TOOL_USER_CHECKED_ATTRIBUTE);
         }
@@ -431,15 +447,16 @@ public class AuthenticationFilter extends AbstractFilter {
                 preview = (Preview) request.getAttribute(PREVIEW_ATTRIBUTE);
 
             } else {
-                String cookieValue = JspUtils.getSignedCookie(request, PREVIEW_COOKIE);
+                String previewCookie = getPreviewCookieName();
+                String cookieValue = JspUtils.getSignedCookie(request, previewCookie);
 
-                if (cookieValue == null || cookieValue.length() < PREVIEW_COOKIE.length()) {
+                if (cookieValue == null || cookieValue.length() < previewCookie.length()) {
                     preview = null;
 
                 } else {
                     preview = Query
                             .from(Preview.class)
-                            .where("_id = ?", ObjectUtils.to(UUID.class, cookieValue.substring(PREVIEW_COOKIE.length())))
+                            .where("_id = ?", ObjectUtils.to(UUID.class, cookieValue.substring(previewCookie.length())))
                             .first();
 
                     request.setAttribute(PREVIEW_ATTRIBUTE, preview);
@@ -452,13 +469,13 @@ public class AuthenticationFilter extends AbstractFilter {
         }
 
         public static void setCurrentPreview(HttpServletRequest request, HttpServletResponse response, Preview preview) {
-            setSignedCookie(request, response, PREVIEW_COOKIE, preview.getId().toString(), -1, true);
+            setSignedCookie(request, response, getPreviewCookieName(), preview.getId().toString(), -1, true);
             request.setAttribute(PREVIEW_ATTRIBUTE, preview);
             request.setAttribute(PREVIEW_CHECKED_ATTRIBUTE, Boolean.TRUE);
         }
 
         public static void removeCurrentPreview(HttpServletRequest request, HttpServletResponse response) {
-            setSignedCookie(request, response, PREVIEW_COOKIE, "", 0, true);
+            setSignedCookie(request, response, getPreviewCookieName(), "", 0, true);
             request.removeAttribute(PREVIEW_ATTRIBUTE);
             request.removeAttribute(PREVIEW_CHECKED_ATTRIBUTE);
         }


### PR DESCRIPTION
Which allows simultaneous logins on separate environments without having cookies conflict.

Currently, if two environments are on the same domain or same top-level domain but have separate databases (for example, www-dev.example.com vs www.example.com), then the generated login cookies conflict, and you must use incognito or separate browsers to log into both environments at the same time.  This tweaks the cookies so that you can set an environmentName setting that will also be included in the cookie key, preventing the cookies of separate environments from conflicting.

If the setting is not specified, then cookies will act identically to how they do now.