### PR TITLE
Repeatable Collection Item Weight/Toggle Improvements

### DIFF
--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -698,7 +698,7 @@ if (!isValueExternal) {
                             "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : null,
                             "data-progress-field-value", !StringUtils.isBlank(progressFieldName) ? 0.0 : null,
                             "data-toggle-field-value", !StringUtils.isBlank(toggleFieldName) ? true : null,
-                            "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? "auto" : null
+                            "data-weight-field-value", !StringUtils.isBlank(weightFieldName) ? "" : null
                     );
                         wp.writeStart("a",
                                 "href", wp.cmsUrl("/content/repeatableObject.jsp",

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -612,7 +612,7 @@ The HTML within the repeatable element must conform to these standards:
 
             },
 
-           /**
+            /**
              * Conditionally initializes the weighting display for an individual item.
              *
              * @param {Element|jquery object} item
@@ -631,8 +631,15 @@ The HTML within the repeatable element must conform to these standards:
                 if (!$repeatableForm.hasClass('repeatableForm-weighted') || !weightFieldName) {
                     return false;
                 }
-
-                // TODO: setup click event for .removeButton to toggle off item
+                
+                $item.on('click', '.removeButton', function() {
+                    var $this = $(this);
+                    if ($this.closest('li').hasClass('toBeRemoved')) {
+                        self.removeCollectionItemWeight($item);
+                    } else {
+                        self.addCollectionItemWeight($item);
+                    }
+                });
 
                 self.addCollectionItemWeight($item);
             },
@@ -849,8 +856,8 @@ The HTML within the repeatable element must conform to these standards:
 
                                 var newLeftWeightDouble = Math.max(data.originalLeftWeight - (deltaDouble), 0);
                                 var newRightWeightDouble = data.totalWeightDouble - newLeftWeightDouble;
-                                var newLeftWeightPct = Math.round(newLeftWeightDouble * 100);
-                                var newRightWeightPct = Math.round(newRightWeightDouble * 100);
+                                var newLeftWeightPct = Math.max(Math.round(newLeftWeightDouble * 100), 0);
+                                var newRightWeightPct = Math.max(Math.round(newRightWeightDouble * 100), 0);
 
                                 data.leftElement.css({
                                     'flex': newLeftWeightDouble + ' 1 0%'

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -681,7 +681,7 @@ The HTML within the repeatable element must conform to these standards:
                 }
                 
                 // Only add weight and handle if toggle is true or not available
-                if ($item.attr('data-toggle-field-value') !== 'true') {
+                if ($item.attr('data-toggle-field-value') === 'false') {
                     return;
                 }
 
@@ -693,7 +693,7 @@ The HTML within the repeatable element must conform to these standards:
                 });
 
                 var itemIndex = $item.parent()
-                                     .children('[data-toggle-field-value="true"]:not(.toBeRemoved)')
+                                     .children(':not([data-toggle-field-value="false"], .toBeRemoved)')
                                      .index($item);
 
                 var $itemWeightContainer = $item.closest('.repeatableForm').find('.repeatableForm-itemWeights');
@@ -888,7 +888,7 @@ The HTML within the repeatable element must conform to these standards:
                                 data.rightIndex = data.rightElement.index();
                                 data.leftIndex = data.leftElement.index();
                                 
-                                var $listElements = self.dom.$list.children('[data-toggle-field-value="true"]:not(.toBeRemoved)');
+                                var $listElements = self.dom.$list.children(':not([data-toggle-field-value="false"], .toBeRemoved)');
 
                                 data.rightLabel = $($listElements.get(data.rightIndex)).find('.repeatableLabel-weightLabel');
                                 data.leftLabel = $($listElements.get(data.leftIndex)).find('.repeatableLabel-weightLabel');

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -631,6 +631,11 @@ The HTML within the repeatable element must conform to these standards:
                 if (!$repeatableForm.hasClass('repeatableForm-weighted') || !weightFieldName) {
                     return false;
                 }
+
+                // Add weight reset button if not already added
+                if ($repeatableForm.find('> .repeatableForm-weightResetButton').size() <= 0) {
+                    self.initCollectionItemWeightResetButton();
+                }
                 
                 $item.on('click', '.removeButton', function() {
                     var $this = $(this);
@@ -689,7 +694,7 @@ The HTML within the repeatable element must conform to these standards:
                         $itemWeightContainer.children().eq(itemIndex - 1).after($itemWeightColumn);
                     }
 
-                    self.recalculateWeights($item);
+                    self.fixCollectionItemWeights($item);
                 }
             },
 
@@ -708,25 +713,57 @@ The HTML within the repeatable element must conform to these standards:
 
                 $itemWeightsContainer.find('.repeatableForm-itemWeight[data-target="' + $itemWeightInputName + '"]').remove();
 
-                var $itemWeights = $itemWeightsContainer.find('.repeatableForm-itemWeight');
+                //var $itemWeights = $itemWeightsContainer.find('.repeatableForm-itemWeight');
+                self.fixCollectionItemWeights(item);
 
-                var totalRemainingPercent = 0;
-                $itemWeights.each(function(i) {
-                    var $itemWeight = $(this);
-                    totalRemainingPercent += parseFloat($itemWeight.attr('data-weight'));
+                //var totalRemainingPercent = 0;
+                //$itemWeights.each(function(i) {
+                //    var $itemWeight = $(this);
+                //    totalRemainingPercent += parseFloat($itemWeight.attr('data-weight'));
+                //});
+                //
+                //$itemWeights.each(function(i) {
+                //   var $itemWeight = $(this);
+                //   var newDouble = parseFloat($itemWeight.attr('data-weight')) / totalRemainingPercent;
+                //   self.updateCollectionItemWeightData($itemWeight, Math.round(newDouble * 100));
+                //});
+            },
+
+            initCollectionItemWeightResetButton: function () {
+                var self = this;
+                self.dom.$list.parent().prepend(
+                  $('<a>', {
+                      'class': 'repeatableForm-weightResetButton',
+                      'text': 'Reset Weights to Default'
+                  }).on('click', function () {
+                      self.resetCollectionItemWeights();
+                  })
+                );
+            },
+
+            resetCollectionItemWeights: function () {
+
+                var self = this;
+                var $itemWeights = self.dom.$list.parent().find('.repeatableForm-itemWeight');
+                var itemWeightsCount = $itemWeights.size();
+
+                if (itemWeightsCount <= 0) {
+                    return false;
+                }
+
+                var weight = Math.floor(100 / itemWeightsCount);
+
+                $itemWeights.each(function () {
+                    self.updateCollectionItemWeightData(this, weight);
                 });
 
-                $itemWeights.each(function(i) {
-                   var $itemWeight = $(this);
-                   var newDouble = parseFloat($itemWeight.attr('data-weight')) / totalRemainingPercent;
-                   self.updateItemWeightData($itemWeight, Math.round(newDouble * 100));
-                });
+                //self.fixCollectionItemWeights(self.dom.$list.find('li').first());
             },
 
             /**
-             * Recalculates collection item weights.
+             * Prevents rounding errors and sum of weights from exceeding 100%.
              */
-            recalculateWeights: function(item) {
+            fixCollectionItemWeights: function(item) {
 
                 var self = this;
                 var $item = $(item);
@@ -765,11 +802,11 @@ The HTML within the repeatable element must conform to these standards:
                     //     }
                     // }
 
-                    self.updateItemWeightData($itemWeight, newWeightPercent);
+                    self.updateCollectionItemWeightData($itemWeight, newWeightPercent);
                 });
             },
 
