### PR TITLE
RTE error when style does not contain onCreate

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1404,7 +1404,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 } else {
                     mark = rte.toggleStyle(item.style);
 
-                    if (mark) {
+                    if (mark && styleObj.onCreate) {
                         styleObj.onCreate(mark);
                     }
                 }


### PR DESCRIPTION
Previous commit added styleObj.onCreate functionality, but it was trying to call onCreate for every style, which caused an error when applying a style that didn't have on onCreate function. This commit checks for existence of onCreate before trying to call it.