### PR TITLE
RTE bugfix for track changes session storage (BSP-1885)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -896,7 +896,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             name = self.$el.closest('.inputContainer').attr('data-name') || '';
             
             if (name) {
-                name = 'bsp.rte.changesTracking.' + name;
+                name = 'bsp.rte2.changesTracking.' + name;
             }
             
             return name;


### PR DESCRIPTION
If there were multiple RTE fields on the page and track changes was turned on for more than one, a javascript error occurred when the page was submitted, due to code from the old richtext editor.

This commit changes the name of the sessionStorage key used to save trackChanges state for the new RTE, to prevent interference from the old richtext.js code.