### PR TITLE
RTE change toolbar ordering for RichText elements

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1110,7 +1110,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 
                 var styleName = rtElement.styleName;
                 var submenuName = rtElement.submenu;
-                var submenu;
+                var $submenu;
                 var toolbarButton;
 
                 toolbarButton = {
@@ -1126,27 +1126,19 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 }
 
                 if (submenuName) {
-                    submenu = submenus[submenuName];
-
-                    if (!submenu) {
-                        submenu = [ ];
-                        submenus[submenuName] = submenu;
+                    
+                    $submenu = submenus[submenuName];
+                    if (!$submenu) {
+                        $submenu = submenus[submenuName] = self.toolbarAddSubmenu({text: submenuName}, $toolbar);
                     }
 
-                    submenu.push(toolbarButton);
+                    self.toolbarAddButton(toolbarButton, $submenu);
 
                 } else {
                     self.toolbarAddButton(toolbarButton, $toolbar);
                 }
             });
 
-            $.each(submenus, function (text, submenuItems) {
-                var $submenu;
-                $submenu = self.toolbarAddSubmenu({text: text}, $toolbar);
-                $.each(submenuItems, function(i, item) {
-                    self.toolbarAddButton(item, $submenu);
-                });
-            });
         },
 
 


### PR DESCRIPTION
Change the toolbar ordering logic so a submenu is added in the same order the buttons appear in RICH_TEXT_ELEMENTS.

Previously for RICH_TEXT_ELEMENTS, any buttons that were not in submenus were added to the toolbar, followed later by submenus. This made it impossible to specify the desired order on the backend.