### PR TITLE
RTE bugfix onsubmit not firing (BSP-1735)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -652,7 +652,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Set up a submit event on the form to copy the value back into the textarea
             if (self.doOnSubmit) {
 
-                self.$el.closest('form').on('submit', function(){p
+                self.$el.closest('form').on('submit', function(){
                     if (self.rte.modeGet() === 'rich' && !self.rte.readOnlyGet()) {
                         self.trackChangesSave();
                         self.$el.val(self.toHTML());

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2920,6 +2920,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 $(document).one('closed', '[name=' + frameName + ']', function(){
                     self.focus();
                     $div.remove();
+                    self.rte.triggerChange();
                 });
 
             }, 100);


### PR DESCRIPTION
Fixes a typo in the onsubmit handler that caused an error and prevented the RTE from updating the content.

Also adds a change event when the RichTextElement popup is closed, to ensure that the preview is updated (among other things).