### PR TITLE
RTE bugfix for js error when pasting

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2827,7 +2827,9 @@ define([
             $.each(lineStyles, function(styleKey) {
                 var mark;
                 mark = self.blockGetLineData(styleKey, range.from.line);
-                marks.push(mark);
+                if (mark) {
+                    marks.push(mark);
+                }
             });
         
             // Find all the inline marks for the clicked position


### PR DESCRIPTION
While working on a project's clipboardSanitize rules, a javascript error occurred due to a lack of error checking in the RTE. This commit adds a check to prevent the error.