### PR TITLE
RTE bugfix toggle inline style across lines (BSP-1646)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -893,7 +893,7 @@ define([
          */
         inlineRemoveStyle: function(styleKey, range, options) {
 
-            var className, deleteText, editor, lineNumber, self, from, to;
+            var className, deleteText, editor, lineNumber, self, from, to, triggerChange;
 
             self = this;
 
@@ -1126,22 +1126,25 @@ define([
 
                         editor.replaceRange('', position.from, position.to, '+brightspotFormatRemoveClass');
                         
-                        // Trigger a change event for the editor
-                        if (options.triggerChange !== false) {
-                            self.triggerChange();
-                        }
+                        // Trigger a change event for the editor later
+                        triggerChange = true;
                     }
                 }
                 if (mark.shouldRemove) {
                     
                     mark.clear();
                     
-                    // Trigger a change event for the editor
-                    if (options.triggerChange !== false) {
-                        self.triggerChange();
-                    }
+                    // Trigger a change event for the editor later
+                    triggerChange = true;
                 }
             });
+
+            // We hold off on triggering a change event until the end because
+            // it seems to cause problems if we trigger a change in the middle
+            // of examining all the marks
+            if (triggerChange && options.triggerChange !== false) {
+                self.triggerChange();
+            }
 
             // Trigger a cursor activity event so the toolbar can update
             CodeMirror.signal(editor, "cursorActivity");


### PR DESCRIPTION
When toggling an inline style with a range that goes across multiple lines, the style is being removed on the first line, but not on the other lines. I traced this to a side effect of triggering a change event for each line that is changed, which for some reason modified the other marks. I modified the code until a change event will not be triggered until all the lines are processed, and this seems to make the problem go away.