### PR TITLE
RTE bugfix for font ligatures and cursor position (BSP-2119)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -454,6 +454,10 @@ li.CodeMirror-hint-active {
     overflow: visible;
     z-index: inherit;
   }
+  .CodeMirror pre {
+    // Solve problem of certain font-ligatures like "fi" from messing up CodeMirror cursor positions
+    font-variant-ligatures: no-common-ligatures;
+  }
 }
 
 .rte-fullscreen {


### PR DESCRIPTION
Chrome browser must have recently added support for font ligatures, which combines certain characters like "fi" so they will display nicer. This messes up the CodeMirror cursor position logic. This commit adds a CSS rule to turn off ligatures within CodeMirror.