### PR TITLE
Repeatable bugfix: click edits wrong slide (BSP-1815)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -1961,11 +1961,11 @@ The HTML within the repeatable element must conform to these standards:
                     var headerHeight;
                     var scrollPosition;
                     
-                    // Switch to the carousel view
-                    self.modePreviewShowCarousel();
-
                     // Set the active tile in the carousel
                     self.carousel.setActive( $item.index() + 1 );
+                    
+                    // Switch to the carousel view
+                    self.modePreviewShowCarousel();
 
                     if (goToActiveTile !== false) {
                         


### PR DESCRIPTION
Due to a recent change we added (when switching to gallery view automatically edit the first slide if no slide has been selected https://github.com/perfectsense/brightspot-cms/pull/516), clicking "Edit" on a slide was not selecting the correct slide to edit, instead it was always editing the first slide.

This commit changes the order in which the active slide is set to fix this issue.