-            updateItemWeightData: function(itemWeight, percent) {
+            updateCollectionItemWeightData: function(itemWeight, percent) {
 
                 var $itemWeight = $(itemWeight);
                 var $repeatableForm = $itemWeight.closest('.repeatableForm');

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -893,6 +893,17 @@ The HTML within the repeatable element must conform to these standards:
 
                                 var newLeftWeightDouble = Math.max(data.originalLeftWeight - (deltaDouble), 0);
                                 var newRightWeightDouble = data.totalWeightDouble - newLeftWeightDouble;
+
+                                if (newLeftWeightDouble < 0) {
+                                    newLeftWeightDouble = 0;
+                                    newRightWeightDouble = data.totalWeightDouble;
+                                }
+
+                                if (newRightWeightDouble < 0) {
+                                    newRightWeightDouble = 0;
+                                    newLeftWeightDouble = data.totalWeightDouble;
+                                }
+                                
                                 var newLeftWeightPct = Math.max(Math.round(newLeftWeightDouble * 100), 0);
                                 var newRightWeightPct = Math.max(Math.round(newRightWeightDouble * 100), 0);
 

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1178,7 +1178,7 @@ The HTML within the repeatable element must conform to these standards:
             },
 
           /**
-           * Shortcut function to tell if the mode is 'preview'
+           * Shortcut function to tell if the mode is 'weighted'
            * @returns {Boolean}
            */
           modeIsWeighted: function() {

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -658,30 +658,26 @@ The HTML within the repeatable element must conform to these standards:
                 var $item = $(item);
                 var color = self.getCollectionItemWeightColor($item);
                 var inputName = $item.find('> input[type="hidden"][name$=".id"]').val() + '/' + $item.data("weight-field");
-                var $itemWeightContainer = $item.closest('.repeatableForm').find('.repeatableForm-itemWeights');
                 var $repeatableWeightLabel = $item.find('> .repeatableLabel-weightLabel');
                 
                 var weightFieldValue;
                 if ($repeatableWeightLabel.size() === 0) {
-
-                    // Add hidden input and label for item weight
                     weightFieldValue = $item.attr('data-weight-field-value');
-                    
+
                     $('<div>', {
                         'class': 'repeatableLabel-weightLabel'
                     }).append($('<span>', {
                         'class': 'repeatableLabel-color',
                         'style': 'background-color: ' + color
                     })).append(
-                        $('<input>', {
-                            'type': 'hidden',
-                            'name': inputName,
-                            'value': weightFieldValue
-                        })
+                      $('<input>', {
+                          'type': 'hidden',
+                          'name': inputName,
+                          'value': weightFieldValue
+                      })
                     ).prependTo($item);
-                    
                 } else {
-                    weightFieldValue = $repeatableWeightLabel.find('input').val();
+                    weightFieldValue = $item.find('> .repeatableLabel-weightLabel').find('input').val();
                 }
                 
                 // Only add weight and handle if toggle is true or not available
@@ -700,6 +696,7 @@ The HTML within the repeatable element must conform to these standards:
                                      .children('[data-toggle-field-value="true"]:not(.toBeRemoved)')
                                      .index($item);
 
+                var $itemWeightContainer = $item.closest('.repeatableForm').find('.repeatableForm-itemWeights');
                 if (itemIndex === 0) {
                     $itemWeightContainer.prepend($itemWeight);
                 } else {
@@ -710,30 +707,28 @@ The HTML within the repeatable element must conform to these standards:
 
                 var itemWeightDoubleValue = $itemWeight.attr('data-weight');
                 
-                var newWeightDouble;
-                var newWeightPercent;
-                
                 // If item has no data-weight attr, it is a new item,
                 // and should scale other weights against `baseWeight`
                 
-                if (self.isInitialized == true || !itemWeightDoubleValue) {
-
+                if (self.isInitialized === true || !itemWeightDoubleValue) {
+                    
+                    var newWeightDouble;
+                    
                     if (!itemWeightDoubleValue) {
-                        // base weight which is proportional to the # of items
-                        var baseWeight = Math.round((1 / ($itemWeightContainer.children().size())) * 100) / 100;
-                        newWeightPercent = Math.floor(baseWeight * 100);    
+                        // new items are added with a weight proportional to the number of items
+                        newWeightDouble = Math.round((1 / ($itemWeightContainer.children().size())) * 100) / 100;
                     } else {
-                        // if item has a value, use it
-                        newWeightPercent = Math.round(parseFloat(itemWeightDoubleValue) * 100);
+                        // if item exists, use existing weight
+                        newWeightDouble = parseFloat(itemWeightDoubleValue);
                     }
                     
-                    var modifier = 1 - (newWeightPercent / 100);
+                    var modifier = 1 - newWeightDouble;
 
                     $($itemWeightContainer.children().not($itemWeight)).each(function () {
                         self.updateCollectionItemWeightData($(this), Math.floor(modifier * $(this).attr('data-weight') * 100));
                     });
 
-                    self.updateCollectionItemWeightData($itemWeight, newWeightPercent);
+                    self.updateCollectionItemWeightData($itemWeight, (newWeightDouble * 100).toFixed());
                     self.fixCollectionItemWeights();
                 } else {
                     self.updateCollectionItemWeightData($itemWeight, (itemWeightDoubleValue * 100).toFixed());

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -985,20 +985,26 @@
     > .repeatableLabel {
       padding-left: 120px;
     }
-    
-    &[data-toggle-field-value="false"] {
-        > .repeatableLabel {
-            background: @color-heading;
-        }
-        
-        .repeatableLabel-color {
-            visibility: hidden;
-        }
-        
-        .repeatableLabel-weightLabel:after {
-            content: "-%";
-            min-width: 18px;
-        }
+
+    &[data-toggle-field-value="false"], &.toBeRemoved {
+      > .repeatableLabel {
+        background: @color-heading;
+      }
+
+      .repeatableLabel-color {
+        visibility: hidden;
+      }
+
+      .repeatableLabel-weightLabel:after {
+        content: "-%";
+        min-width: 18px;
+      }
+    }
+
+    &.toBeRemoved {
+      .repeatableLabel-toggleLabel, .repeatableLabel-progress {
+        display: none;
+      }
     }
   }
     

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -975,15 +975,6 @@
     }
     > .removeButton {
       top: 10px;
-    }  
-  }   
-}
-
-.repeatableForm-weighted {
-
-  > ol > li {
-    > .repeatableLabel {
-      padding-left: 120px;
     }
 
     &[data-toggle-field-value="false"], &.toBeRemoved {
@@ -1005,6 +996,15 @@
       .repeatableLabel-toggleLabel, .repeatableLabel-progress {
         display: none;
       }
+    }
+  }   
+}
+
+.repeatableForm-weighted {
+
+  > ol > li {
+    > .repeatableLabel {
+      padding-left: 120px;
     }
   }
     

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -967,7 +967,7 @@
   > ol > li {
     > .repeatableLabel {
       background: white;
-      border-bottom: 1px solid #ededed;
+      border-bottom: 1px solid @color-border;
       padding: 12px 45px 12px 45px;
       &:after {
         top: 12px;
@@ -984,6 +984,21 @@
   > ol > li {
     > .repeatableLabel {
       padding-left: 120px;
+    }
+    
+    &[data-toggle-field-value="false"] {
+        > .repeatableLabel {
+            background: @color-heading;
+        }
+        
+        .repeatableLabel-color {
+            visibility: hidden;
+        }
+        
+        .repeatableLabel-weightLabel:after {
+            content: "-%";
+            min-width: 18px;
+        }
     }
   }
     
@@ -1010,6 +1025,10 @@
         display:inline-block;
         background:white;
         width: 1px;
+    }
+    
+    &:first-child .repeatableForm-itemWeightHandle {
+        display: none;
     }
   }
 
@@ -1066,13 +1085,6 @@
     display: inline-block;
     height: 20px;
     width: 20px;
-  }
-  
-  .repeatableLabel-weightInput {
-    display: inline-block;
-    float: right;
-    margin-left: 8px;
-    font-weight: bold;
   }
     
 }

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -1005,6 +1005,7 @@
   > ol > li {
     > .repeatableLabel {
       padding-left: 120px;
+      padding-right: 368px;
     }
   }
     

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -977,7 +977,7 @@
       top: 10px;
     }
     
-    &[data-progress-field-value] .repeatableLabel {
+    &[data-progress-field-value] > .repeatableLabel {
       padding-right: 368px;
     }
 

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -1140,3 +1140,11 @@
     }
   }
 }
