### PR TITLE
RTE switch from handsontable to new table editor (BSP-1488)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1,7 +1,7 @@
 /* jshint undef: true, unused: true, browser: true, jquery: true, devel: true */
 /* global define */
 
-define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extra', 'jquery.handsontable.full'], function($, CodeMirrorRte) {
+define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plugin/popup', 'jquery.extra', 'jquery.handsontable.full'], function($, CodeMirrorRte, tableEditor) {
 
     var CONTEXT_PATH, Rte;
 
@@ -3312,23 +3312,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          */
         tableCreate: function($content, line) {
             
-            var columns, contextMenuItems, data, dataRows, $div, ht, $placeholder, self;
+            var $div, mark, $placeholder, self, tEdit;
             self = this;
 
-            // Get the structure of the HTML including attributes
-            data = self.tableHTMLToData($content);
-            
-            // Convert the HTML structure into data that handsontable will understand
-            dataRows = [];
-            $.each(data.childNodes, function(i, row) {
-                var dataRow;
-                dataRow = [];
-                $.each(row.childNodes, function(i, cell) {
-                    dataRow.push(cell.childNodes[0]);
-                });
-                dataRows.push(dataRow);
-            });
-
+            // Get the line number where the table should be added
             if (line === undefined) {
                 line = self.rte.getRange().from.line;
             }
@@ -3340,172 +3327,121 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             // Create the placeholder div that will hold the table.
             // Note it appears you must set the style directly on the element or table resizing doesn't work correctly.
-            $placeholder = $('<div/>', {'class':'rte2-table-placeholder', style:'overflow:hidden;height:auto;width:100%;'}).appendTo($div);
+            $placeholder = $('<div/>', {'class':'rte2-table-placeholder', style:'height:auto;width:100%;'}).appendTo($div);
 
             // Create a fake CodeMirror mark to store the table attributes.
             // We set rteTableMark to true so we can later tell that this is not a real mark,
             // so we can avoid certain things like trying to get the range or html for the mark.
-            self.tableMarkSetTable($placeholder, self.tableMarkCreate($placeholder, data.attr));
+            // self.tableMarkSetTable($placeholder, self.tableMarkCreate($placeholder, data.attr));
 
-            // Set up the context menu for table cells
-            contextMenuItems = {
-                edit: {name:'Edit'}
-            };
+            // Create the table editor
+            tEdit = Object.create(tableEditor);
 
+            // Create the popup context men
+            tEdit.contextMenu = $.extend({
+                edit: {
+                    name: 'Edit Cell',
+                    handler: function(o, $cell) {
+                        self.tableEditSelection($cell);
+                    }
+                }
+            }, tEdit.contextMenu);
+
+            // If there are RichText elements for table, tr, td add buttons to the context menu
             if (self.tableStyleTable && self.tableStyleTable.onClick) {
-                contextMenuItems.attrTable = {name:'Edit Table Attributes'}
+                tEdit.contextMenu.attrTable = {
+                    name:'Edit Table Attributes',
+                    handler: function(o, $cell) {
+                        self.tableEditAttrTable($cell.closest('table'));
+                    }
+                };
             }
             if (self.tableStyleRow && self.tableStyleRow.onClick) {
-                contextMenuItems.attrRow = {name:'Edit Row Attributes'}
+                tEdit.contextMenu.attrRow = {
+                    name:'Edit Row Attributes',
+                    handler: function(o, $cell) {
+                        self.tableEditAttrRow($cell.closest('tr'));
+                    }
+                };
             }
             if (self.tableStyleCell && self.tableStyleCell.onClick) {
-                contextMenuItems.attrCell = {name:'Edit Cell Attributes'}
+                tEdit.contextMenu.attrCell = {
+                    name:'Edit Cell Attributes',
+                    handler: function(o, $cell) {
+                        self.tableEditAttrCell($cell);
+                    }
+                };
             }
-            
-            $.extend(contextMenuItems, {
-                row_above: {},
-                row_below: {},
-                col_left: {},
-                col_right: {},
-                remove_row: {},
-                remove_col: {},
-                clear_cell: {name: 'Clear cells'},
-                undo: {},
-                redo: {}
-            });
-            
-            // Initialize the table.
-            $placeholder.handsontable({
-                'data': dataRows,
-                minCols:1,
-                minRows:1,
-                stretchH: 'all',
-                contextMenu: {
-                    callback: function (key, options) {
-                        self.rte.triggerChange();
-                        switch (key) {
-                        case 'edit':
-                            self.tableEditSelection($placeholder);
-                            break;
-                        case 'attrTable':
-                            self.tableEditAttrTable($placeholder);
-                            break;
-                        case 'attrRow':
-                            self.tableEditAttrRow($placeholder);
-                            break;
-                        case 'attrCell':
-                            self.tableEditAttrCell($placeholder);
-                            break;
-                        case 'clear_cell':
-                            self.tableClearSelection($placeholder);
-                            break;
-                        }
-                    },
-                    items: contextMenuItems
-                },
-                fillHandle: false,
-                renderAllRows: true,
-                autoColumnsSize:true,
-                autoRowSize:true,
-                renderer: 'html',
-                wordWrap:true,
-                outsideClickDeselects:false,
-                editor:false,
-                afterSelectionEnd: function(r, c, r2, c2){
-                    self.tableShowContextMenu($placeholder, r, c);
-                },
-                afterCreateRow: function() {
-                    // Workaround - after a row or column is added a cell is selected.
-                    // Do not pop up the editor in that case.
-                    self.tableCancelEdit = true;
-                },
-                afterCreateCol: function() {
-                    // Workaround - after a row or column is added a cell is selected.
-                    // Do not pop up the editor in that case.
-                    self.tableCancelEdit = true;
-                },
-                afterRemoveRow: function() {
-                    // Workaround - after a row or column is removed a cell is selected.
-                    // Do not pop up the editor in that case.
-                    self.tableCancelEdit = true;
-                    
-                },
-                afterRemoveCol: function() {
-                    // Workaround - after a row or column is removed a cell is selected.
-                    // Do not pop up the editor in that case.
-                    self.tableCancelEdit = true;
-                }
-                 
-            });
 
+            // Start the table editor
+            tEdit.init($placeholder, {tableEl: $content});
+
+            // Save the table editor on the placeholder so we can get to it later
+            $placeholder.data('tableEditor', tEdit);
+            
             // Add the div to the editor
             mark = self.rte.enhancementAdd($div[0], line, {
                 block:true,
                 // Set up a custom "toHTML" function so the editor can output the enhancement
                 toHTML:function(){
+                    var $table, html;
                     if (self.tableIsToBeRemoved($div)) {
-                        return '';
+                        html = '';
                     } else {
-                        return self.tableToHTML($placeholder);
+                        $table = tEdit.tableGet({html:false});
+                        html = self.tableToHtml($table);
                     }
+                    return html;
                 }
             });
-
-            // Set meta data onto the handsontable cells.
-            // This will be used to save the element attributes from the HTML,
-            // and also to give a place for the backend RichText elements to
-            // update elements.
-            ht = $placeholder.handsontable('getInstance');
-            $.each(data.childNodes, function(rowIndex, row) {
-                
-                var rowMark;
-
-                rowMark = self.tableMarkCreate($placeholder, row.attr);
-                
-                $.each(row.childNodes, function(cellIndex, cell) {
-                    
-                    var cellMark;
-
-                    cellMark = self.tableMarkCreate($placeholder, cell.attr);
-                    self.tableMarkSetCell($placeholder, rowIndex, cellIndex, cellMark);
-                });
-
-                // Note the row mark is set on every cell in the row.
-                // If it is changed it should be updated on every cell in the row.
-                self.tableMarkSetRow($placeholder, rowIndex, rowMark);
-
-            });
-
-            // Table will not render when it is not visible,
-            // so tell it to render now that it has been added to the page
-            $placeholder.handsontable('render');
         },
 
         
         /**
-         * Show the context menu for a table cell.
-         * NOTE: this is not an offically supported API for handsontable,
-         * so it could possibly  break with future updates.
+         * Convert the table to HTML.
+         * Checks each table, tr, td, th element to see if it has a fake CodeMirror mark
+         * where attributes might have been added, and if so sets the attributes on the element.
          *
-         * @param {Element} el
-         * The placeholder element where the table was created.
-         * @param {Number} row
-         * @param {Number} col
+         * @param {Element|jQuery} table
+         * The table element.
+         *
+         * @returns {String}
+         * HTML for the table.
          */
