### PR TITLE
RTE add dropdown to comments to show user and time

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -107,6 +107,32 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                     attrs['data-user-id'] = $html.attr('data-user-id');
                     attrs['data-user-label'] = $html.attr('data-user-label');
                     attrs['data-time'] = +new Date();
+                },
+
+                // Text to display in a dropdown when cursor moves over this style
+                dropdown: function(mark) {
+
+                    var date, user, time, label;
+
+                    label = '';
+                    
+                    if (mark.attributes) {
+                        
+                        user = mark.attributes['data-user-label'];
+                        time = mark.attributes['data-time'];
+
+                        if (user && time) {
+
+                            date = new Date(parseInt(time));
+                            label = user;
+                            try {
+                                // Just in case older browser doesn't support toLocale functions catch the error
+                                label += ': ' + date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+                            } catch (e) {}
+                        }
+                    }
+                    
+                    return label;
                 }
             },
             link: {

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2830,7 +2830,7 @@ define([
             marks = $.map(marks, function(mark, i) {
                 var styleObj;
                 styleObj = self.classes[mark.className];
-                if (styleObj && (styleObj.onClick || styleObj.void || styleObj.readOnly)) {
+                if (styleObj && (styleObj.onClick || styleObj.void || styleObj.readOnly || styleObj.dropdown)) {
                     // Keep in the array
                     return mark;
                 } else {
@@ -2870,6 +2870,11 @@ define([
                     'class': 'rte2-dropdown-item'
                 }).appendTo(self.$dropdown);
 
+                if (styleObj.dropdown) {
+                    $div.append( styleObj.dropdown(mark) );
+                    return;
+                }
+                
                 $('<span/>', {
                     'class':'rte2-dropdown-label',
                     text: label


### PR DESCRIPTION
We recently started saving the user name and timestamp as attributes on comments, but there is no way for the user to see this information.

This commit adds a dropdown that appears when the cursor is over the comment. The dropdown shows the username, the date, and the time at which the comment was originally created.

![rte-comment-dropdown](https://cloud.githubusercontent.com/assets/185461/13967910/015c02f0-f050-11e5-9ec4-5f1006c25c90.png)
