### PR TITLE
RTE float enhancements fix toolbar and dropdown (BSP-1501, BSP-1903)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -1,3 +1,25 @@
+.rte2-submenu() {
+  display:none;
+  margin:0;
+  position:absolute;
+  padding:0.5em;
+  background-color: fade(white, 93%);
+  border:1px solid @color-separator;
+  z-index:3;
+  &:hover {
+    z-index: 4;
+  }
+      
+  li {
+    display:block;
+
+    a {
+          // Prevent submenu from shrinking and cutting off text when on right side
+      white-space: nowrap;
+    }
+  }
+}
+
 .rte2-toolbar {
   background: white;
   border-color: transparent;
@@ -48,25 +70,7 @@
     height: 25px;
 
     > ul {  // Submenu
-      display:none;
-      margin:0;
-      position:absolute;
-      padding:0.5em;
-      background-color: fade(white, 93%);
-      border:1px solid @color-separator;
-      z-index:3;
-      &:hover {
-        z-index: 4;
-      }
-      
-      li {
-        display:block;
-
-        a {
-          // Prevent submenu from shrinking and cutting off text when on right side
-          white-space: nowrap;
-        }
-      }
+      .rte2-submenu;
     }
 
     &:hover {
@@ -199,6 +203,10 @@
   background-color: transparent;
   border-style: none;
   padding: 0;
+  > li:last-of-type {
+    // Remove the extra space normally reserved for the word count
+      margin-right: 0;
+  }
 
   .rte2-enhancement-toolbar-up { .icon; .icon-arrow-up; }
   .rte2-enhancement-toolbar-down { .icon; .icon-arrow-down; }
@@ -211,7 +219,28 @@
   .rte2-enhancement-toolbar-change { .icon; .icon-random; width:auto; padding-right:0.5em; }
   .rte2-enhancement-toolbar-options { .icon; .icon-cog; width:auto; padding-right:0.5em; }
   .rte2-enhancement-toolbar-edit { .icon; .icon-pencil; width:auto; padding-right:0.5em; }
-  .rte2-enhancement-toolbar-size { width:auto; }
+  .rte2-enhancement-toolbar-size {
+    .icon;
+    .icon-caret-right;
+    &.hovered, &:hover {
+      .icon-caret-down;
+    }
+    width:auto;
+    padding-right:0.5em;
+    &:before { padding: 0 0 1px 3px; }
+  }
+}
+
+.rte2-enhancement-sizes-popup:extend(.rte2-toolbar all) {
+  .rte2-submenu;
+  width:auto;
+  a { width:auto; display:block; }
+  > li {
+    &:last-of-type {
+      // Remove the extra space normally reserved for the word count
+      margin-right: 0;
+    }
+  }
 }
 
 .rte2-enhancement.toBeRemoved, .rte2-table.toBeRemoved {
@@ -308,15 +337,21 @@
   width:100%;
   margin:1em 0;
 }
+.rte2-style-enhancement-float() {
+  width:auto;
+  .rte2-enhancement-toolbar {
+    white-space:nowrap;
+  }
+}
 .rte2-style-enhancement-left {
+  .rte2-style-enhancement-float;
   float:left;
   margin:0 1em 0 0;
-  width:400px;
 }
 .rte2-style-enhancement-right {
+  .rte2-style-enhancement-float;
   float:right;
   margin:0 0 0 1em;
-  width:400px;
 }
 .rte2-style-track-delete, .rte2-table-placeholder del {
   background-color: rgba(255, 0, 0, 0.3);


### PR DESCRIPTION
In the RTE if you create an enhancement (old style) and make it float to the right or left, then the toolbar buttons did not work if they wrapped to two lines. In addition, the image size dropdown did not work because the items in the dropdown were not getting mouse events.

This commit changes the enhancement toolbar so the buttons will not wrap, so the buttons will always get mouse events. This might extend the size of the floated enhancement slightly, but not much wider than it already was.

For the image size dropdown menu, it was not possible to use the easy CSS-based dropdown, so a javascript solution was implemented to overlay the dropdown when the mouse hovers the "image size" toolbar button.