### PR TITLE
RTE bugfix performance problem with inlineCleanup (BSP-2023)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -1697,6 +1697,17 @@ define([
          * This allows other functions to operate correctly.
          */
         inlineCleanup: function() {
+            var self;
+            
+            self = this;
+
+            // For performance, tell CodeMirror not to update the DOM
+            // until our inlineCleanup() has completed.
+            self.codeMirror.operation(function(){
+                self._inlineCleanup();
+            });
+        },
+        _inlineCleanup: function() {
 
             var doc, editor, marks, marksByClassName, self;
 


### PR DESCRIPTION
For content with a large number of marks, the inlineCleanup() function was causing performance problems. This commit wraps that function within a CodeMirror.operation() to prevent CodeMirror from updating the display until the entire cleanup operation has completed.