### PR TITLE
BSP-1908: Bug fixes for the Selections Widget

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
@@ -147,7 +147,7 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
 
             PaginatedResult<T> result = getPaginatedResult(page);
 
-            writePaginationHtml(page, result, 0);
+            writePaginationHtml(page, result, page.paramOrDefault(int.class, LIMIT_PARAMETER, LIMITS[0]));
 
             if (result.hasPages()) {
                 writeResultsHtml(page, result);

--- a/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
@@ -2,6 +2,7 @@ package com.psddev.cms.tool.widget;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import com.psddev.cms.db.ToolRole;
 import com.psddev.cms.db.ToolUser;
@@ -118,25 +119,34 @@ public class SelectionsWidget extends AbstractPaginatedResultWidget<SearchResult
     @Override
     public void writeResultsItemHtml(ToolPageContext page, SearchResultSelection selection) throws IOException {
 
-        if (StringUtils.isBlank(selection.getName())) {
-            return;
-        }
-
         Search search = new Search();
         search.setAdditionalPredicate(selection.createItemsQuery().getPredicate().toString());
         search.setLimit(10);
 
-        page.writeStart("td");
+        page.writeStart("tr");
+            page.writeStart("td");
 
-            page.writeStart("a",
-                    "target", "_top",
-                    "href", page.cmsUrl("/searchAdvancedFull",
-                        "search", ObjectUtils.toJson(search.getState().getSimpleValues()),
-                        "view", MixedSearchResultView.class.getCanonicalName()));
-                page.writeObjectLabel(selection);
+                page.writeStart("a",
+                        "target", "_top",
+                        "href", page.cmsUrl("/searchAdvancedFull",
+                                "search", ObjectUtils.toJson(search.getState().getSimpleValues()),
+                                "view", MixedSearchResultView.class.getCanonicalName()));
+                    if (StringUtils.isBlank(selection.getName())) {
+                        page.writeStart("i").writeHtml("<untitiled>").writeEnd();
+                    } else {
+                        page.writeObjectLabel(selection);
+                    }
+                page.writeEnd();
 
             page.writeEnd();
-
+            page.writeStart("td");
+                page.writeHtml(!ObjectUtils.isBlank(selection.getEntities())
+                        ? selection.getEntities().stream().map(e -> e.getState().getLabel()).collect(Collectors.joining(", "))
+                        : "");
+            page.writeEnd();
+            page.writeStart("td");
+                page.writeHtml(selection.size() + " item" + (selection.size() != 1 ? "s" : ""));
+            page.writeEnd();
         page.writeEnd();
     }
 

--- a/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
@@ -17,7 +17,6 @@ import com.psddev.dari.db.ObjectType;
 import com.psddev.dari.db.Query;
 import com.psddev.dari.db.State;
 import com.psddev.dari.util.ObjectUtils;
-import com.psddev.dari.util.StringUtils;
 
 public class SelectionsWidget extends AbstractPaginatedResultWidget<SearchResultSelection> {
 

--- a/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
@@ -131,11 +131,7 @@ public class SelectionsWidget extends AbstractPaginatedResultWidget<SearchResult
                         "href", page.cmsUrl("/searchAdvancedFull",
                                 "search", ObjectUtils.toJson(search.getState().getSimpleValues()),
                                 "view", MixedSearchResultView.class.getCanonicalName()));
-                    if (StringUtils.isBlank(selection.getName())) {
-                        page.writeStart("i").writeHtml("<untitiled>").writeEnd();
-                    } else {
-                        page.writeObjectLabel(selection);
-                    }
+                    page.writeObjectLabel(selection);
                 page.writeEnd();
 
             page.writeEnd();

--- a/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import com.psddev.cms.db.ToolEntity;
 import com.psddev.cms.db.ToolRole;
 import com.psddev.cms.db.ToolUser;
@@ -144,7 +145,7 @@ public class SelectionsWidget extends AbstractPaginatedResultWidget<SearchResult
                         : "");
             page.writeEnd();
             page.writeStart("td");
-                page.writeHtml(selection.size() + " item" + (selection.size() != 1 ? "s" : ""));
+                page.writeHtml(page.localize(SelectionsWidget.class, ImmutableMap.of("count", selection.size()), "numItems"));
             page.writeEnd();
         page.writeEnd();
     }

--- a/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/SelectionsWidget.java
@@ -1,9 +1,11 @@
 package com.psddev.cms.tool.widget;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.psddev.cms.db.ToolEntity;
 import com.psddev.cms.db.ToolRole;
 import com.psddev.cms.db.ToolUser;
 import com.psddev.cms.tool.Search;
@@ -136,8 +138,9 @@ public class SelectionsWidget extends AbstractPaginatedResultWidget<SearchResult
 
             page.writeEnd();
             page.writeStart("td");
-                page.writeHtml(!ObjectUtils.isBlank(selection.getEntities())
-                        ? selection.getEntities().stream().map(e -> e.getState().getLabel()).collect(Collectors.joining(", "))
+                Set<ToolEntity> entities = selection.getEntities();
+                page.writeHtml(!ObjectUtils.isBlank(entities)
+                        ? entities.stream().map(e -> e.getState().getLabel()).collect(Collectors.joining(", "))
                         : "");
             page.writeEnd();
             page.writeStart("td");

--- a/db/src/main/resources/com/psddev/cms/tool/widget/SelectionsWidgetDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/widget/SelectionsWidgetDefault_en.properties
@@ -1,1 +1,2 @@
 title=Selections
+numItems={count, plural, one{# item}other{# items}}

--- a/db/src/main/resources/com/psddev/cms/tool/widget/SelectionsWidgetDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/widget/SelectionsWidgetDefault_es.properties
@@ -1,1 +1,2 @@
 title=Seleccións
+numItems={count, plural, one{# artículos}other{# artículo}}


### PR DESCRIPTION
- Pagination now works correctly (it was incorrect before because untitled selections were skipped, but pagination wasnt aware of that)
- Each selection link goes to a correctly configured advanced search page (converted to single item per line to achieve this)
- The User option in the dropdown started working after the other changes. Im still unclear why it was wrong before
- Modified AbstractPaginatedResultWidget to correcly use/select the Show dropdown (it was using 0 in all cases)
- Did not fix the problem that, for selections with many items, the url length limit will be an issue