### PR TITLE
RTE bugfix for change indicator when readonly (BSP-1716)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -632,8 +632,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Set up a submit event on the form to copy the value back into the textarea
             if (self.doOnSubmit) {
 
-                self.$el.closest('form').on('submit', function(){
-                    if (self.rte.modeGet() === 'rich') {
+                self.$el.closest('form').on('submit', function(){p
+                    if (self.rte.modeGet() === 'rich' && !self.rte.readOnlyGet()) {
                         self.trackChangesSave();
                         self.$el.val(self.toHTML());
                     }
@@ -3439,6 +3439,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             var html, self, val;
             
             self = this;
+
+            // Do not update if we are in read only mode
+            if (self.rte.readOnlyGet()) {
+                return;
+            }
 
             html = self.toHTML();
 


### PR DESCRIPTION
When the RTE is in readonly mode, the change indicator was sometimes appearing (in cases where the parsed HTML gets modified during parsing). This commit adds some code to ensure that the textarea is never updated when the editor is in readonly mode, to prevent parse changes from being submitted and changing the value of the texteara.