### PR TITLE
RTE bugfix toolbar submenu cutting off on right (BSP-1737)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -58,6 +58,11 @@
       
       li {
         display:block;
+
+        a {
+          // Prevent submenu from shrinking and cutting off text when on right side
+          white-space: nowrap;
+        }
       }
     }
 


### PR DESCRIPTION
When the RTE toolbar submenu is displayed on the right side it is sometimes not wide enough and the links are cut off. This appears to be caused by the text wrapping due to spaces in the toolbar links. The wrapped text is hidden by overflow:hidden, so you never see it.

This commit fixes the problem by preventing the text from wrapping, and therefore the submenu stretches fully to show all the text.