### PR TITLE
Constrains the value types that are handled by ViewMap.

### DIFF
--- a/db/src/main/java/com/psddev/cms/view/ViewMap.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewMap.java
@@ -1,7 +1,5 @@
 package com.psddev.cms.view;
 
-import com.psddev.dari.db.Recordable;
-import com.psddev.dari.db.State;
 import com.psddev.dari.util.Once;
 import com.psddev.dari.util.Settings;
 import com.psddev.dari.util.StringUtils;
@@ -212,12 +210,6 @@ class ViewMap implements Map<String, Object> {
      */
     private Object convertValue(Object value) {
 
-        // FIXME: Always exclude database objects for now. Eventually
-        // @ViewInterface will be required, naturally excluding these object types
-        if (value instanceof State || value instanceof Recordable) {
-            return null;
-        }
-
         if (value instanceof String) {
             return value;
 
@@ -261,7 +253,7 @@ class ViewMap implements Map<String, Object> {
 
             return convertedMap;
 
-        } else if (value != null) {
+        } else if (value != null && !getViewClasses(value).isEmpty()) {
             return new ViewMap(value, includeClassName);
         }
 
@@ -300,7 +292,7 @@ class ViewMap implements Map<String, Object> {
     private static List<Class<?>> getViewClasses(Object view) {
 
         // find all the classes that could contain annotations
-        List<Class<?>> viewInterfaces = ViewUtils.getAnnotatableClasses(view.getClass())
+        return ViewUtils.getAnnotatableClasses(view.getClass())
                 .stream()
                 // only look at interfaces
                 .filter(Class::isInterface)
@@ -308,14 +300,6 @@ class ViewMap implements Map<String, Object> {
                 .filter(klass -> klass.isAnnotationPresent(ViewInterface.class))
                 // add to list
                 .collect(Collectors.toList());
-
-        // if there are none, just return a single item list with the original class
-        // TODO: Eventually this can be removed, and @ViewInterface will be required.
-        if (viewInterfaces.isEmpty()) {
-            viewInterfaces = Collections.singletonList(view.getClass());
-        }
-
-        return viewInterfaces;
     }
 
     // Gets the list of bean property descriptors for the specified class.

--- a/db/src/main/java/com/psddev/cms/view/ViewMap.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewMap.java
@@ -1,37 +1,30 @@
 package com.psddev.cms.view;
 
-import com.psddev.dari.db.Location;
-import com.psddev.dari.db.Metric;
 import com.psddev.dari.db.Recordable;
 import com.psddev.dari.db.State;
 import com.psddev.dari.util.Once;
 import com.psddev.dari.util.Settings;
 import com.psddev.dari.util.StringUtils;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
-import java.io.File;
+
+import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -82,15 +75,61 @@ class ViewMap implements Map<String, Object> {
         this.unresolved = new LinkedHashMap<>();
         this.resolved = new LinkedHashMap<>();
 
-        try {
-            Arrays.stream(Introspector.getBeanInfo(view.getClass()).getPropertyDescriptors())
-                    .filter((prop) -> includeClassName || !"class".equals(prop.getName()))
-                    .filter((prop) -> prop.getReadMethod() != null)
-                    .forEach(prop -> unresolved.put(prop.getName(), () -> invoke(prop.getReadMethod(), view)));
+        // find all the classes that should be checked for bean properties
+        getViewClasses(view)
+                .stream()
+                // grab the list of bean property descriptors
+                .map(ViewMap::getBeanPropertyDescriptors)
+                // flatten the descriptors across all the interfaces
+                .flatMap(Collection::stream)
+                // exclude the getClass() method
+                .filter((prop) -> !"class".equals(prop.getName()))
+                // ensure the read (getter) method is present
+                .filter((prop) -> prop.getReadMethod() != null)
+                // load the properties into a map.
+                .collect(Collectors.toMap(
+                        // key is the descriptor name
+                        PropertyDescriptor::getName,
+                        // value is a supplier of the read method's value.
+                        prop -> () -> invoke(prop.getReadMethod(), view),
+                        // merge function just keeps the original value
+                        (m1, m2) -> m1,
+                        // store them in the unresolved map
+                        () -> unresolved));
 
+        if (includeClassName) {
+            resolved.put("class", view.getClass().getName());
+        }
+    }
+
+    private static List<Class<?>> getViewClasses(Object view) {
+
+        // find all the classes that could contain annotations
+        List<Class<?>> viewInterfaces = ViewUtils.getAnnotatableClasses(view.getClass())
+                .stream()
+                // only look at interfaces
+                .filter(Class::isInterface)
+                // that are annotated with @ViewInterface
+                .filter(klass -> klass.isAnnotationPresent(ViewInterface.class))
+                // add to list
+                .collect(Collectors.toList());
+
+        // if there are none, just return a single item list with the original class
+        // TODO: Eventually this can be removed, and @ViewInterface will be required.
+        if (viewInterfaces.isEmpty()) {
+            viewInterfaces = Collections.singletonList(view.getClass());
+        }
+
+        return viewInterfaces;
+    }
+
+    private static List<PropertyDescriptor> getBeanPropertyDescriptors(Class<?> viewClass) {
+        try {
+            return Arrays.asList(Introspector.getBeanInfo(viewClass).getPropertyDescriptors());
         } catch (IntrospectionException e) {
             LOGGER.warn("Failed to introspect bean info for view of type ["
-                    + view.getClass().getName() + "]. Cause: " + e.getMessage());
+                    + viewClass.getClass().getName() + "]. Cause: " + e.getMessage());
+            return Collections.emptyList();
         }
     }
 
@@ -198,11 +237,19 @@ class ViewMap implements Map<String, Object> {
                 .collect(Collectors.toList()), ", ") + "}";
     }
 
-    // Converts a value to a Json Map friendly value.
-    // Types not currently handled... ReferentialText and Region
+    /*
+     * Converts a value to a Json Map friendly value. Only supports String,
+     * Boolean, Number, Collection, and simple String key (non-State) based Maps.
+     */
     private Object convertValue(Object value) {
 
-        if (value instanceof CharSequence) {
+        // FIXME: Always exclude database objects for now. Eventually
+        // @ViewInterface will be required, naturally excluding these object types
+        if (value instanceof State || value instanceof Recordable) {
+            return null;
+        }
+
+        if (value instanceof String) {
             return value;
 
         } else if (value instanceof Boolean) {
@@ -211,60 +258,45 @@ class ViewMap implements Map<String, Object> {
         } else if (value instanceof Number) {
             return value;
 
-        } else if (value instanceof Date) {
-            return ((Date) value).getTime();
-
-        } else if (value instanceof URI || value instanceof URL) {
-            return value.toString();
-
-        } else if (value instanceof Locale) {
-            return ((Locale) value).toLanguageTag();
-
-        } else if (value instanceof File) {
-            return ((File) value).getName();
-
-        } else if (value instanceof UUID) {
-            return value.toString();
-
-        } else if (value instanceof Location) {
-            return ImmutableMap.of(
-                    "x", ((Location) value).getX(),
-                    "y", ((Location) value).getY());
-
-        } else if (value instanceof Metric) {
-            return ((Metric) value).getSum();
-
-        } else if (value instanceof State) { // should we handle this?
-            return ((State) value).getSimpleValues();
-
-        } else if (value instanceof Recordable) { // should we handle this?
-            return ((Recordable) value).getState().getSimpleValues();
-
-        } else if (value instanceof Iterable) {
+        } else if (value instanceof Collection) {
             List<Object> immutableViewList = new ArrayList<>();
 
             for (Object item : (Iterable<?>) value) {
-                immutableViewList.add(convertValue(item));
+
+                Object convertedItem = convertValue(item);
+                if (convertedItem != null) {
+                    immutableViewList.add(convertedItem);
+                }
             }
-            value = immutableViewList;
+            return immutableViewList;
 
         } else if (value instanceof ViewMap) { // pass through
             return value;
 
         } else if (value instanceof Map) {
-            return value;
 
-        } else if (value instanceof Class) {
-            return ((Class) value).getName();
+            Map<String, Object> convertedMap = new LinkedHashMap<>();
 
-        } else if (value instanceof Enum) {
-            return value.toString();
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                Object entryKey = entry.getKey();
+                Object entryValue = entry.getValue();
+
+                if (entryKey instanceof String) {
+                    Object convertedEntryValue = convertValue(entryValue);
+
+                    if (convertedEntryValue != null) {
+                        convertedMap.put((String) entryKey, convertedEntryValue);
+                    }
+                }
+            }
+
+            return convertedMap;
 
         } else if (value != null) {
-            value = new ViewMap(value, includeClassName);
+            return new ViewMap(value, includeClassName);
         }
 
-        return value;
+        return null;
     }
 
     private static Object invoke(Method method, Object view) {

--- a/db/src/main/java/com/psddev/cms/view/ViewMap.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewMap.java
@@ -102,37 +102,6 @@ class ViewMap implements Map<String, Object> {
         }
     }
 
-    private static List<Class<?>> getViewClasses(Object view) {
-
-        // find all the classes that could contain annotations
-        List<Class<?>> viewInterfaces = ViewUtils.getAnnotatableClasses(view.getClass())
-                .stream()
-                // only look at interfaces
-                .filter(Class::isInterface)
-                // that are annotated with @ViewInterface
-                .filter(klass -> klass.isAnnotationPresent(ViewInterface.class))
-                // add to list
-                .collect(Collectors.toList());
-
-        // if there are none, just return a single item list with the original class
-        // TODO: Eventually this can be removed, and @ViewInterface will be required.
-        if (viewInterfaces.isEmpty()) {
-            viewInterfaces = Collections.singletonList(view.getClass());
-        }
-
-        return viewInterfaces;
-    }
-
-    private static List<PropertyDescriptor> getBeanPropertyDescriptors(Class<?> viewClass) {
-        try {
-            return Arrays.asList(Introspector.getBeanInfo(viewClass).getPropertyDescriptors());
-        } catch (IntrospectionException e) {
-            LOGGER.warn("Failed to introspect bean info for view of type ["
-                    + viewClass.getClass().getName() + "]. Cause: " + e.getMessage());
-            return Collections.emptyList();
-        }
-    }
-
     /**
      * @return the backing view object for this map.
      */
@@ -323,6 +292,40 @@ class ViewMap implements Map<String, Object> {
             } else {
                 throw new RuntimeException(message, cause);
             }
+        }
+    }
+
+    // Gets a list of all the interface classes that are implemented by the view
+    // objects and are annotated with @ViewInterface.
+    private static List<Class<?>> getViewClasses(Object view) {
+
+        // find all the classes that could contain annotations
+        List<Class<?>> viewInterfaces = ViewUtils.getAnnotatableClasses(view.getClass())
+                .stream()
+                // only look at interfaces
+                .filter(Class::isInterface)
+                // that are annotated with @ViewInterface
+                .filter(klass -> klass.isAnnotationPresent(ViewInterface.class))
+                // add to list
+                .collect(Collectors.toList());
+
+        // if there are none, just return a single item list with the original class
+        // TODO: Eventually this can be removed, and @ViewInterface will be required.
+        if (viewInterfaces.isEmpty()) {
+            viewInterfaces = Collections.singletonList(view.getClass());
+        }
+
+        return viewInterfaces;
+    }
+
+    // Gets the list of bean property descriptors for the specified class.
+    private static List<PropertyDescriptor> getBeanPropertyDescriptors(Class<?> viewClass) {
+        try {
+            return Arrays.asList(Introspector.getBeanInfo(viewClass).getPropertyDescriptors());
+        } catch (IntrospectionException e) {
+            LOGGER.warn("Failed to introspect bean info for view of type ["
+                    + viewClass.getClass().getName() + "]. Cause: " + e.getMessage());
+            return Collections.emptyList();
         }
     }
 }


### PR DESCRIPTION
Only supports String, Boolean, Number, Collection, Maps with String keys and value types that fall into this same list, and Objects that implement one or more interfaces annotated with @ViewInterface.

Depends on https://github.com/perfectsense/brightspot-styleguide/pull/33