### PR TITLE
RTE popup table cell editor make TD contextRoot (BSP-1488)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -3675,7 +3675,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             self.$tableEditTextarea = $('<textarea>').appendTo(self.$tableEditDiv);
             self.tableEditRte = Object.create(Rte);
-            self.tableEditRte.init(self.$tableEditTextarea);
+            self.tableEditRte.init(self.$tableEditTextarea, {contextRoot:'td'});
 
             $controls = $('<div/>', {'class': 'rte2-table-editor-controls'}).appendTo(self.$tableEditDiv);
 


### PR DESCRIPTION
When popping up a new RTE for editing a table cell, the root context of the editor should be set to the TD element, to prevent the user from clicking toolbar buttons for styles that are not allowed within a table cell.