### PR TITLE
RTE mark changed only after user input (BSP-1720)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -720,13 +720,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Note we do this after a short timeout because the editor's change events
             // are debounced, and we need to give the editor time to add the initial
             // content before we start listening for change events.
-            
+
             self.changed = false;
-            setTimeout(function() {
-                self.$editor.on('rteChange', function(){
-                    self.changed = true;
-                });
-            }, 1000);
+            self.$editor.one('rteChange', function(){
+                self.changed = true;
+            });
 
             // Set up periodic update of the textarea
             self.previewInit();

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -454,9 +454,9 @@ define([
                 
             });
             
-            editor.on('changes', $.debounce(200, function(instance, event) {
+            editor.on('changes', function(instance, event) {
                 self.triggerChange(event);
-            }));
+            });
 
             editor.on('focus', function(instance, event) {
                 self.$el.trigger('rteFocus', [self]);

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -455,7 +455,7 @@ define([
             });
             
             editor.on('changes', $.debounce(200, function(instance, event) {
-                self.triggerChange();
+                self.triggerChange(event);
             }));
 
             editor.on('focus', function(instance, event) {
@@ -470,12 +470,19 @@ define([
         
         /**
          * Trigger an rteChange event.
+         *
          * This can happen when user types changes into the editor, or if some kind of mark is modified.
+         * When the event is triggered, it is sent additional data: the object for this rte, plus an optional
+         * extra data parameter.
+         *
+         * @param {Object} [extra]
+         * Extra data parameter to pass with the rteChange event.
+         * For example, this could be the CodeMirror change event.
          */
-        triggerChange: function() {
+        triggerChange: function(extra) {
             var self;
             self = this;
-            self.$el.trigger('rteChange', [self]);
+            self.$el.trigger('rteChange', [self, extra]);
         },
 
         
@@ -2551,6 +2558,8 @@ define([
             self.enhancementRemove(mark);
             
             mark = self.enhancementAdd($content[0], lineNumber, options);
+
+            self.triggerChange();
             
             return mark;
         },


### PR DESCRIPTION
Since the RTE must parse the input HTML, in some cases the output will not match the input, even in cases where the user has not interacted with the editor to change the content.

This commit sets a "changed" flag on the editor only after the user has performed some modification to the editor content. If the content has not been changed by the user, then the textarea will not be updated with the editor output.

This will prevent the input from being marked as "changed" until the user modifies the content, so the user will not be prevented from leaving the page.

Also it means that if the user publishes the page, the original value in the textarea will be retained (and not the modified output from the editor).