### PR TITLE
RTE mark changed after user input enhancement bug (BSP-1720)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2473,12 +2473,13 @@ define([
             // Save the mark in an internal cache so we can use it later to output content.
             mark.options.id = self.enhancementId++;
             self.enhancementCache[ mark.options.id ] = mark;
+
+            self.triggerChange();
             
             // Small delay before refreshing the editor to prevent cursor problems
             setTimeout(function(){
                 self.refresh();
                 mark.changed();
-                self.triggerChange();
             }, 100);
             
             return mark;


### PR DESCRIPTION
If the RTE contains an enhancement, it was being marked as "changed" even though the user did not make a change. This commit changes the timing of the enhancement creation event so it doesn't cause this error.

This is a following to pull request https://github.com/perfectsense/brightspot-cms/pull/663