### PR TITLE
Prevent font ligatures messing up cursor positions (BSP-2119)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/index.less
+++ b/tool-ui/src/main/webapp/style/v3/index.less
@@ -14,6 +14,11 @@
 @import 'element.less';
 @import 'reset.less';
 
+* {
+  // Solve problem of certain font-ligatures like "fi" from messing up cursor positions in input fields
+  font-variant-ligatures: no-common-ligatures !important;
+}
+
 .repeatableForm > ol > li > .inputLabel > .inputSmall,
 .repeatableForm > ul > li > .inputLabel > .inputSmall {
   display: inline-block;


### PR DESCRIPTION
In input fields and rich text editor, font ligatures for certain character combinations like "fi" were messing up the cursor movement. This commit turns off all common font ligatures.