### PR TITLE
BSP-1797: Fixes RTE toolbar stickiness.

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/sticky.js
+++ b/tool-ui/src/main/webapp/script/v3/sticky.js
@@ -66,6 +66,7 @@ define([ 'jquery', 'bsp-utils', 'sticky-kit' ], function($, bsp_utils) {
   bsp_utils.onDomInsert(document, '.rte2-toolbar', {
     insert: function (element) {
       $(element).stick_in_parent({
+        recalc_every: 100,
         offset_top: function () {
           return toolHeaderBottom(false);
         }


### PR DESCRIPTION
This happened because RTE toolbar is a sticky element that's inside
another sticky element that's constantly being shifted in position. The
fix is to brute force the recalc for now.