-        tableShowContextMenu: function(el, row, col) {
-
-            var h, height, menu, offset, self, $td;
-
+        tableToHtml: function(table) {
+            var html, self, $table;
             self = this;
-            
-            h = $(el).handsontable('getInstance');
-            if (h) {
-                menu = h.getPlugin('contextMenu');
-                $td = $(h.getCell(row, col));
-                offset = $td.offset();
-                height = $td.height();
-                menu.open({pageY:offset.top + height, pageX:offset.left});
-            }
+            $table = $(table);
+
+            $table.find('tr,td,th').add($table).each(function() {
+                var $el, mark;
+                $el = $(this);
+
+                // Retrieve the mark for the table/tr/td/th element
+                mark = self.tableMarkGet($el);
+                if (mark && mark.attributes) {
+                    self.replaceAttributes($el, mark.attributes);
+                }
+            });
+            html = $('<div/>').append($table.clone()).html();
+            return html;
+        },
+
+        
+        /**
+         * Replace the attributes on an element with a new set of attributes.
+         */
+        replaceAttributes: function(el, attributes) {
+            var $el, original, self;
+            self = this;
+            $el = $(el);
+            original = self.rte.getAttributes($el);
+            $.each(original, function(attr, value) {
+                $el.removeAttr(attr);
+            });
+            $.each(attributes, function(attr, value) {
+                $el.attr(attr, value);
+            });
         },
 
         
@@ -3681,173 +3617,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
         
         /**
-         * Parse the HTML of a table and return as a data object.
-         *
-         * @param [String|Object] {$content}
-         * HTML for the table element, or a DOM or jQuery object.
-         * If this is not specified returns data for a new table.
-         *
-         * @returns Object
-         * Data from the table in the form of an nested Object.
-         * The object consists of nodes with the following parameters:
-         *   tagName = the name of the element (table, tr, td, th)
-         *   attr = a set of key/value pairs representing the attributes on the element
-         *   childNodes = an array of child nodes
-         * Or a node can be a string to represents next within an element.
-         */
-        tableHTMLToData: function($content) {
-            
-            var data, self;
-
-            self = this;
-
-            // If creating a new table, start with one that has a single row with two columns
-            if (!$content) {
-                data = {
-                    tagName:'table',
-                    childNodes:[
-                        {
-                            tagName: 'tr',
-                            childNodes: [
-                                { tagName: 'td', childNodes: [''] },
-                                { tagName: 'td', childNodes: [''] }
-                            ]
-                        }
-                    ]
-                };
-                return data;
-            }
-            
-            // Just in case HTML or a DOM element is passed in convert to jQuery object
-            $content = $($content);
-
-            // Create the initial table node
-            data = {
-                tagName:'table',
-                childNodes: [],
-                attr: self.rte.getAttributes($content)
-            };
-
-            // Loop through the rows in the table
-            $content.find('>tr,>tbody >tr,>thead >tr,>tfoot >tr').each(function(i, tr) {
-                
-                var dataRow;
-                
-                // Create the node for the row
-                dataRow = {
-                    tagName: 'tr',
-                    childNodes: [],
-                    attr: self.rte.getAttributes(tr)
-                };
-
-                // Loop through all the columns in the row
-                $(tr).find('>td,>th').each(function(i, cell) {
-
-                    var dataCell;
-
-                    dataCell = {
-                        tagName: $(cell).prop('tagName').toLowerCase(),
-                        childNodes: [],
-                        attr: self.rte.getAttributes(cell)
-                    };
-
-                    // Get the HTML in the column and add it to the row
-                    dataCell.childNodes.push( $(cell).html() );
-
-                    // Add the cell to the row
-                    dataRow.childNodes.push(dataCell);
-                });
-
-                // Add the row to the table
-                data.childNodes.push(dataRow);
-                
-            });
-
-            return data;
-        },
-
-        
-        /**
-         * Convert a handsontable placeholder to the HTML for the table.
-         *
-         * @param {Element|jQuery} placeholder
-         * The placeholder element on which handsontable was initialized.
-         *
-         * @returns String
-         * The HTML for the table.
-         */
-        tableToHTML: function(placeholder) {
-
-            var data, ht, html, $placeholder, self, tableAttr, tableMark;
-
-            self = this;
-
-            $placeholder = $(placeholder);
-            
-            ht = $placeholder.handsontable('getInstance');
-
-            data = ht.getData();
-
-            tableMark = self.tableMarkGetTable(placeholder) || {};
-            
-            html = self.tableOpenElement('table', tableMark.attributes);
-            
-            $.each(data, function(rowIndex, row) {
-                
-                var rowMark;
-
-                rowMark = self.tableMarkGetRow(placeholder, rowIndex) || {};
-
-                html += self.tableOpenElement('tr', rowMark.attributes);
-
-                $.each(row, function(cellIndex, cell) {
-                    var cellMark;
-
-                    cellMark = self.tableMarkGetCell(placeholder, rowIndex, cellIndex) || {};
-                    
-                    html += self.tableOpenElement('td', cellMark.attributes) + (cell || '') + '</td>';
-                });
-                html += '</tr>';
-            });
-
-            html += '</table>';
-
-            return html;
-        },
-
-        
-        /**
-         * Create the opening element plus attributes when exporting HTML.
-         *
-         * @param {String} element
-         * Element name.
-         *
-         * @param {Object} attributes
-         * Set of key/value pairs representing attributes on the element.
-         */
-        tableOpenElement: function(element, attributes) {
-
-            var html, self;
-
-            self = this;
-            
-            html = '';
-
-            attributes = attributes || {};
-                
-            html = '<' + element;
-
-            $.each(attributes, function(attr, value) {
-                html += ' ' + attr + '="' + self.rte.htmlEncode(value) + '"';
-            });
-                
-            html += '>';
-            
-            return html;
-        },
-        
-
-        /**
          * 
          */
         tableEditInit: function() {
@@ -3910,17 +3679,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         
         /**
          * @param jQuery $el
-         * The placeholder div that contains the handsontable
+         * The table cell that is being edited.
          */
         tableEditSelection: function($el) {
 
-            var range, self, value;
+            var self, value;
 
             self = this;
             
-            range = $el.handsontable('getSelected');
-
-
             // Set up a nested rich text editor in a popup
             // (but only do this once)
             self.tableEditInit();
@@ -3928,9 +3694,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Set a flag so we only update the table cell if user clicks the save button
             self.tableEditCancel = false;
             
-            value = $el.handsontable('getValue') || '';
+            value = $el.html();
 
-            self.$tableEditDiv.popup('source', $($el.handsontable('getCell', range[0], range[1])));
+            self.$tableEditDiv.popup('source', $el);
             self.$tableEditDiv.popup('open');
 
             self.tableEditRte.fromHTML(value);
@@ -3945,56 +3711,23 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
             self.tableEditRte.refresh();
 
-            // Due to a bug in handsontable, it steals the arrow keys even when it does not have focus.
-            // So until that bug is fixed we must deselect the current cell to allow the editor to get the arrow keys.
-            $el.handsontable('deselectCell');
-
             self.$tableEditDiv.popup('container').one('closed', function(){
 
                  if (self.tableEditCancel) {
                      self.tableEditCancel = false;
                  } else {
                      value = self.tableEditRte.toHTML();
-                     $el.handsontable('setDataAtCell', range[0], range[1], value);
+                     $el.html(value);
                  }
 
             });
-        },
-
-
-        /**
-         * Clear the cell that is currently selected.
-         * @param {Element|jQuery} el
-         * The placeholder element where handsontable was instantiated.
-         */
-        tableClearSelection: function(el) {
-            
-            var $el, range, self, value, row, rowMin, rowMax, col, colMin, colMax;
-
-            self = this;
-            $el = $(el);
-            range = $el.handsontable('getSelected');
-
-            rowMin = Math.min(range[0], range[2]);
-            rowMax = Math.max(range[0], range[2]);
-            
-            colMin = Math.min(range[1], range[3]);
-            colMax = Math.max(range[1], range[3]);
-
-            for (row = rowMin; row <= rowMax; row++) {
-                for (col = colMin; col <= colMax; col++) {
-                    $el.handsontable('setDataAtCell', row, col, '');
-                }
-            }
-
-            self.rte.triggerChange();
         },
 
         
         /**
          * Edit the table element attributes.
          * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
+         * The table element to edit.
          */
         tableEditAttrTable: function(el) {
             
@@ -4007,7 +3740,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             if (!self.tableStyleTable) { return; }
 
             // Get the existing attributes for the table
-            mark = self.tableMarkGetTable(el);
+            mark = self.tableMarkGet(el, true);
             if (!mark) { return; }
 
             mark.className = self.tableStyleTable.className;
@@ -4020,11 +3753,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         /**
          * Edit the tr element attributes.
          * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
+         * The tr element.
          */
         tableEditAttrRow: function(el) {
             
-            var $el, mark, rangeTable, self;
+            var $el, mark, self;
             
             self = this;
             $el = $(el);
@@ -4032,14 +3765,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Make sure there is backend style that is meant for editing the table
             if (!self.tableStyleRow) { return; }
 
-            // Get the selected cell
-            rangeTable = $el.handsontable('getSelected');
-
-            mark = self.tableMarkGetRow(el, rangeTable[0]);
-            if (!mark) {
-                mark = self.tableMarkCreate(el);
-                self.tableMarkSetRow(el, rangeTable[0], mark);
-            }
+            mark = self.tableMarkGet(el, true);
+            if (!mark) { return; }
 
             mark.className = self.tableStyleRow.className;
             
@@ -4051,7 +3778,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
         /**
          * Edit the td element attributes.
          * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
+         * The td or th element.
          */
         tableEditAttrCell: function(el) {
             
@@ -4063,17 +3790,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             // Make sure there is backend style that is meant for editing the table
             if (!self.tableStyleCell) { return; }
 
-            // Get the selected cell
-            rangeTable = $el.handsontable('getSelected');
-
-            mark = self.tableMarkGetCell(el, rangeTable[0], rangeTable[1]);
-            if (!mark) {
-                mark = self.tableMarkCreate(el);
-                self.tableMarkSetCell(el, rangeTable[0], rangeTable[1], mark);
-            }
+            mark = self.tableMarkGet(el, true);
+            if (!mark) { return; }
 
             mark.className = self.tableStyleCell.className;
-            
+
             // Pop up backend form to edit the table attributes
             self.inlineEnhancementHandleClick(null, mark);
         },
@@ -4081,20 +3802,32 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
 
         /**
          * Create a fake CodeMirror mark to be used for table, tr, td elements.
+         *
+         * @param {Element} el
+         * The element (table, tr, td, or th).
+         *
          * @param {Object} attributes
+         * Additional attributes to be added.
+         * Note we start with a list of all attributes from the element.
+         *
          * @param {Object} [parameters]
          * Optional set of parameters to also add to the mark.
          * For example, to add a className.
          */
-        tableMarkCreate: function(el, attributes, parameters) {
+        tableMarkCreate: function(el, extraAttributes, markParameters) {
             
-            var mark, self;
+            var attributes, mark, self;
             
             self = this;
 
+            attributes = self.rte.getAttributes(el);
+            if (extraAttributes) {
+                $.extend(attributes, extraAttributes);
+            }
+            
             mark = {
                 rteTableMark:true,
-                attributes: attributes || {},
+                attributes: attributes,
                 find: function() {
                     // TODO: this returns the position of the bottom of the table,
                     // which is not a good representation of where we want the
@@ -4115,13 +3848,15 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
                 }
             };
 
-            if (parameters) {
-                $.extend(mark, parameters);
+            if (markParameters) {
+                $.extend(mark, markParameters);
             }
+
+            // Save the mark on the element for future use
+            $(el).data('tableMark', mark);
             
             return mark;
         },
-
         
         /**
          * Update the mark for the table element.
@@ -4130,126 +3865,38 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          * @param {Object} mark
          * The fake CodeMirror mark for the table element.
          */
-        tableMarkSetTable: function(el, mark) {
+        tableMarkSet: function(el, mark) {
             var self;
             self = this;
             $(el).data('markTable', mark);
         },
 
-        
+
         /**
          * Retrieve the mark for the table element.
+         * If a mark does not yet exist, creates it.
          *
          * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
+         * The table, tr, td, or th element.
+         *
+         * @param {Boolean} [create=false]
+         * If this flag is true, create the mark if it doesn't already exist.
          *
          * @returns {Object} mark
          * The fake CodeMirror mark for the table element, or undefined if none is defined.
          */
-        tableMarkGetTable: function(el) {
-            var self;
+        tableMarkGet: function(el, create) {
+            var mark, self;
             self = this;
-            return $(el).data('markTable');
-        },
 
-        
-        /**
-         * Update the mark for the tr element.
-         * Note this sets the mark on every cell in the row
-         * because cells can be removed and we need to maintain the row mark
-         * when that happens.
-         *
-         * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
-         *
-         * @param {Number} row
-         * The row number of the table.
-         *
-         * @param {Object} mark
-         * The fake CodeMirror mark for the table element.
-         */
-        tableMarkSetRow: function(el, row, mark) {
-            var col, ht, self;
-            self = this;
-            ht = $(el).handsontable('getInstance');
-            for (col = 0; col < ht.countCols(); col++) {
-                ht.setCellMeta(row, col, 'rowMark', mark);
+            // Get the mark from a data attribute if it was previously created
+            mark = $(el).data('markTable');
+            if (!mark && create) {
+                // Mark doesn't exist so create it
+                mark = self.tableMarkCreate(el);
+                self.tableMarkSet(el, mark);
             }
-        },
-
-
-        /**
-         * Retrieve the mark for a table row.
-         * 
-         * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
-         *
-         * @param {Number} row
-         * The row number of the table.
-         *
-         * @returns {Object}
-         * The fake CodeMirror mark for the table element, or undefined if none is defined.
-         */
-        tableMarkGetRow: function(el, row) {
-            var col, ht, meta, self;
-            self = this;
-            ht = $(el).handsontable('getInstance');
-
-            // In some cases like when a new column is added to the table,
-            // the first cell in the row might not have the row mark saved.
-            // So we start with the leftmost cell and keep going until we find a row mark.
-            for (col = 0; col < ht.countCols(); col++) {
-                meta = ht.getCellMeta(row, col);
-                if (meta) {
-                    break;
-                }
-            }
-
-            return meta;
-        },
-
-        
-        /**
-         * Update the mark for the td element (table cell).
-         *
-         * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
-         *
-         * @param {Number} row
-         * The row number of the table.
-         *
-         * @param {Number} col
-         * The column number of the table.
-         *
-         * @param {Object} mark
-         * The fake CodeMirror mark for the table element.
-         */
-        tableMarkSetCell: function(el, row, col, mark) {
-            var ht, self;
-            self = this;
-            ht = $(el).handsontable('getInstance');
-            ht.setCellMeta(row, col, 'cellMark', mark);
-        },
-
-        
-        /**
-         * Retrieve the mark for a table cell.
-         * 
-         * @param {Element|jquery} el
-         * The placeholder element where handsontable was initialized.
-         *
-         * @param {Number} row
-         * The row number of the table.
-         *
-         * @returns {Object}
-         * The fake CodeMirror mark for the table element, or undefined if none is defined.
-         */
-        tableMarkGetCell: function(el, row, col) {
-            var ht, meta, self;
-            self = this;
-            ht = $(el).handsontable('getInstance');
-            meta = ht.getCellMeta(row, col);
-            return meta.cellMark;
+            return mark;
         },
 
         

--- a/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
+++ b/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
@@ -1,0 +1,743 @@
+/* jshint undef: true, unused: true, browser: true, jquery: true, devel: true */
+/* global define */
+
+define(['jquery'], function($) {
+
+    var module;
+
+    /**
+     * Table editor module.
+     *
+     * @example
+     * // Create default table
+     * var t = Object.create(module);
+     * t.init($('#placeholder'));
+     * 
+     * @example
+     * // Create table from existing HTML
+     * var t = Object.create(module);
+     * t.init($('#placeholder'), {tableHtml: '<table>...</table>'});
+     *
+     * @example
+     * // Create table from existing table
+     * var t = Object.create(module);
+     * t.init($('#placeholder'), {tableEl: $('#mytable')});
+     */
+    module = {
+
+        /**
+         * Base class name for styling various elements.
+         */
+        className: 'bspTableEdit',
+
+        
+        /**
+         * A set of key/value settings to customize the context menu for each cell.
+         *
+         * The following keys are standard:
+         * rowAddAbove, rowAddBelow, rowDelete, colAddLeft, colAddRight, colDelete, cellClear
+         * In addition you can add your own custom keys such as "edit"
+         *
+         * The value must be an object, and may contain the following parameters:
+         *
+         * {String} [name]: the name to display in the context menu
+         *
+         * {Function} [handler]: a function to handle clicks on the content menu.
+         * TODO what is passed in to the handler
+         */
+        contextMenu: {
+            rowAddAbove: {},
+            rowAddBelow: {},
+            colAddLeft: {},
+            colAddRight: {},
+            rowDelete: {},
+            colDelete: {},
+            cellClear: {}
+        },
+
+        
+        /**
+         * Default names for the standard context menu actions.
+         */
+        contextMenuNames: {
+            rowAddAbove: 'Add Row Above',
+            rowAddBelow: 'Add Row Below',
+            colAddLeft: 'Add Column Left',
+            colAddRight: 'Add Column Right',
+            rowDelete: 'Delete Row',
+            colDelete: 'Delete Column',
+            cellClear: 'Clear Cell'
+        },
+
+        
+        /**
+         * @param {Element|jQuery|Selector} el
+         * Element where the table should be rendered.
+         *
+         * @param {Object} options
+         * Set of key/value options.
+         *
+         * @param {String} options.tableHtml
+         * @param {Element} options.tableEl
+         * 
+         */
+        init: function(el, options) {
+            
+            var self;
+            self = this;
+            self.$el = $(el);
+
+            if (options) {
+                $.extend(self, options);
+            }
+            
+            if (options.tableEl) {
+                self.$table = $(options.tableEl);
+            } else if (options.tableHtml) {
+                self.$table = $(options.tableHtml);
+            } else {
+                self.$table = $('<table><tr><td>&nbsp;</td><td>&nbsp;</td></tr></table>');
+            }
+
+            self.$wrapper = $('<div/>', {
+                'class': self.className + 'Wrapper'
+            }).appendTo(self.$el);
+
+            self.$tableWrapper = $('<div/>', {
+                'class': self.className + 'TableWrapper'
+            }).appendTo(self.$wrapper);
+                
+            self.$table.appendTo(self.$tableWrapper);
+
+            self.activeClass = self.className + 'Active';
+            
+            self.initEvents();
+            self.contextInit();
+        },
+
+
+        /**
+         * Set up the click event for table cells.
+         */
+        initEvents: function() {
+
+            var self;
+
+            self = this;
+            
+            self.$tableWrapper.on('click', function(event) {
+
+                var $cell;
+                
+                event.preventDefault();
+                event.stopPropagation();
+
+                $cell = $(event.target).closest('td, th');
+
+                self.selectedSet($cell);
+                self.contextShow();
+
+            });
+        },
+
+        
+        /**
+         * Set the table cell (td or th) that is currently selected.
+         */
+        selectedSet: function(el) {
+            var self;
+            self = this;
+            self.$selected = $(el);
+            self.activeSet(el);
+        },
+
+        
+        /**
+         * Return thte table cell (td or th) that is currently selected.
+         */
+        selectedGet: function() {
+            var self;
+            self = this;
+            return self.$selected || self.$table.find('td,th').eq(0);
+        },
+
+        
+        /**
+         * Clear the active class from all cells.
+         */
+        activeClear: function() {
+            var self;
+            self = this;
+            self.$table.find('.' + self.activeClass).removeClass(self.activeClass);
+            delete self.$active;
+        },
+
+        
+        /**
+         * Set the active class on a cell.
+         * 
+         */
+        activeSet: function(cell) {
+            var self;
+            self = this;
+            self.activeClear();
+            $(cell).addClass(self.activeClass);
+            self.$active = $(cell);
+        },
+
+
+        /**
+         * Returns the active cell.
+         * @returns {jQuery|undefined}
+         */
+        activeGet: function() {
+            var self;
+            self = this;
+            return self.$active;
+        },
+
+        
+        /**
+         * Create the context menu
+         */
+        contextInit: function() {
+            
+            var self;
+            
+            self = this;
+            
+            self.$context = $('<div/>', {
+                'class': self.className + 'Context'
+            }).hide().on('click', function(event) {
+                event.preventDefault();
+                event.stopPropagation();
+            }).appendTo(self.$wrapper);
+        },
+
+        
+        /**
+         * Before displaying the context menu put the appropriate links inside it.
+         */
+        contextUpdate: function() {
+            
+            var $el, self;
+            
+            self = this;
+
+            self.$context.empty();
+            $el = self.selectedGet();
+            
+            $.each(self.contextMenu, function(key, options){
+
+                var item, $item;
+
+                // Set up default values for this item
+                item = {
+                    name: self.contextMenuNames[key] || key,
+                    handler: function() {
+                        self.contextHandler(key);
+                    }
+                };
+
+                // Make the options override the defaults
+                $.extend(item, options);
+
+                $item = $('<a/>', {
+                    'class': 'tableModuleContextItem',
+                    href: '#',
+                    text: item.name
+                }).on('click', function(event) {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    self.activeClear();
+                    self.contextHide();
+
+                    // Call the handler function for the context menu item.
+                    // Pass in this tableEditor object, plus the active cell
+                    item.handler(self, $el);
+                });
+
+                $('<div/>').html($item).appendTo(self.$context);
+            });
+        },
+
+
+        /**
+         * Update the position of the context menu so it appears below the active cell.
+         */
+        contextPosition: function() {
+            
+            var $el, pos, self;
+            
+            self = this;
+
+            $el = self.selectedGet();
+            pos = $el.position();
+            if (pos) {
+                self.$context.css({left:pos.left, top:pos.top + $el.outerHeight() - 1});
+            }
+        },
+
+        
+        /**
+         * Handle the context menu for the built-in functionality.
+         *
+         * @param {String} key
+         * Context menu key for any of the built-in functions.
+         */
+        contextHandler: function(key) {
+            
+            var self;
+            self = this;
+
+            switch (key) {
+                
+            case 'rowAddAbove':
+                self.rowAdd({above:true});
+                break;
+            case 'rowAddBelow': 
+                self.rowAdd();
+                break;
+            case 'colAddLeft': 
+                self.colAdd({left:true});
+                break;
+            case 'colAddRight': 
+                self.colAdd();
+                break;
+            case 'rowDelete': 
+                self.rowDelete();
+                break;
+            case 'colDelete': 
+                self.colDelete();
+                break;
+            case 'cellClear':
+                self.cellClear();
+                break;
+            }
+        },
+
+        
+        /**
+         * Show the context menu for a cell.
+         */
+        contextShow: function() {
+            
+            var self;
+            
+            self = this;
+
+            // Update the links that are in the context menu
+            self.contextUpdate();
+            
+            // Position the context menu based on the selected cell
+            self.contextPosition();
+
+            self.$context.show();
+            
+            // Hide the context menu automatically if user clicks outside
+            $(document).on('mouseup.contextHide', function(event) {
+                if (!self.$context.is(event.target) && self.$context.has(event.target).length === 0) {
+                    self.activeClear();
+                    self.contextHide();
+                }
+            });
+        },
+
+        
+        /**
+         * Hide the context menu.
+         */
+        contextHide: function() {
+            var self;
+            self = this;
+            self.$context.hide();
+
+            // Remove event that hides the context menu
+            $(document).off('mouseup.contextHide');
+        },
+
+
+        contextIsVisible: function() {
+            var self;
+            self = this;
+            return self.$context.is(':visible');
+        },
+
+        
+        /**
+         * Add a row.
+         *
+         * @param {Object} options
+         * A set of key/value pairs to set options.
+         *
+         * @param {Boolean} [options.above=false]
+         * Set to true if you want to add the row above the current row.
+         * Defaults to false (add the row below the current row).
+         *
+         * @param {Element} [options.cell=selected cell]
+         * A cell (td or th) within the table. Used to position the new row.
+         * If not specified, defaults to the last clicked cell.
+         */
+        rowAdd: function(options) {
+            
+            var $cell, cols, i, $row, $rowNew, self;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+            
+            $row = $cell.closest('tr');
+
+            $rowNew = $('<tr/>');
+            cols = self.colCount($cell);
+            for (i=0; i<cols; i++) {
+                $rowNew.append( self.cellCreate() );
+            }
+            
+            if (options.above) {
+                $rowNew.insertBefore($row);
+            } else {
+                $rowNew.insertAfter($row);
+            }
+        },
+
+        
+        /**
+         * Delete a row.
+         *
+         * @param {Object} options
+         * A set of key/value pairs to set options.
+         *
+         * @param {Element} [options.cell=selected cell]
+         * A cell (td or th) within the table. Used to position the new row.
+         * If not specified, defaults to the last clicked cell.
+         */
+        rowDelete: function(options) {
+            
+            var $cell, $row, self;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+            
+            // Do not remove the last row
+            if (self.rowCount($cell) <= 1) {
+                return;
+            }
+            
+            $row = $cell.closest('tr');
+            $row.remove();
+        },
+
+
+        /**
+         * Return the number of rows in the table.
+         *
+         * NOTE: does not support ROWSPAN attributes.
+         *
+         * @param {Element} [cell=selected cell]
+         * A cell (td or th) within the table.
+         * If not specified, defaults to the last clicked cell.
+         */
+        rowCount: function(cell) {
+            var $cell, self, $table;
+            self = this;
+            $cell = cell ? $(cell) : self.selectedGet();
+            $table = $cell.closest('table');
+            return $table.find('> * > tr').length;
+        },
+
+        
+        /**
+         * Add a column.
+         *
+         * @param {Object} options
+         * A set of key/value pairs to set options.
+         *
+         * @param {Boolean} [options.left=false]
+         * Set to true if you want to add the column to the left if the current column.
+         * Defaults to false (add the column to the right of the current column).
+         *
+         * @param {Element} [options.cell=selected cell]
+         * A cell (td or th) within the table. Used to position the new row.
+         * If not specified, defaults to the last clicked cell.
+         */
+        colAdd: function(options) {
+            
+            var $cell, colCount, colNumber, self, $table;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+
+            // Make sure each row has the correct number of cells
+            self.colNormalize({cell:$cell});
+            
+            // Get total number of columns across the entire table
+            colCount = self.colCount($cell);
+            
+            colNumber = $cell.index();
+            if (!options.left) {
+                colNumber++;
+            }
+
+            $table = $cell.closest('table');
+            $table.find('> * > tr').each(function() {
+                
+                var $td, $tds, $tr;
+
+                $tr = $(this);
+                $tds = $tr.find('> td, > th');
+
+                // Now add a new cell at the insertion point
+                $td = self.cellCreate();
+                if (colNumber >= colCount) {
+                    $td.appendTo($tr);
+                } else {
+                    $td.insertBefore( $tr.find('> td, > th').eq(colNumber) );
+                }
+            });
+        },
+
+        
+        /**
+         * Delete a column.
+         *
+         * @param {Object} options
+         * A set of key/value pairs to set options.
+         *
+         * @param {Element} [options.cell=selected cell]
+         * A cell (td or th) within the table.
+         * If not specified, defaults to the last clicked cell.
+         */
+        colDelete: function(options) {
+            
+            var $cell, colCount, colNumber, self, $table;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+
+            // Make sure each row has the correct number of cells
+            self.colNormalize({cell:$cell});
+
+            // Special case - do not delete the last column
+            colCount = self.colCount($cell);
+            if (colCount === 1) {
+                return;
+            }
+            
+            colNumber = $cell.index();
+
+            $table = $cell.closest('table');
+            $table.find('> * > tr').each(function() {
+                
+                var $tds, $tr;
+
+                $tr = $(this);
+                $tds = $tr.find('> td, > th');
+
+                // Delete the cell for the column
+                $tds.eq(colNumber).remove();
+            });
+        },
+
+        
+        /**
+         * Return the number of columns in the table.
+         *
+         * NOTE: does not support COLSPAN attributes.
+         *
+         * @param {Element} [cell=selected cell]
+         * A cell (td or th) within the table.
+         * If not specified, defaults to the last clicked cell.
+         */
+        colCount: function(cell) {
+            
+            var $cell, count, self, $table;
+            self = this;
+            $cell = cell ? $(cell) : self.selectedGet();
+            $table = $cell.closest('table');
+
+            count = 0;
+            $table.find('> * > tr').each(function() {
+                var $tr, cellCount;
+                $tr = $(this);
+                cellCount = $tr.find('> td, > th').length;
+                count = Math.max(count, cellCount);
+            });
+            
+            return count;
+        },
+
+
+        /**
+         * Normalize all the rows in a table so they have same number of cells
+         * and are not missing any columns.
+         *
+         * NOTE: does not support COLSPAN attributes.
+         *
+         * @param {Object} options
+         * A set of key/value pairs to set options.
+         *
+         * @param {Element} [options.cell=selected cell]
+         * A cell (td or th) within the table.
+         * If not specified, defaults to the last clicked cell.
+         */
+        colNormalize: function(options) {
+            
+            var $cell, colCount, self, $table;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+
+            // Get total number of columns across the entire table
+            colCount = self.colCount($cell);
+            
+            $table = $cell.closest('table');
+            $table.find('> * > tr').each(function() {
+                
+                var i, $tds, $tr;
+
+                $tr = $(this);
+                $tds = $tr.find('> td, > th');
+
+                // If this row is missing cells add them first
+                for (i = $tds.length; i < colCount; i++) {
+                    $tr.append( self.cellCreate() );
+                }
+                
+            });
+        },
+
+        /**
+         * Creates a new cell to be inserted into the table.
+         * @returns {jQuery}
+         */
+        cellCreate: function() {
+            return $('<td/>', {html:'&nbsp;'});
+        },
+
+        
+        /**
+         * Clear the content of a cell.
+         *
+         * @param {String|Element|jQuery} content
+         * Content to replace in the cell.
+         *
+         * @param {Object} [options]
+         * Set of key/value options.
+         *
+         * @param {Object} [options.cell=selected cell]
+         * The cell to set. 
+         */
+        cellClear: function(options) {
+            var self;
+            self = this;
+            self.cellSet('&nbsp;', options);
+        },
+
+        
+        /**
+         * Set the content of a cell.
+         *
+         * @param {String|Element|jQuery} content
+         * Content to replace in the cell.
+         *
+         * @param {Object} [options]
+         * Set of key/value options.
+         *
+         * @param {Object} [options.cell=selected cell]
+         * The cell to set. 
+         */
+        cellSet: function(content, options) {
+            
+            var $cell, self;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+
+            $cell.html(content);
+        },
+
+        
+        /**
+         * Get the contents of a cell.
+         *
+         * @param {Object} [options]
+         * Set of key/value options.
+         *
+         * @param {Object} [options.cell=selected cell]
+         * The cell to retrieve. 
+         *
+         * @param {Boolean} [options.html=false]
+         * Set to true if you want to return an HTML string.
+         * Defaults to false and returns a jQuery object of the cell contents.
+         *
+         * @returns {jQuery|String}
+         */
+        cellGet: function(options) {
+            
+            var $cell, self;
+            
+            self = this;
+            
+            options = options || {};
+            
+            $cell = options.cell ? $(options.cell) : self.selectedGet();
+
+            return options.html ? $cell.html() : $cell.contents();
+        },
+
+        
+        /**
+         * Get the entire contents of the table.
+         *
+         * @param {Object} [options]
+         * Set of key/value options.
+         *
+         * @param {Boolean} [options.html=false]
+         * Set to true if you want to return an HTML string.
+         * Defaults to false and returns a jQuery object pointing to the table.
+         *
+         * @returns {jQuery|String}
+         */
+        tableGet: function(options) {
+            
+            var $cloned, self;
+            
+            self = this;
+            
+            options = options || {};
+
+            // Remove the active class first
+            self.activeClear();
+            
+            $cloned = $('<div/>').append( self.$table.clone() );
+
+            // Remove any empty 'class' attributes because jquery leaves those around after setting and removing the active classes
+            $cloned.find('[class=""]').removeAttr('class');
+            return options.html ? $cloned.html() : self.$table;
+        }
+    };
+    
+    return module;
+
+});
+
+// Set filename for debugging tools to allow breakpoints even when using a cachebuster
+//# sourceURL=tableEditor.js

--- a/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
+++ b/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
@@ -46,13 +46,13 @@ define(['jquery'], function($) {
          * TODO what is passed in to the handler
          */
         contextMenu: {
+            cellClear: {},
             rowAddAbove: {},
             rowAddBelow: {},
+            rowDelete: {},
             colAddLeft: {},
             colAddRight: {},
-            rowDelete: {},
-            colDelete: {},
-            cellClear: {}
+            colDelete: {}
         },
 
         

--- a/tool-ui/src/main/webapp/style/v3/index.less
+++ b/tool-ui/src/main/webapp/style/v3/index.less
@@ -43,6 +43,7 @@
 @import 'repeatable.less';
 @import 'rte.less';
 @import 'rte2.less';
+@import 'tableEditor.less';
 @import 'scheduled-events.less';
 @import 'search.less';
 @import 'taxonomy.less';

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -249,9 +249,9 @@
   .rte2-enhancement-toolbar-remove-completely { display:inline-block; }
 }
 .rte2-table-placeholder {
-  overflow:hidden;
   height:auto;
   width:100%;
+  position:relative;
 }
 .rte2-style-html {
   font-family: @fontFamily-code;
@@ -673,11 +673,6 @@ li.CodeMirror-hint-active {
   
 }
 
-.rte2-table-editor {
-  .rte2-wrapper {
-    overflow: hidden;
-  }
-}
 .rte2-table-editor-save {
   margin-right: 0.5em;
 }
@@ -690,7 +685,9 @@ li.CodeMirror-hint-active {
   strike { text-decoration:line-through;}
   
   // Within the table do not let users click link or button elements
-  a, button { pointer-events:none; }
+  table {
+    a, button { pointer-events:none; }
+  }
 
   .rte-comment {
     &:extend(.rte2-style-comment);

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -5,9 +5,9 @@
   padding:0.5em;
   background-color: fade(white, 93%);
   border:1px solid @color-separator;
-  z-index:3;
+  z-index:4;
   &:hover {
-    z-index: 4;
+    z-index: 5;
   }
       
   li {
@@ -47,12 +47,12 @@
   .rte2-wrapper > & {
 
     // Give a higher z-index than the rich text editor.
-    z-index: 3;
+    z-index: 4;
 
     // When hovering the toolbar, give it a higher z-index than other toolbars
     // below so that the submenu will be on top of other toolbars.
     &:hover {
-      z-index: 4;
+      z-index: 5;
     }
   }
 

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -679,7 +679,10 @@ li.CodeMirror-hint-active {
   .closeButton {
     display:none;
   }
-  
+
+  .rte2-codemirror {
+    overflow: hidden;
+  }
 }
 
 .rte2-table-editor-save {

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -608,7 +608,7 @@ li.CodeMirror-hint-active {
       padding:0.25em;
     }
 
-    a {
+    .rte2-enhancement-toolbar a {
       color: @color-placeholder;
 
       &:hover {

--- a/tool-ui/src/main/webapp/style/v3/tableEditor.less
+++ b/tool-ui/src/main/webapp/style/v3/tableEditor.less
@@ -1,0 +1,55 @@
+.bspTableEditWrapper {
+  
+  position:relative;
+  z-index: 3;
+
+  table {
+    
+    width:100%;
+    background-color: #fff;
+
+    // Nested tables
+    table {
+      
+      // http://stackoverflow.com/questions/8812757/html-table-full-width-with-margin
+      margin: 1em auto;
+      width: calc(100% - 0.5em);
+    }
+  }
+
+  td, th {
+    min-width:200px;
+    min-height:1em;
+    border:1px solid @color-border;
+    padding:0.25em;
+  }
+
+  .bspTableEditActive {
+    border:1px solid @color-focus;
+    background-color: #eee;
+    & table {
+      background-color: #eee;
+    }
+  }
+}
+
+// Table goes inside here, and if it is too wide it should be scrollable
+.bspTableEditTableWrapper {
+  overflow:auto;
+}
+
+// Context menu will be positioned using javascript
+.bspTableEditContext {
+  display:none;
+  position:absolute;
+  width:auto;
+  padding: 0.25em;
+  border:1px solid #aaa;
+  background-color: #fff;
+  white-space:nowrap;
+
+  a {
+    display:block;
+    margin: 0.2em;
+  }
+}

--- a/tool-ui/src/main/webapp/style/v3/tableEditor.less
+++ b/tool-ui/src/main/webapp/style/v3/tableEditor.less
@@ -7,13 +7,14 @@
     
     width:100%;
     background-color: #fff;
+    margin: 0;
 
     // Nested tables
     table {
-      
+
       // http://stackoverflow.com/questions/8812757/html-table-full-width-with-margin
-      margin: 1em auto;
-      width: calc(100% - 0.5em);
+      margin: 5px auto;
+      width: ~'calc(100% - 10px)';
     }
   }
 
@@ -21,15 +22,12 @@
     min-width:200px;
     min-height:1em;
     border:1px solid @color-border;
-    padding:0.25em;
+    padding: 5px;
   }
 
   .bspTableEditActive {
-    border:1px solid @color-focus;
-    background-color: #eee;
-    & table {
-      background-color: #eee;
-    }
+    border:1px solid mix(@color-focus, white, 50%);
+    background-color: mix(@color-focus, white, 10%);
   }
 }
 

--- a/tool-ui/src/main/webapp/style/v3/tableEditor.less
+++ b/tool-ui/src/main/webapp/style/v3/tableEditor.less
@@ -26,8 +26,18 @@
   }
 
   .bspTableEditActive {
-    border:1px solid mix(@color-focus, white, 50%);
-    background-color: mix(@color-focus, white, 10%);
+    position: relative;
+
+    &:before {
+      border: 1px solid mix(@color-focus, white, 50%);
+      bottom: -1px;
+      content: '';
+      left: -1px;
+      pointer-events: none;
+      position: absolute;
+      right: -1px;
+      top: -1px;
+    }
   }
 }
 
@@ -41,13 +51,23 @@
   display:none;
   position:absolute;
   width:auto;
-  padding: 0.25em;
-  border:1px solid #aaa;
+  padding: 10px 0;
+  border:1px solid mix(@color-focus, white, 50%);
+  border-top-color: white;
+  margin-top: 1px;
   background-color: #fff;
   white-space:nowrap;
 
   a {
+    color: black;
     display:block;
-    margin: 0.2em;
+    height: 30px;
+    line-height: 30px;
+    padding: 0 15px;
+
+    &:hover {
+      background-color: fade(@color-focus, 10%);
+      text-decoration: none;
+    }
   }
 }


### PR DESCRIPTION
To support nested tables, switch from using handsontable to a custom table editor.

This pull request adds a new TableEditor module that provides the same functionality we were using from handsontable to edit tables: adding/removing table rows/columns, etc.

In addition (unlike handsontable) it supports nested tables: users can click on any table cell to get a popup menu for the appropriate table, even one nested within another.

Also with handsontable we did not have a lot of control over table styling - handsontable would tend to expand table cells beyond the 100% width that we wanted. The new TableEditor lets us use CSS to control the table cell width, so in general the table will attempt to stay within the 100% width of the container element (although there is also a min-width style added to prevent the table cell from shrinking so much that it is unusable).

![table-editor](https://cloud.githubusercontent.com/assets/185461/14791504/235ceadc-0ae4-11e6-8023-d8defcdd63ef.png)
