### PR TITLE
Ability to disable code mirror for an individual user

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/ToolUser.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUser.java
@@ -142,8 +142,7 @@ public class ToolUser extends Record implements ToolEntity {
     private boolean disableNavigateAwayAlert;
 
     @ToolUi.Tab("Advanced")
-    @DisplayName("Disable Code Mirror Rich Text Editor?")
-    private boolean disableCodeMirrorEditor;
+    private boolean disableCodeMirrorRichTextEditor;
 
     @ToolUi.Note("Force the user to change the password on next log in.")
     private boolean changePasswordOnLogIn;
@@ -808,12 +807,12 @@ public class ToolUser extends Record implements ToolEntity {
         this.disableNavigateAwayAlert = disableNavigateAwayAlert;
     }
 
-    public boolean isDisableCodeMirrorEditor() {
-        return disableCodeMirrorEditor;
+    public boolean isDisableCodeMirrorRichTextEditor() {
+        return disableCodeMirrorRichTextEditor;
     }
 
-    public void setDisableCodeMirrorEditor(boolean disableCodeMirrorEditor) {
-        this.disableCodeMirrorEditor = disableCodeMirrorEditor;
+    public void setDisableCodeMirrorRichTextEditor(boolean disableCodeMirrorRichTextEditor) {
+        this.disableCodeMirrorRichTextEditor = disableCodeMirrorRichTextEditor;
     }
 
     public boolean isChangePasswordOnLogIn() {

--- a/db/src/main/java/com/psddev/cms/db/ToolUser.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUser.java
@@ -141,6 +141,9 @@ public class ToolUser extends Record implements ToolEntity {
     @ToolUi.Tab("Advanced")
     private boolean disableNavigateAwayAlert;
 
+    @ToolUi.Tab("Advanced")
+    private boolean disableCodeMirrorEditor;
+
     @ToolUi.Note("Force the user to change the password on next log in.")
     private boolean changePasswordOnLogIn;
 
@@ -802,6 +805,14 @@ public class ToolUser extends Record implements ToolEntity {
      */
     public void setDisableNavigateAwayAlert(boolean disableNavigateAwayAlert) {
         this.disableNavigateAwayAlert = disableNavigateAwayAlert;
+    }
+
+    public boolean isDisableCodeMirrorEditor() {
+        return disableCodeMirrorEditor;
+    }
+
+    public void setDisableCodeMirrorEditor(boolean disableCodeMirrorEditor) {
+        this.disableCodeMirrorEditor = disableCodeMirrorEditor;
     }
 
     public boolean isChangePasswordOnLogIn() {

--- a/db/src/main/java/com/psddev/cms/db/ToolUser.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUser.java
@@ -142,6 +142,7 @@ public class ToolUser extends Record implements ToolEntity {
     private boolean disableNavigateAwayAlert;
 
     @ToolUi.Tab("Advanced")
+    @DisplayName("Disable Code Mirror Rich Text Editor?")
     private boolean disableCodeMirrorEditor;
 
     @ToolUi.Note("Force the user to change the password on next log in.")

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2166,7 +2166,7 @@ public class ToolPageContext extends WebPageContext {
             write("var ENABLE_PADDED_CROPS = ", getCmsTool().isEnablePaddedCrop(), ';');
             write("var DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR = ",
                     getCmsTool().isDisableCodeMirrorRichTextEditor()
-                            || (getUser() != null && getUser().isDisableCodeMirrorEditor()), ';');
+                            || (getUser() != null && getUser().isDisableCodeMirrorRichTextEditor()), ';');
             write("var DISABLE_RTC = ", getCmsTool().isDisableRtc(), ';');
         writeEnd();
 

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2165,7 +2165,8 @@ public class ToolPageContext extends WebPageContext {
             write("var RICH_TEXT_ELEMENTS = ", ObjectUtils.toJson(richTextElements), ';');
             write("var ENABLE_PADDED_CROPS = ", getCmsTool().isEnablePaddedCrop(), ';');
             write("var DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR = ",
-                    getCmsTool().isDisableCodeMirrorRichTextEditor() || getUser().isDisableCodeMirrorEditor(), ';');
+                    getCmsTool().isDisableCodeMirrorRichTextEditor()
+                            || (getUser() != null && getUser().isDisableCodeMirrorEditor()), ';');
             write("var DISABLE_RTC = ", getCmsTool().isDisableRtc(), ';');
         writeEnd();
 

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2164,7 +2164,8 @@ public class ToolPageContext extends WebPageContext {
             write("var COMMON_TIMES = ", ObjectUtils.toJson(commonTimes), ';');
             write("var RICH_TEXT_ELEMENTS = ", ObjectUtils.toJson(richTextElements), ';');
             write("var ENABLE_PADDED_CROPS = ", getCmsTool().isEnablePaddedCrop(), ';');
-            write("var DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR = ", getCmsTool().isDisableCodeMirrorRichTextEditor(), ';');
+            write("var DISABLE_CODE_MIRROR_RICH_TEXT_EDITOR = ",
+                    getCmsTool().isDisableCodeMirrorRichTextEditor() || getUser().isDisableCodeMirrorEditor(), ';');
             write("var DISABLE_RTC = ", getCmsTool().isDisableRtc(), ';');
         writeEnd();
 


### PR DESCRIPTION
Some of our users want to be able to use the new, updated Code Mirror RTE, but others find the old RTE easier for some features.  This allows users to choose which one they want to use or even switch between the two.