### PR TITLE
RTE bugfix placeholder issues (BSP-1976, BSP-1674, BSP-1325)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/content/state.js
+++ b/tool-ui/src/main/webapp/script/v3/content/state.js
@@ -112,7 +112,14 @@ define([ 'jquery', 'bsp-utils' ], function($, bsp_utils) {
                     $element.html(text);
 
                 } else if ($element.is('[data-dynamic-placeholder]')) {
+                    
                     $element.prop('placeholder', text);
+                    
+                    // Trigger a placeholderUpdate event so other code can listen for placeholder changes
+                    // (used by the rich text editor).
+                    // Note: originally called this event 'placeholder' but that caused a jquery error for some reason,
+                    // so using placeholderUpdate instead.
+                    $element.trigger('placeholderUpdate');
                 }
               }
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -4346,6 +4346,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
             self.$container.on('rteChange', $.throttle(500, function(){
                 self.placeholderRefresh();
             }));
+
+            // If data-dynamic-placeholder is used on the textarea
+            // then it triggers a placeholderUpdate event to let us know
+            // when the placeholder changes.
+            // (refer to state.js for more information)
+            self.$el.on('placeholderUpdate', function() {
+                self.placeholderRefresh();
+            });
         },
 
 
@@ -4355,7 +4363,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/plugin/popup', 'jquery.extr
          */
         placeholderRefresh: function() {
             var self = this;
-            var placeholder = self.$el.attr('placeholder');
+            var placeholder = self.$el.prop('placeholder');
 
             if (!placeholder) {
                 return;

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -767,3 +767,7 @@ li.CodeMirror-hint-active {
     -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
   }
 }
+
+.rte2-placeholder-showing .CodeMirror pre {
+  color: @color-placeholder;
+}


### PR DESCRIPTION
When using data-dyanmic-placeholder, the palceholder was not showing on initial load of the RTE (but it would appear after you focus into the RTE). This is because the placeholder is set after the RTE initializes. This commit adds a placeholderUpdate event to the state.js code that sets the dynamic placeholder, so the RTE can listen for this event to know when the placeholder is available.

Also modify placeholder handling so it supports HTML. Previous code used a single-line truncated overlay to display a fake placeholder, and it would display raw HTML. New code actually parses the HTML and places it into the RTE, plus adds other code to ensure that other parts of the code recognize when the placeholder content is in place (to avoid the placeholder HTML being returned as the actual value for the field).