+
+.repeatableForm-weightResetButton {
+  position: absolute;
+  top: -20px;
+  right: 0;
+  .icon();
+  .icon-refresh();
+}

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -968,7 +968,7 @@
     > .repeatableLabel {
       background: white;
       border-bottom: 1px solid @color-border;
-      padding: 12px 45px 12px 45px;
+      padding: 12px 368px 12px 45px;
       &:after {
         top: 12px;
       }
@@ -1005,7 +1005,6 @@
   > ol > li {
     > .repeatableLabel {
       padding-left: 120px;
-      padding-right: 368px;
     }
   }
     

--- a/tool-ui/src/main/webapp/style/v3/repeatable.less
+++ b/tool-ui/src/main/webapp/style/v3/repeatable.less
@@ -968,13 +968,17 @@
     > .repeatableLabel {
       background: white;
       border-bottom: 1px solid @color-border;
-      padding: 12px 368px 12px 45px;
+      padding: 12px 120px 12px 45px;
       &:after {
         top: 12px;
       }
     }
     > .removeButton {
       top: 10px;
+    }
+    
+    &[data-progress-field-value] .repeatableLabel {
+      padding-right: 368px;
     }
 
     &[data-toggle-field-value="false"], &.toBeRemoved {


### PR DESCRIPTION
Two major improvements for handling ToolUi.CollectionItemToggle and ToolUi.CollectionItemWeight:
 
### Adds a "Reset Weights" Button#

![image](https://cloud.githubusercontent.com/assets/1299507/13614565/288941f6-e53f-11e5-84bd-954be9e47a61.png)

### Recalculates weights when toggled/removed

Improves interaction between toggling items with `@ToolUi.CollectionItemToggle` and `@ToolUi.CollectionItemWeight`

Toggling off or removing an item from the collection will now remove the weight color and recalibrate the remaining weights.

![image](https://cloud.githubusercontent.com/assets/1299507/13614518/f4353a90-e53e-11e5-855b-5c1b47b3323f.png)
