### PR TITLE
RTE track changes is messing up context checks (BSP-1829)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -696,7 +696,7 @@ define([
                     if (rightmostMark) {
 
                         styleObj = self.classes[rightmostMark.className];
-                        if (styleObj && styleObj.element) {
+                        if (styleObj && styleObj.element && !styleObj.internal) {
                             context[styleObj.element] = true;
                         }
                         


### PR DESCRIPTION
For styles that are disabled based on the context of the cursor position, track changes marks are interfering with the context check. This commit excludes track changes marks from being considered as part of the context.