### PR TITLE
RTE bugfix for enhancement move

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2508,9 +2508,12 @@ define([
             
             if (lineNumber > lineMax) {
                 
-                // Add another line to the end of the editor
+                // Add another line to the end of the editor.
+                // Set the change event origin to "brightspotEnhancementMove" so we know this newline is being
+                // added automatically rather than the user typing (so we don't try to adjust the
+                // position of the enhancement - see enhancementNewlineAdjust()
                 lineLength = editor.getLine(lineMax).length;
-                editor.replaceRange('\n', {line:lineMax, ch:lineLength}, 'brightspotEnhancementMove');
+                editor.replaceRange('\n', {line:lineMax, ch:lineLength}, undefined, 'brightspotEnhancementMove');
                 
             }
 
@@ -2573,6 +2576,10 @@ define([
             var lineInfo, lineNumber, self;
 
             self = this;
+
+            if (changeObj.origin === 'brightspotEnhancementMove') {
+                return;
+            }
             
             if (changeObj.from &&
                 changeObj.from.ch === 0 && // change occurred at the first character of the line


### PR DESCRIPTION
Fix a problem when moving enhancement down when the enhancement is already on the last line. The intended behavior is to add a new line to the end of the content, then move the enhancement down.

Currently an error occurs when the new line is added due to a missing argument in the call to CodeMirror.

Also, another recent fix (to adjust the position of an enhancement when the user presses enter at the beginning of the line) was causing problems when moving an enhancement down. This commit adds some checking to determine if the user pressed enter vs pressing the down arrow button for the enhancement.