### PR TITLE
RTE fix enhancement dropdown menu z-index (BSP-1903)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -54,7 +54,10 @@
       padding:0.5em;
       background-color: fade(white, 93%);
       border:1px solid @color-separator;
-      z-index:1;
+      z-index:3;
+      &:hover {
+        z-index: 4;
+      }
       
       li {
         display:block;


### PR DESCRIPTION
The z-index of the RTE was previously adjusted, but the enhancement dropdowns were still using the older values, so the dropdown menu appeared below the other RTE text.

This can be seen when you have a large number of image sizes in the dropdown.

Note there is still a related problem for enhancements that are float left / float right.