### PR TITLE
RTE bugfix for link within a RichText popup (BSP-1819)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3001,10 +3001,20 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 $divLink.click();
 
                 // When the popup is closed put focus back on the editor
-                $(document).one('closed', '[name=' + frameName + ']', function(){
+                $(document).on('closed.' + frameName, '[name=' + frameName + ']', function(event){
+                    
+                    // Make sure this 'closed' event was fired on the frame,
+                    // and not on some popup within the frame
+                    if (event.target !== event.currentTarget) {
+                        return;
+                    }
+                    
                     self.focus();
                     $div.remove();
                     self.rte.triggerChange();
+
+                    // Stop listening for this event
+                    $(document).off('closed.' + frameName);
                 });
 
             }, 100);


### PR DESCRIPTION
When using a RichText popup (inline enhancement), if it contained a nested RTE, then creating a link was interfering with the popup and the RichText element could not be saved. This commit adds some event checking to ensure that the link popup does not interfere with the RichText popup.