### PR TITLE
RTE table, row, and cell attribute popup forms (BSP-1488)

### DIFF
--- a/tool-ui/bower.json
+++ b/tool-ui/bower.json
@@ -7,7 +7,7 @@
     "codemirror": "5.10.0",
     "css-element-queries": "4250c87c5ab2efd467f99d901252c73eb6bb80ea",
     "d3": "3.4.6",
-    "handsontable": "0.21.0",
+    "handsontable": "0.23.0",
     "husl": "4.0.0",
     "jquery": "1.8.3+1",
     "jsdiff": "2.0.2",

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3447,8 +3447,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 data = {
                     tagName:'table',
                     childNodes:[
-                        { tagName: 'td', childNodes: [''] },
-                        { tagName: 'td', childNodes: [''] }
+                        {
+                            tagName: 'tr',
+                            childNodes: [
+                                { tagName: 'td', childNodes: [''] },
+                                { tagName: 'td', childNodes: [''] }
+                            ]
+                        }
                     ]
                 };
                 return data;

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1059,20 +1059,21 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             $.each(RICH_TEXT_ELEMENTS, function (index, rtElement) {
 
-                // Always skip table elements, because those are used
-                // only to specify context and attributes, but should not
-                // appear in the toolbar
-                if (rtElement.tag === 'table') {
-                    return;
-                }
-                
                 // For this instance of the RTE, was there a custom list
                 // of elements that should be displayed in the toolbar?
                 if (tags && tags.indexOf(rtElement.tag) < 0) {
+                    
                     // Skip this element if it is not listed in the allowed elements
                     return;
                 }
 
+                // Always skip TR and TD elements, because those are used
+                // only to specify context and attributes, but should not
+                // appear in the toolbar
+                if (rtElement.tag === 'tr' || rtElement.tag === 'td') {
+                    return;
+                }
+                
                 var styleName = rtElement.styleName;
                 var submenuName = rtElement.submenu;
                 var submenu;
@@ -1084,6 +1085,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     text: rtElement.displayName,
                     tooltip: rtElement.tooltipText
                 };
+
+                // Special case - the table element is treated as a toolbar action instead of a style
+                if (rtElement.tag === 'table') {
+                    toolbarButton.action = 'table';
+                }
 
                 if (submenuName) {
                     submenu = submenus[submenuName];

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -485,6 +485,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.linkInit();
             self.enhancementInit();
             self.inlineEnhancementInit();
+            self.tableInit();
             self.trackChangesInit();
             self.placeholderInit();
             self.modeInit();
@@ -1522,28 +1523,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     // Special case for the "Table" button, we will look for a style
                     // definition for the "table" element, to see if it has any
                     // context specified
-                    if (config.action === 'table') {
-
-                        // See if we previously saved the table style config
-                        // so we don't do it repeatedly for performance reasons
-                        if (self.tableStyle) {
-                            // We saved it earlier so use it again
-                            styleObj = self.tableStyle;
-                        } else {
-
-                            styleObj = {};
-                            
-                            // Go through all the style definitions and see if one is for the "table" element
-                            $.each(self.styles, function(styleKey, styleObj2) {
-                                if (styleObj2.element === 'table') {
-                                    styleObj = styleObj2;
-                                    return false;
-                                }
-                            });
-
-                            // Cache this style for later so we don't have to find it again
-                            self.tableStyle = styleObj;
-                        }
+                    if (config.action === 'table' && self.tableStyleTable) {
+                        styleObj = self.tableStyleTable;
                     }
 
                     if (styleObj.context) {
@@ -3023,6 +3004,38 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         /*==================================================
          * Tables
          *==================================================*/
+
+
+        /**
+         * Initialize some data used to create tables.
+         */
+        tableInit: function() {
+
+            var self;
+
+            self = this;
+
+            // Go through all the style definitions and see if one is for the "table" element
+            $.each(self.styles, function(styleKey, styleObj) {
+
+                switch (styleObj.element) {
+
+                case 'table':
+                    self.tableStyleTable = styleObj;
+                    break;
+                    
+                case 'tr':
+                    self.tableStyleRow = styleObj;
+                    break;
+                
+                case 'td':
+                case 'th':
+                    self.tableStyleCell = styleObj;
+                    break;
+                }
+                
+            });
+        },
 
 
         /**


### PR DESCRIPTION
This pull request gives the ability for the backend to create RichText element forms to edit the attributes of table, tr, and td elements. These elements should set the attributes only, as we do not support them setting the body (innerHTML) of the elements at this time.

After creating a RichText element with tag of table, tr, or td, within the RTE if you click on a table cell the following menu items will appear in the dropdown: Edit Table Attributes, Edit Row Attributes, Edit Cell Attributes. Selecting one of these menu items should pop up the form for that inline enhancement.

An update to the "handsontable" plugin was also required to get a bugfix.

As a side effect of adding support for table/tr/td attributes, now when the RTE imports HTML, if those elements have existing attributes, they will be maintained when loading and saving from the RTE. This can be seen by switching the RTE to "HTML mode" then manually adding the table/tr/td attributes, then switching back and forth from "HTML mode" to "Rich text mode", to verify the attributes are maintained. This also required a small change to the "clipboard sanitize rules", so when pasting HTML from an outside source we strip the table attributes so we don't end up with a bunch of junk attributes in the pasted content.