### PR TITLE
Settings option to disable ajax save

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/CmsTool.java
+++ b/db/src/main/java/com/psddev/cms/tool/CmsTool.java
@@ -115,6 +115,9 @@ public class CmsTool extends Tool {
     @ToolUi.Tab("Debug")
     private boolean disableAutomaticallySavingDrafts;
 
+    @ToolUi.Tab("Debug")
+    private boolean disableAjaxSaves;
+
     @ToolUi.Tab("UI")
     private boolean enableFrontEndUploader;
 
@@ -629,6 +632,14 @@ public class CmsTool extends Tool {
 
     public void setDisableAutomaticallySavingDrafts(boolean disableAutomaticallySavingDrafts) {
         this.disableAutomaticallySavingDrafts = disableAutomaticallySavingDrafts;
+    }
+
+    public boolean isDisableAjaxSaves() {
+        return disableAjaxSaves;
+    }
+
+    public void setDisableAjaxSaves(boolean disableAjaxSaves) {
+        this.disableAjaxSaves = disableAjaxSaves;
     }
 
     public boolean isEnableFrontEndUploader() {

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2166,6 +2166,7 @@ public class ToolPageContext extends WebPageContext {
             write("var ENABLE_PADDED_CROPS = ", getCmsTool().isEnablePaddedCrop(), ';');
             write("var DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR = ", getCmsTool().isDisableCodeMirrorRichTextEditor(), ';');
             write("var DISABLE_RTC = ", getCmsTool().isDisableRtc(), ';');
+            write("var DISABLE_AJAX_SAVES = ", getCmsTool().isDisableAjaxSaves(), ';');
         writeEnd();
 
         writeStart("script", "type", "text/javascript", "src", "//www.google.com/jsapi");

--- a/tool-ui/src/main/webapp/script/v3/content/publish.js
+++ b/tool-ui/src/main/webapp/script/v3/content/publish.js
@@ -47,7 +47,7 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
           }
         });
 
-        if ($draftButton.closest('.message').length > 0) {
+        if ($draftButton.closest('.message').length > 0 && !window.DISABLE_AJAX_SAVES) {
           var saving = false;
           var toolMessageTimeout;
 


### PR DESCRIPTION
Ajax save is causing some problems and confusion for our users. This commit allows us to disable this feature, causing saves to lead to a full page reload like the previous behavior.