### PR TITLE
RTE table add clear cells dropdown option (BSP-1709)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3137,6 +3137,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 col_right: {},
                 remove_row: {},
                 remove_col: {},
+                clear_cell: {name: 'Clear cells'},
                 undo: {},
                 redo: {}
             });
@@ -3161,6 +3162,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                             break;
                         case 'attrCell':
                             self.tableEditAttrCell($placeholder);
+                            break;
+                        case 'clear_cell':
+                            self.tableClearSelection($placeholder);
                             break;
                         }
                     },
@@ -3716,6 +3720,35 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                  }
 
             });
+        },
+
+
+        /**
+         * Clear the cell that is currently selected.
+         * @param {Element|jQuery} el
+         * The placeholder element where handsontable was instantiated.
+         */
+        tableClearSelection: function(el) {
+            
+            var $el, range, self, value, row, rowMin, rowMax, col, colMin, colMax;
+
+            self = this;
+            $el = $(el);
+            range = $el.handsontable('getSelected');
+
+            rowMin = Math.min(range[0], range[2]);
+            rowMax = Math.max(range[0], range[2]);
+            
+            colMin = Math.min(range[1], range[3]);
+            colMax = Math.max(range[1], range[3]);
+
+            for (row = rowMin; row <= rowMax; row++) {
+                for (col = colMin; col <= colMax; col++) {
+                    $el.handsontable('setDataAtCell', row, col, '');
+                }
+            }
+
+            self.rte.triggerChange();
         },
 
         


### PR DESCRIPTION
Add ability to clear the contents of the currently selected table cells. New table cell dropdown "Clear cells" will clear a single cell, or multiple cells that are selected in a range.