### PR TITLE
Option to disable CodeMirror search dialog

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/CmsTool.java
+++ b/db/src/main/java/com/psddev/cms/tool/CmsTool.java
@@ -127,6 +127,9 @@ public class CmsTool extends Tool {
     @ToolUi.Tab("RTE")
     private boolean enableAnnotations;
 
+    @ToolUi.Tab("RTE")
+    private boolean disableCodeMirrorSearchDialog;
+
     @ToolUi.Tab("UI")
     private boolean disableContentLocking;
 
@@ -661,6 +664,14 @@ public class CmsTool extends Tool {
 
     public void setEnableAnnotations(boolean enableAnnotations) {
         this.enableAnnotations = enableAnnotations;
+    }
+
+    public boolean isDisableCodeMirrorSearchDialog() {
+        return disableCodeMirrorSearchDialog;
+    }
+
+    public void setDisableCodeMirrorSearchDialog(boolean disableCodeMirrorSearchDialog) {
+        this.disableCodeMirrorSearchDialog = disableCodeMirrorSearchDialog;
     }
 
     public boolean isDisableContentLocking() {

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2160,6 +2160,7 @@ public class ToolPageContext extends WebPageContext {
             write("var STANDARD_IMAGE_SIZES = ", ObjectUtils.toJson(standardImageSizes), ";");
             write("var RTE_LEGACY_HTML = ", getCmsTool().isLegacyHtml(), ';');
             write("var RTE_ENABLE_ANNOTATIONS = ", getCmsTool().isEnableAnnotations(), ';');
+            write("var RTE_DISABLE_CODE_MIRROR_SEARCH = ", getCmsTool().isDisableCodeMirrorSearchDialog(), ';');
             write("var DISABLE_TOOL_CHECKS = ", getCmsTool().isDisableToolChecks(), ';');
             write("var COMMON_TIMES = ", ObjectUtils.toJson(commonTimes), ';');
             write("var RICH_TEXT_ELEMENTS = ", ObjectUtils.toJson(richTextElements), ';');

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4595,6 +4595,12 @@ define([
                 }
             });
 
+            //Cmd/Ctrl-F will bubble up to the browser as normal if this RTE option is checked in CmsTool
+            if (window.RTE_DISABLE_CODE_MIRROR_SEARCH) {
+                keymap['Cmd-F'] = false;
+                keymap['Ctrl-F'] = false;
+            }
+
             return keymap;
         },
 


### PR DESCRIPTION
Cmd/Ctrl-F will bubble up to the browser instead.

Our users prefer the native browser search for now, so this adds an option to disable the CodeMirror search addon.