### PR TITLE
Improves error messaging when a template cannot be found.

### DIFF
--- a/db/src/main/java/com/psddev/cms/view/UrlViewTemplateLoader.java
+++ b/db/src/main/java/com/psddev/cms/view/UrlViewTemplateLoader.java
@@ -21,7 +21,7 @@ public abstract class UrlViewTemplateLoader implements ViewTemplateLoader {
      * Returns the template located at the named path as a URL.
      *
      * @param path the path to the template.
-     * @return the template URL.
+     * @return the template URL. Never {@code null}.
      * @throws IOException if a problem occurred fetching the URL for the given path.
      */
     protected abstract URL getTemplateUrl(String path) throws IOException;

--- a/db/src/main/java/com/psddev/cms/view/ViewTemplateLoader.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewTemplateLoader.java
@@ -13,7 +13,7 @@ public interface ViewTemplateLoader {
      * {@link java.io.InputStream} object.
      *
      * @param path the path to the template.
-     * @return the template as a stream.
+     * @return the template as a stream. Never {@code null}.
      * @throws IOException if a problem occurred fetching the template at the given path.
      */
     InputStream getTemplate(String path) throws IOException;

--- a/db/src/main/java/com/psddev/cms/view/servlet/ServletViewTemplateLoader.java
+++ b/db/src/main/java/com/psddev/cms/view/servlet/ServletViewTemplateLoader.java
@@ -1,7 +1,7 @@
 package com.psddev.cms.view.servlet;
 
+import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import javax.servlet.ServletContext;
@@ -14,6 +14,8 @@ import com.psddev.dari.util.CodeUtils;
  */
 public class ServletViewTemplateLoader extends UrlViewTemplateLoader {
 
+    private static final String TEMPLATE_NOT_FOUND_MESSAGE_FORMAT = "Could not find template at path [%s]!";
+
     private ServletContext servletContext;
 
     /**
@@ -24,12 +26,20 @@ public class ServletViewTemplateLoader extends UrlViewTemplateLoader {
     }
 
     @Override
-    public InputStream getTemplate(String path) {
-        return CodeUtils.getResourceAsStream(servletContext, path);
+    public InputStream getTemplate(String path) throws IOException{
+        InputStream template = CodeUtils.getResourceAsStream(servletContext, path);
+        if (template == null) {
+            throw new IOException(String.format(TEMPLATE_NOT_FOUND_MESSAGE_FORMAT, path));
+        }
+        return template;
     }
 
     @Override
-    protected URL getTemplateUrl(String path) throws MalformedURLException {
-        return CodeUtils.getResource(servletContext, path);
+    protected URL getTemplateUrl(String path) throws IOException {
+        URL templateUrl = CodeUtils.getResource(servletContext, path);
+        if (templateUrl == null) {
+            throw new IOException(String.format(TEMPLATE_NOT_FOUND_MESSAGE_FORMAT, path));
+        }
+        return templateUrl;
     }
 }


### PR DESCRIPTION
The original implementation could return null. Modified the API documentation to clarify that null should never be returned.