### PR TITLE
Bugfix/rte does not indicate changes (BSP-1497)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/change.js
+++ b/tool-ui/src/main/webapp/script/v3/input/change.js
@@ -30,8 +30,8 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
   $(document).on('change', '.inputContainer', function() {
     var $container = $(this);
     var changed = false;
-
-    $container.find('input, textarea').each(function() {
+      
+    $container.find('input[name], textarea[name]').each(function() {
       if (this.defaultValue !== this.value) {
         changed = true;
         return false;

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3403,28 +3403,28 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self = this;
 
             self.$container.on('rteChange', $.debounce(2000, function(){
-                if ($('.contentPreview').is(':visible')) {
-                    self.previewUpdate();
-                }
+                self.previewUpdate();
             }));
         },
 
         
         /**
          * Update the textarea with the latest content from the rich text editor,
-         * plus trigger an "input" event so the preview will be updated.
+         * plus trigger an "input" event so the preview will be updated, and
+         * a "change" event so the change indicator can be updated.
          */
         previewUpdate: function() {
             
-            var html, self;
+            var html, self, val;
             
             self = this;
 
             html = self.toHTML();
+
+            val = self.$el.val();
             
-            if (html !== self.previewUpdateSaved) {
-                self.previewUpdateSaved = html;
-                self.$el.val(html).trigger('input');
+            if (html !== val) {
+                self.$el.val(html).trigger('input').trigger('change');
             }
         },
 


### PR DESCRIPTION
Changes to the RTE were not always updating the original textarea, and were not triggering a "change" event to indicate the field had changed.

This commit periodically updates the textarea (even if the preview window is not showing), and when doing so triggers a change event so the colored change indicator shows up for the input. For performance reasons, we debounce this aggressively to limit how often we need to export the editor content into HTML (only updates after user has stopped typing for 2 sec).

Note this includes a change to the base change.js code used for all inputs:

The "change" event handler looks for form inputs and textareas to determine if changes have been made; however, CodeMirror adds a few inputs and textareas to do its job, and these cause problems because it always appears that they have changed. This commit modifies the change event handler so it only looks for inputs and textareas that have a "name" attribute (and thus are submitted when the form is posted), so it will ignore the CodeMirror inputs.