### PR TITLE
Directory - adds decodeUri to normalizePath (BSP-539)

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/Directory.java
+++ b/db/src/main/java/com/psddev/cms/db/Directory.java
@@ -53,6 +53,11 @@ public class Directory extends Record {
         }
         path = "/" + path + "/";
         path = StringUtils.replaceAll(path, "/(?:/+|\\./)", "/");
+        try {
+            path = StringUtils.decodeUri(path);
+        } catch (IllegalArgumentException exception) {
+            //ignore, user might be typing a "%20" and an exception will be thrown as they type "%"
+        }
         return path;
     }
 


### PR DESCRIPTION
To match the decoded path that is provided by request.getServletPath.

This will fix Directory findByPath with paths that have URL encoded characters like %20's. "/foo%bar" would get saved as "/foo bar" and match the decoded "http://foo%20bar" on a request. Note existing content with "%20" paths would need to be re-published