### PR TITLE
BSP-2070: Adds option to hide standard image size from UI.

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/StandardImageSize.java
+++ b/db/src/main/java/com/psddev/cms/db/StandardImageSize.java
@@ -2,6 +2,7 @@ package com.psddev.cms.db;
 
 import com.psddev.dari.db.Record;
 import com.psddev.dari.db.Query;
+import com.psddev.dari.db.State;
 import com.psddev.dari.util.PeriodicValue;
 import com.psddev.dari.util.PullThroughValue;
 
@@ -18,6 +19,8 @@ import org.slf4j.LoggerFactory;
 public class StandardImageSize extends Record {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StandardImageSize.class);
+
+    private static final String HIDDEN_FROM_UI_VALIDATION_ERROR_MESSAGE = "'Independent' and 'Hide From UI' fields cannot be checked at the same time.";
 
     private static final PullThroughValue<PeriodicValue<List<StandardImageSize>>>
             ALL = new PullThroughValue<PeriodicValue<List<StandardImageSize>>>() {
@@ -57,6 +60,10 @@ public class StandardImageSize extends Record {
 
     @ToolUi.Note("Check to prevent this standard image size from merging with others in the image editor.")
     private boolean independent;
+
+    @ToolUi.Note("Check to hide this standard image size from UI.")
+    @DisplayName("Hide From UI")
+    private Boolean hiddenFromUI;
 
     private CropOption cropOption;
     private ResizeOption resizeOption;
@@ -106,6 +113,14 @@ public class StandardImageSize extends Record {
         this.independent = independent;
     }
 
+    public boolean isHiddenFromUI() {
+        return Boolean.TRUE.equals(hiddenFromUI);
+    }
+
+    public void setHiddenFromUI(Boolean hiddenFromUI) {
+        this.hiddenFromUI = hiddenFromUI;
+    }
+
     public CropOption getCropOption() {
         return cropOption;
     }
@@ -120,5 +135,15 @@ public class StandardImageSize extends Record {
 
     public void setResizeOption(ResizeOption resizeOption) {
         this.resizeOption = resizeOption;
+    }
+
+    @Override
+    protected void onValidate() {
+        super.onValidate();
+        if (isIndependent() && isHiddenFromUI()) {
+            State state = getState();
+            state.addError(state.getField("independent"), HIDDEN_FROM_UI_VALIDATION_ERROR_MESSAGE);
+            state.addError(state.getField("hiddenFromUI"), HIDDEN_FROM_UI_VALIDATION_ERROR_MESSAGE);
+        }
     }
 }

--- a/db/src/main/java/com/psddev/cms/tool/file/ImageFileType.java
+++ b/db/src/main/java/com/psddev/cms/tool/file/ImageFileType.java
@@ -339,6 +339,7 @@ public class ImageFileType implements FileContentType {
                                         page.writeStart("tr",
                                                 "data-size-name", page.h(size.getInternalName()),
                                                 "data-size-independent", page.h(size.isIndependent()),
+                                                "data-size-hidden", page.h(size.isHiddenFromUI()),
                                                 "data-size-width", page.h(size.getWidth()),
                                                 "data-size-height", page.h(size.getHeight()));
                                             page.writeStart("th");

--- a/tool-ui/src/main/webapp/script/v3/input/image.js
+++ b/tool-ui/src/main/webapp/script/v3/input/image.js
@@ -1175,20 +1175,22 @@ define([
                 // Loop through all the individual sizes within the group
                 $.each(groupInfo.sizeInfos, function(sizeName, sizeInfo) {
 
-                    // Determine if we need to have a line break before this label.
-                    // addBreak will be undefined on the first loop so we will not add a break,
-                    // but on subsequent loops it will be true.
-                    if (addBreak) {
-                        groupLabel.append('<br/>');
-                    } else {
-                        addBreak = true;
+                    // Skip rendering of size if hiddenFromUi option is selected.
+                    if (!sizeInfo.hiddenFromUi) {
+                        // Determine if we need to have a line break before this label.
+                        // addBreak will be undefined on the first loop so we will not add a break,
+                        // but on subsequent loops it will be true.
+                        if (addBreak) {
+                            groupLabel.append('<br/>');
+                        } else {
+                            addBreak = true;
+                        }
+
+                        $('<span/>', {
+                            title: sizeInfo.description + ' (' + sizeInfo.width + ' x ' + sizeInfo.height + ')',
+                            html: sizeInfo.description
+                        }).appendTo(groupLabel);
                     }
-
-                    $('<span/>', {
-                        title: sizeInfo.description + ' (' + sizeInfo.width + ' x ' + sizeInfo.height + ')',
-                        html: sizeInfo.description
-                    }).appendTo(groupLabel);
-
                 });
 
                 // Create the preview image for the group
@@ -1354,7 +1356,7 @@ define([
             // From there we can get to the other information about the size.
             self.dom.$sizesTable.find('th').each(function(){
 
-                var group, independent, inputs, sizeAspectRatio, sizeAspectRatioApproximate,
+                var group, hiddenFromUi, independent, inputs, sizeAspectRatio, sizeAspectRatioApproximate,
                     sizeDescription, sizeHeight, sizeInfo, sizeName, sizeWidth, sizes, $source, $th, $tr;
 
                 $th = $(this);
@@ -1362,6 +1364,7 @@ define([
                 sizeName = $tr.attr('data-size-name');
                 sizeDescription = $th.text();
                 independent = $tr.attr('data-size-independent') === 'true';
+                hiddenFromUi = $tr.attr('data-size-hidden') === 'true';
                 sizeWidth = parseFloat($tr.attr('data-size-width'));
                 sizeHeight = parseFloat($tr.attr('data-size-height'));
                 sizeAspectRatio = sizeWidth / sizeHeight;
@@ -1400,6 +1403,7 @@ define([
                     description: sizeDescription,
                     inputs: inputs,
                     independent: independent,
+                    hiddenFromUi: hiddenFromUi,
                     width: sizeWidth,
                     height: sizeHeight,
                     aspectRatio: sizeAspectRatio

--- a/tool-ui/src/main/webapp/script/v3/input/image2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/image2.js
@@ -1176,20 +1176,22 @@ define([
                 // Loop through all the individual sizes within the group
                 $.each(groupInfo.sizeInfos, function(sizeName, sizeInfo) {
 
-                    // Determine if we need to have a line break before this label.
-                    // addBreak will be undefined on the first loop so we will not add a break,
-                    // but on subsequent loops it will be true.
-                    if (addBreak) {
-                        groupLabel.append('<br/>');
-                    } else {
-                        addBreak = true;
+                    // Skip rendering of size if hiddenFromUi option is selected.
+                    if (!sizeInfo.hiddenFromUi) {
+                        // Determine if we need to have a line break before this label.
+                        // addBreak will be undefined on the first loop so we will not add a break,
+                        // but on subsequent loops it will be true.
+                        if (addBreak) {
+                            groupLabel.append('<br/>');
+                        } else {
+                            addBreak = true;
+                        }
+
+                        $('<span/>', {
+                            title: sizeInfo.description + ' (' + sizeInfo.width + ' x ' + sizeInfo.height + ')',
+                            html: sizeInfo.description
+                        }).appendTo(groupLabel);
                     }
-
-                    $('<span/>', {
-                        title: sizeInfo.description + ' (' + sizeInfo.width + ' x ' + sizeInfo.height + ')',
-                        html: sizeInfo.description
-                    }).appendTo(groupLabel);
-
                 });
 
                 // Create the preview image for the group
@@ -1355,7 +1357,7 @@ define([
             // From there we can get to the other information about the size.
             self.dom.$sizesTable.find('th').each(function(){
                 
-                var group, independent, inputs, sizeAspectRatio, sizeAspectRatioApproximate,
+                var group, hiddenFromUi, independent, inputs, sizeAspectRatio, sizeAspectRatioApproximate,
                     sizeDescription, sizeHeight, sizeInfo, sizeName, sizeWidth, sizes, $source, $th, $tr;
 
                 $th = $(this);
@@ -1363,6 +1365,7 @@ define([
                 sizeName = $tr.attr('data-size-name');
                 sizeDescription = $th.text();
                 independent = $tr.attr('data-size-independent') === 'true';
+                hiddenFromUi = $tr.attr('data-size-hidden') === 'true';
                 sizeWidth = parseFloat($tr.attr('data-size-width'));
                 sizeHeight = parseFloat($tr.attr('data-size-height'));
                 sizeAspectRatio = sizeWidth / sizeHeight;
@@ -1422,6 +1425,7 @@ define([
                     description: sizeDescription,
                     inputs: inputs,
                     independent: independent,
+                    hiddenFromUi: hiddenFromUi,
                     width: sizeWidth,
                     height: sizeHeight,
                     aspectRatio: sizeAspectRatio,


### PR DESCRIPTION

![screen shot 2016-05-10 at 6 21 00 pm](https://cloud.githubusercontent.com/assets/1467624/15164305/029f66b8-16dc-11e6-87c0-23b7e7e25238.png)

This will hide unnecessary image sizes from UI. 
![screen shot 2016-05-10 at 6 12 23 pm](https://cloud.githubusercontent.com/assets/1467624/15164270/bff2f834-16db-11e6-98ab-459072640698.png)
![screen shot 2016-05-10 at 6 14 57 pm](https://cloud.githubusercontent.com/assets/1467624/15164271/c39c7230-16db-11e6-947e-65cec6344a26.png)
