### PR TITLE
RTE msword paste double lines (BSP-1741)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -235,11 +235,22 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             
             'p[style*="text-align:right"]': 'alignRight',
             'p[style*="text-align:center"]': 'alignCenter',
+
+            // MSWord 'p' elements should be treated as a new line
+            // Special case if 'p' element contains only whitespace remove the whitespace
+            'p[class^=Mso]': function($el) {
+                var $replacement, t;
+                t = $el.text() || '';
+                if (t.match(/^\s*$/)) {
+                    $el.text('');
+                }
+                $replacement = $('<span>', {'data-rte2-sanitize': 'linebreakSingle'});
+                $replacement.append( $el.contents() );
+                $el.replaceWith( $replacement );
+            },
             
-            // Any 'p' element should be treated as a new line
-            // Note: we also add an extra <br> element after the <p> elements.
+            // Any 'p' element should be treated as a new line with a blank line after
             'p': 'linebreak'
-            
         },
 
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -174,7 +174,12 @@ define([
 
             linebreak: {
                 line:true
+            },
+
+            linebreakSingle:{
+                line:true
             }
+            
         }, // styles
 
         
@@ -3691,12 +3696,21 @@ define([
             if (self.clipboardSanitizeRules) {
                 $.each(self.clipboardSanitizeRules, function(selector, style) {
                     $el.find(selector).each(function(){
-                        var $match = $(this);
-                        var $replacement = $('<span>', {'data-rte2-sanitize': style});
-                        $replacement.append( $match.contents() );
-                        $match.replaceWith( $replacement );
+                        var $match, $replacement;
+
+                        $match = $(this);
+                        
+                        if ($.isFunction(style)) {
+                            style($match);
+                        } else {
+                            $replacement = $('<span>', {'data-rte2-sanitize': style});
+                            $replacement.append( $match.contents() );
+                            $match.replaceWith( $replacement );
+                        }
                     });
                 });
+
+                // Anything we replaced with "linebreak" should get an extra blank line after
                 $el.find('[data-rte2-sanitize=linebreak]').after('<br/>');
             }
 


### PR DESCRIPTION
When pasting content from MSWord, double lines were appearing between paragraphs.

This commit adds some new functionality to the clipboardSanitize rules, so you can specify a selector plus a function to perform additional checks and modifications on the incoming HTML.

For MSWord paragraphs, changed them to output single line instead of a line followed by a blank line (since MSWord outputs complete paragraph for the blank line after a paragraph). Also added a check to see if the blank line contains only whitespace, to avoid adding extra space (since MSWord puts a non-breaking-space in the blank line after each paragraph).