### PR TITLE
RTE add style to force scrollbar display for table (BSP-1438)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -705,3 +705,17 @@ li.CodeMirror-hint-active {
     padding-left:0.25em;
   }
 }
+
+.rte2-table-placeholder {
+
+  .wtHolder::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 5px;
+    height:5px;
+  }
+  .wtHolder::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(0,0,0,.25);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+  }
+}


### PR DESCRIPTION
Within an RTE table, if a cell can expand and push other cells to the right. The user must scroll the div that contains the table in order to access the other columns.

However, in Mac OS X, scrollbars are hidden by default until the user tries to scroll. This can lead to some confusion since the user does not necessarily know that the area is scrollable.

This commit adds some styles so the scrollbar will always appear (when the table is scrollable) and the user will know the area is scrollable.

![scrollbar](https://cloud.githubusercontent.com/assets/185461/14079882/2c35d338-f4cf-11e5-8714-b22eadb7b747.png)
