### PR TITLE
RTE allow style to toggle off when it has context (BSP-1776)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1623,6 +1623,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
                             // Is this contextElement listed among the context allowed by the current style?
                             if ($.inArray(contextElement, styleObj.context) === -1) {
+
+                                // Special case - if this style can be toggled, then it should be considered valid
+                                // if the entire range contains this style
+                                if (contextElement === styleObj.element && styleObj.toggle && styles[config.style]) {
+                                    return;
+                                }
+                                
                                 validContextInner = false;
                                 return false; // stop looping
                             }


### PR DESCRIPTION
If a style definition has context rules, currently the toolbar cannot be used to toggle off that style. Since typically the context rules might not let you use a style within itself, the toolbar button gets disabled, and therefore the user cannot click the button to toggle off the style.

This commit adds a check when every character in the range has the style, and the style is toggleable, then do not disable the button (since clicking the button would only remove the style).