### PR TITLE
RTE javascript lint and cleanup

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1,9 +1,10 @@
 /* jshint undef: true, unused: true, browser: true, jquery: true, devel: true */
-/* global define */
+/* global clearTimeout define document RICH_TEXT_ELEMENTS setTimeout window */
 
 define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plugin/popup', 'jquery.extra', 'jquery.handsontable.full'], function($, CodeMirrorRte, tableEditor) {
 
-    var CONTEXT_PATH, Rte;
+    var CONTEXT_PATH;
+    var Rte;
 
     // Global variable set by the CMS, typically "/cms/"
     CONTEXT_PATH = window.CONTEXT_PATH || '';
@@ -112,7 +113,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 // Text to display in a dropdown when cursor moves over this style
                 dropdown: function(mark) {
 
-                    var date, user, time, label;
+                    var date;
+                    var user;
+                    var time;
+                    var label;
 
                     label = '';
                     
@@ -128,7 +132,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                             try {
                                 // Just in case older browser doesn't support toLocale functions catch the error
                                 label += ': ' + date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
-                            } catch (e) {}
+                            } catch (e) {
+                                // continue regardless of error
+                            }
                         }
                     }
                     
@@ -307,7 +313,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     // MSWord 'p' elements should be treated as a new line
                     // Special case if 'p' element contains only whitespace remove the whitespace
                     'p[class^=Mso]': function($el) {
-                        var $replacement, t;
+                        var $replacement;
+                        var t;
                         t = $el.text() || '';
                         if (t.match(/^\s*$/)) {
                             $el.text('');
@@ -646,7 +653,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         initStylesCustom: function() {
 
-            var stylesCustom, self;
+            var stylesCustom;
+            var self;
 
             self = this;
 
@@ -661,7 +669,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                 $.each(window.CSS_CLASS_GROUPS, function() {
 
-                    var group, groupName;
+                    var group;
+                    var groupName;
 
                     group = this;
                     groupName = 'cms-' + group.internalName;
@@ -669,7 +678,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     // Loop through all the styles in this group
                     $.each(group.cssClasses, function() {
 
-                        var classConfig, cmsClassName, styleDef;
+                        var classConfig;
+                        var cmsClassName;
+                        var styleDef;
 
                         classConfig = this;
 
@@ -725,7 +736,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         initRte: function() {
 
-            var content, self;
+            var content;
+            var self;
 
             self = this;
 
@@ -834,8 +846,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * Load the custom CMS styles onto the page if they are not already present.
          */
         loadCMSStyles: function() {
-            var self;
-            self = this;
 
             // Check the private variable customStylesLoaded to determine if the styles have already been loaded
             // If there are multiple rich text editors on the page we only want to load the styles once
@@ -971,7 +981,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         trackChangesSave: function() {
             
-            var name, self, state;
+            var name;
+            var self;
+            var state;
 
             self = this;
 
@@ -995,7 +1007,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         trackChangesRestore: function() {
             
-            var name, self;
+            var name;
+            var self;
 
             self = this;
 
@@ -1014,7 +1027,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         trackChangesGetName: function() {
             
-            var name, self;
+            var name;
+            var self;
             
             self = this;
             
@@ -1034,7 +1048,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
         toolbarInit: function() {
 
-            var self, $toolbar;
+            var self;
+            var $toolbar;
 
             self = this;
 
@@ -1137,7 +1152,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             $.each(window.CSS_CLASS_GROUPS, function() {
 
-                var group, groupName, $submenu;
+                var group;
+                var groupName;
+                var $submenu;
 
                 group = this;
                 groupName = 'cms-' + group.internalName;
@@ -1151,7 +1168,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 // Loop through all the styles in this group
                 $.each(group.cssClasses, function() {
 
-                    var classConfig, cmsClassName, toolbarItem;
+                    var classConfig;
+                    var cmsClassName;
+                    var toolbarItem;
 
                     classConfig = this;
 
@@ -1351,7 +1370,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         toolbarHandleClick: function(item, event) {
 
-            var $button, mark, marks, rte, self, styleObj, value;
+            var $button;
+            var mark;
+            var marks;
+            var rte;
+            var self;
+            var styleObj;
+            var value;
 
             self = this;
 
@@ -1455,7 +1480,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     rte.focus();
                     rte.find();
                     return; // return so we don't run rte.focus() again
-                    break;
 
                 case 'replace':
                     rte.focus();
@@ -1548,7 +1572,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         toolbarUpdate: function() {
 
-            var contextArray, $links, mode, rte, self, styles;
+            var context;
+            var $links;
+            var mode;
+            var rte;
+            var self;
+            var styles;
 
             self = this;
             rte = self.rte;
@@ -1579,7 +1608,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // Go through each link in the toolbar and see if the style is defined
             $links.each(function(){
 
-                var activeElements, allRoot, config, $link, makeActive, styleObj;
+                var config;
+                var $link;
+                var makeActive;
+                var styleObj;
 
                 $link = $(this);
 
@@ -1856,7 +1888,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         linkEdit: function(attributes) {
 
-            var deferred, $linkDialog, $href, self;
+            var deferred;
+            var $linkDialog;
+            var $href;
+            var self;
 
             self = this;
 
@@ -1891,8 +1926,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         linkSave: function() {
 
-            var attributes, $linkDialog, self;
-            var href, rel, target, title, cmsId;
+            var $linkDialog;
+            var attributes;
+            var cmsId;
+            var href;
+            var rel;
+            var self;
+            var target;
 
             self = this;
 
@@ -2008,7 +2048,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // somebody else deal with it.
             $(document.body).on('click', '[data-enhancement]', function(event) {
 
-                var data, $enhancement, $popupTrigger, $target;
+                var data;
+                var $enhancement;
+                var $popupTrigger;
+                var $target;
 
                 // The enhancement link that the user clicked
                 $target = $(this);
@@ -2053,7 +2096,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // so we can update the enhancement display (or remove the enhancement)
             $(document.body).on('close', '.popup[name^="contentEnhancement-"]', function() {
 
-                var $enhancement, $popupTrigger, $popup;
+                var $enhancement;
+                var $popupTrigger;
+                var $popup;
 
                 // The popup that was closed
                 $popup = $(this);
@@ -2099,7 +2144,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementCreate: function(config, line) {
 
-            var $enhancement, mark, self;
+            var $enhancement;
+            var self;
 
             self = this;
 
@@ -2131,7 +2177,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             $('<div/>', {'class': 'rte2-enhancement-label' }).appendTo($enhancement);
 
             // Add the enhancement to the editor
-            mark = self.rte.enhancementAdd($enhancement[0], line, {
+            self.rte.enhancementAdd($enhancement[0], line, {
                 block:true,
                 // Set up a custom "toHTML" function so the editor can output the enhancement
                 toHTML:function(){
@@ -2166,7 +2212,16 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementUpdate: function(el) {
 
-            var $content, $options, optionsUrl, $edit, editUrl, $enhancement, emptyText, reference, $select, self;
+            var $content;
+            var $edit;
+            var $enhancement;
+            var $options;
+            var $select;
+            var editUrl;
+            var emptyText;
+            var optionsUrl;
+            var reference;
+            var self;
 
             self = this;
             $enhancement = self.enhancementGetWrapper(el);
@@ -2241,7 +2296,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementToolbarCreate: function(config) {
 
-            var formAction, formId, formTypeId, self, sizes, $sizesSubmenu, $toolbar;
+            var formAction;
+            var formId;
+            var formTypeId;
+            var self;
+            var sizes;
+            var $toolbar;
 
             self = this;
 
@@ -2335,7 +2395,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 className: 'rte2-enhancement-toolbar-change',
                 href: CONTEXT_PATH + (config.marker ? '/content/marker.jsp' : '/enhancementSelect') +
                     '?pt=' + encodeURIComponent(formId) + '&py=' + encodeURIComponent(formTypeId),
-                target: self.enhancementGetTarget(),
+                target: self.enhancementGetTarget()
             }, $toolbar);
 
             // Add the "Edit" button for an enhancement but not for a marker
@@ -2406,7 +2466,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementToolbarAddSubmenu: function(item, $addToSubmenu) {
 
-            var self = this;
             var $submenu;
 
             $submenu = $('<li class="rte2-toolbar-submenu"><span></span><ul></ul></li>');
@@ -2432,7 +2491,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementToolbarAddButton: function(item, $submenu) {
 
-            var self = this;
             var $button;
 
             // This is a toolbar button
@@ -2483,8 +2541,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementToolbarAddSeparator: function($submenu) {
 
-            var self = this;
-
             $('<li/>', {
                 'class': 'rte2-toolbar-separator',
                 html: '&nbsp;'
@@ -2512,7 +2568,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         enhancementRemove: function (el) {
-            var $el, self;
+            var $el;
+            var self;
             self = this;
             $el = self.enhancementGetWrapper(el);
             $el.addClass('toBeRemoved');
@@ -2523,7 +2580,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         enhancementRemoveCompletely: function (el) {
-            var mark, self;
+            var mark;
+            var self;
             self = this;
             mark = self.enhancementGetMark(el);
             if (mark) {
@@ -2536,7 +2594,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         enhancementRestore: function (el) {
-            var $el, self;
+            var $el;
+            var self;
             self = this;
             $el = self.enhancementGetWrapper(el);
             $el.removeClass('toBeRemoved');
@@ -2547,7 +2606,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         enhancementIsToBeRemoved: function(el) {
-            var $el, self;
+            var $el;
+            var self;
             self = this;
             $el = self.enhancementGetWrapper(el);
             return $el.hasClass('toBeRemoved');
@@ -2556,7 +2616,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
         enhancementMove: function(el, direction) {
 
-            var $el, doScroll, mark, self, $popup, topNew, topOriginal, topWindow;
+            var $el;
+            var doScroll;
+            var mark;
+            var self;
+            var $popup;
+            var topNew;
+            var topOriginal;
+            var topWindow;
 
             self = this;
 
@@ -2594,7 +2661,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * Set the editor cursor to the same line that contains the enhancement.
          */
         enhancementSetCursor: function(el) {
-            var line, mark, self;
+            var line;
+            var mark;
+            var self;
 
             self = this;
             
@@ -2621,7 +2690,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementSetPosition: function(el, type) {
 
-            var $el, mark, rte, self;
+            var $el;
+            var mark;
+            var rte;
+            var self;
 
             self = this;
             rte = self.rte;
@@ -2663,7 +2735,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementGetPosition: function(el) {
 
-            var $el, pos, self;
+            var $el;
+            var pos;
+            var self;
 
             self = this;
             $el = self.enhancementGetWrapper(el);
@@ -2686,8 +2760,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The enhancement element, or an element within the enhancement.
          */
         enhancementGetWrapper: function(el) {
-            var self;
-            self = this;
             return $(el).closest('.rte2-enhancement');
         },
 
@@ -2774,7 +2846,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementGetSizes: function() {
 
-            var gotSize, self, sizes, sizesInputContainer, sizesGlobal;
+            var gotSize;
+            var self;
+            var sizes;
+            var sizesInputContainer;
+            var sizesGlobal;
 
             self = this;
 
@@ -2813,11 +2889,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementSetSize: function(el, size) {
 
-            var $enhancement, reference, self, sizes;
+            var reference;
+            var self;
+            var sizes;
 
             self = this;
-
-            $enhancement = self.enhancementGetWrapper(el);
 
             reference = self.enhancementGetReference(el);
 
@@ -2842,7 +2918,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementDisplaySize: function(el) {
 
-            var $enhancement, $label, reference, self, sizes, sizeDisplayName, $sizeLabel;
+            var $enhancement;
+            var $label;
+            var reference;
+            var self;
+            var sizes;
+            var sizeDisplayName;
+            var $sizeLabel;
 
             self = this;
             $enhancement = self.enhancementGetWrapper(el);
@@ -2885,7 +2967,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementPopupSizesCreate: function(el) {
             
-            var $el, $popup, self, sizes;
+            var $el;
+            var $popup;
+            var self;
+            var sizes;
 
             self = this;
             $el = $(el);
@@ -2896,7 +2981,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if (!$popup) {
                 
                 $popup = $('<ul/>', {
-                    'class': 'rte2-enhancement-sizes-popup',
+                    'class': 'rte2-enhancement-sizes-popup'
                 }).hover(function(event){
                     self.enhancementPopupSizesShowDelayed($el);
                 }, function(event) {
@@ -2940,7 +3025,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementPopupSizesShowDelayed: function(el) {
             
-            var timeout, self;
+            var timeout;
+            var self;
 
             self = this;
             
@@ -2962,7 +3048,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementPopupSizesShow: function(el) {
 
-            var $popup, offset, self;
+            var $popup;
+            var offset;
+            var self;
 
             self = this;
 
@@ -2984,7 +3072,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementPopupSizesHideDelayed: function(el) {
             
-            var timeout, self;
+            var timeout;
+            var self;
 
             self = this;
             
@@ -3004,7 +3093,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The image sizes button inside the enhancement element.
          */
         enhancementPopupSizesHide: function(el) {
-            var $popup, self;
+            var $popup;
+            var self;
             self = this;
             $popup = self.enhancementPopupSizesCreate(el);
             $popup.hide();
@@ -3018,7 +3108,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementGetReference: function(el) {
 
-            var $enhancement, reference, self;
+            var $enhancement;
+            var reference;
+            var self;
 
             self = this;
 
@@ -3035,7 +3127,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementSetReference: function(el, reference) {
 
-            var $enhancement, self;
+            var $enhancement;
+            var self;
 
             self = this;
 
@@ -3058,7 +3151,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         enhancementToHTML: function(el) {
 
-            var alignment, reference, $enhancement, html, $html, id, isMarker, self;
+            var alignment;
+            var reference;
+            var $enhancement;
+            var html;
+            var $html;
+            var id;
+            var isMarker;
+            var self;
 
             self = this;
 
@@ -3187,11 +3287,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
         
         inlineEnhancementCreate: function(event, style) {
 
-            var mark, self, styleObj;
+            var mark;
+            var self;
             
             self = this;
-
-            styleObj = self.rte.styles[style] || {};
             
             // Create a new mark then call the onclick function on it
             mark = self.rte.setStyle(style);
@@ -3203,7 +3302,16 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
         inlineEnhancementHandleClick: function(event, mark) {
 
-            var enhancementEditUrl, $div, $divForm, frameName, html, offset, offsetContainer, range, self, styleObj;
+            var $div;
+            var $divForm;
+            var enhancementEditUrl;
+            var frameName;
+            var html;
+            var offset;
+            var offsetContainer;
+            var range;
+            var self;
+            var styleObj;
 
             self = this;
 
@@ -3345,7 +3453,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         inlineEnhancementReplaceMark: function(mark, html) {
             
-            var range, self;
+            var range;
+            var self;
 
             self = this;
             
@@ -3400,7 +3509,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableCreate: function($content, line) {
             
-            var $div, mark, $placeholder, self, tEdit;
+            var $div;
+            var $placeholder;
+            var self;
+            var tEdit;
+            
             self = this;
 
             // Get the line number where the table should be added
@@ -3472,11 +3585,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             $placeholder.data('tableEditor', tEdit);
             
             // Add the div to the editor
-            mark = self.rte.enhancementAdd($div[0], line, {
+            self.rte.enhancementAdd($div[0], line, {
                 block:true,
                 // Set up a custom "toHTML" function so the editor can output the enhancement
                 toHTML:function(){
-                    var $table, html;
+                    var $table;
+                    var html;
                     if (self.tableIsToBeRemoved($div)) {
                         html = '';
                     } else {
@@ -3501,12 +3615,16 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * HTML for the table.
          */
         tableToHtml: function(table) {
-            var html, self, $table;
+            var html;
+            var self;
+            var $table;
+            
             self = this;
             $table = $(table);
 
             $table.find('tr,td,th').add($table).each(function() {
-                var $el, mark;
+                var $el;
+                var mark;
                 $el = $(this);
 
                 // Retrieve the mark for the table/tr/td/th element
@@ -3524,7 +3642,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * Replace the attributes on an element with a new set of attributes.
          */
         replaceAttributes: function(el, attributes) {
-            var $el, original, self;
+            var $el;
+            var original;
+            var self;
+            
             self = this;
             $el = $(el);
             original = self.rte.getAttributes($el);
@@ -3542,7 +3663,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableToolbarCreate: function() {
 
-            var  self, $toolbar;
+            var  self;
+            var $toolbar;
 
             self = this;
 
@@ -3605,7 +3727,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableMove: function(el, direction) {
 
-            var $el, mark, self, topNew, topOriginal, topWindow;
+            var $el;
+            var mark;
+            var self;
+            var topNew;
+            var topOriginal;
+            var topWindow;
             
             self = this;
 
@@ -3636,7 +3763,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * 
          */
         tableRemove: function (el) {
-            var $el, self;
+            var $el;
+            var self;
             self = this;
             $el = self.tableGetWrapper(el);
             $el.addClass('toBeRemoved');
@@ -3648,7 +3776,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * 
          */
         tableRemoveCompletely: function (el) {
-            var mark, self;
+            var mark;
+            var self;
             self = this;
             mark = self.tableGetMark(el);
             if (mark) {
@@ -3661,7 +3790,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * 
          */
         tableRestore: function (el) {
-            var $el, self;
+            var $el;
+            var self;
             self = this;
             $el = self.tableGetWrapper(el);
             $el.removeClass('toBeRemoved');
@@ -3673,7 +3803,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * 
          */
         tableIsToBeRemoved: function(el) {
-            var $el, self;
+            var $el;
+            var self;
             self = this;
             $el = self.tableGetWrapper(el);
             return $el.hasClass('toBeRemoved');
@@ -3687,8 +3818,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The enhancement element, or an element within the enhancement.
          */
         tableGetWrapper: function(el) {
-            var self;
-            self = this;
             return $(el).closest('.rte2-table');
         },
 
@@ -3713,7 +3842,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableEditInit: function() {
             
-            var $controls, self;
+            var $controls;
+            var self;
 
             self = this;
 
@@ -3775,7 +3905,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableEditSelection: function($el) {
 
-            var self, value;
+            var self;
+            var value;
 
             self = this;
             
@@ -3823,10 +3954,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableEditAttrTable: function(el) {
             
-            var $el, mark, self;
+            var mark;
+            var self;
             
             self = this;
-            $el = $(el);
 
             // Make sure there is backend style that is meant for editing the table
             if (!self.tableStyleTable) { return; }
@@ -3849,10 +3980,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableEditAttrRow: function(el) {
             
-            var $el, mark, self;
+            var mark;
+            var self;
             
             self = this;
-            $el = $(el);
 
             // Make sure there is backend style that is meant for editing the table
             if (!self.tableStyleRow) { return; }
@@ -3874,10 +4005,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableEditAttrCell: function(el) {
             
-            var $el, mark, rangeTable, self;
+            var mark;
+            var self;
             
             self = this;
-            $el = $(el);
 
             // Make sure there is backend style that is meant for editing the table
             if (!self.tableStyleCell) { return; }
@@ -3908,7 +4039,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         tableMarkCreate: function(el, extraAttributes, markParameters) {
             
-            var attributes, mark, self;
+            var attributes;
+            var mark;
+            var self;
             
             self = this;
 
@@ -3925,7 +4058,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     // which is not a good representation of where we want the
                     // popup to appear, but that is all that is supported
                     // by inline enhancement right now
-                    var tableMark, line;
+                    var line;
+                    var tableMark;
                     tableMark =  self.tableGetMark(el);
                     if (tableMark) {
                         line = tableMark.line.lineNo();
@@ -3958,8 +4092,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The fake CodeMirror mark for the table element.
          */
         tableMarkSet: function(el, mark) {
-            var self;
-            self = this;
             $(el).data('markTable', mark);
         },
 
@@ -3978,7 +4110,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The fake CodeMirror mark for the table element, or undefined if none is defined.
          */
         tableMarkGet: function(el, create) {
-            var mark, self;
+            var mark;
+            var self;
             self = this;
 
             // Get the mark from a data attribute if it was previously created
@@ -4053,14 +4186,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         placeholderRefresh: function() {
 
-            var count, $editor, placeholder, placeholderIsShowing, self, showPlaceholder;
+            var count;
+            var placeholderIsShowing;
+            var self;
+            var showPlaceholder;
             
             self = this;
-            $editor = self.$editor;
             
-            // Get placeholder content from the textarea
-            placeholder = self.$el.prop('placeholder');
-
             placeholderIsShowing = self.placeholderIsShowing();
             
             // Determine if we should display the placeholder
@@ -4103,7 +4235,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         placeholderShow: function() {
             
-            var placeholder, self;
+            var placeholder;
+            var self;
             
             self = this;
 
@@ -4177,7 +4310,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         previewUpdate: function() {
             
-            var html, self, val;
+            var html;
+            var self;
+            var val;
             
             self = this;
 
@@ -4213,7 +4348,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         toHTML: function() {
-            var html, self;
+            var html;
+            var self;
             self = this;
             if (self.rte.modeGet() === 'rich') {
                 if (self.placeholderIsShowing()) {
@@ -4228,7 +4364,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
         },
 
         toText: function() {
-            var self, text;
+            var self;
+            var text;
             self = this;
             text = self.rte.toText();
             return text;
@@ -4297,7 +4434,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
         _create: function(input) {
 
-            var inline, $input, options, rte;
+            var inline;
+            var $input;
+            var options;
+            var rte;
 
             $input = $(input);
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -1,3 +1,5 @@
+/* global define DOMParser navigator setTimeout window */
+
 define([
     'jquery',
     'bsp-utils',
@@ -319,6 +321,7 @@ define([
          */
         init: function(element, options) {
 
+            var codeMirrorOptions;
             var self;
 
             self = this;
@@ -383,7 +386,14 @@ define([
          */
         initListListeners: function() {
 
-            var editor, isFirstListItem, isLastListItem, isEmptyLine, listType, rangeFirstLine, self;
+            var editor;
+            var isEmptyLine;
+            var isFirstListItem;
+            var isLastListItem;
+            var isStartOfLine;
+            var listType;
+            var rangeFirstLine;
+            var self;
 
             self = this;
             
@@ -393,7 +403,9 @@ define([
             // about lists, to later use in the "change" event
             editor.on('beforeChange', function(instance, changeObj) {
 
-                var listTypePrevious, listTypeNext, rangeBeforeChange;
+                var listTypePrevious;
+                var listTypeNext;
+                var rangeBeforeChange;
 
                 // Get the listType and set the closure variable for later use
                 listType = self.blockGetListType(changeObj.from.line);
@@ -484,7 +496,8 @@ define([
          */
         initEvents: function() {
             
-            var editor, self;
+            var editor;
+            var self;
 
             self = this;
             
@@ -553,7 +566,9 @@ define([
          */
         toggleStyle: function(style, range) {
             
-            var mark, self, styleObj;
+            var mark;
+            var self;
+            var styleObj;
 
             self = this;
             
@@ -584,7 +599,9 @@ define([
          */
         setStyle: function(style, range) {
             
-            var mark, self, styleObj;
+            var mark;
+            var self;
+            var styleObj;
 
             self = this;
             
@@ -661,7 +678,13 @@ define([
             // Example: what if you have xxx<B>xxx<I>RRR</I>xxx</B>xxx
             // Then the context should be considered to be [I]
             
-            var blockStyles, context, contextArray, contextMarks, contextNull, editor, foundBlockStyle, lineNumber, self;
+            var blockStyles;
+            var context;
+            var contextNull;
+            var editor;
+            var foundBlockStyle;
+            var lineNumber;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -674,12 +697,16 @@ define([
             // Loop through all lines in the range
             editor.eachLine(range.from.line, range.to.line + 1, function(line) {
 
-                var charFrom, charTo, isRange, marks, rightmostMark, rightmostPos, styleObj;
+                var charFrom;
+                var charNumber;
+                var charTo;
+                var marks;
+                var rightmostMark;
+                var rightmostPos;
+                var styleObj;
                 
                 charFrom = (lineNumber === range.from.line) ? range.from.ch : 0;
                 charTo = (lineNumber === range.to.line) ? range.to.ch : line.text.length;
-
-                isRange = Boolean(charFrom !== charTo);
                 
                 // Loop through each character in the line
                 for (charNumber = charFrom; charNumber <= charTo; charNumber++) {
@@ -693,7 +720,9 @@ define([
                     // Find the mark with the rightmost starting character
                     marks.forEach(function(mark){
                         
-                        var isRightmost, markPosition, pos, styleObj;
+                        var isRightmost;
+                        var pos;
+                        var styleObj;
                         
                         if (!mark.className) {
                             return;
@@ -818,7 +847,8 @@ define([
          */
         inlineToggleStyle: function(styleKey, range) {
 
-            var mark, self;
+            var mark;
+            var self;
 
             self = this;
 
@@ -853,7 +883,14 @@ define([
          */
         inlineSetStyle: function(style, range, options) {
             
-            var className, editor, isEmpty, line, mark, markOptions, self, styleObj, $widget, widgetOptions;
+            var className;
+            var editor;
+            var isEmpty;
+            var line;
+            var mark;
+            var markOptions;
+            var self;
+            var styleObj;
 
             self = this;
 
@@ -980,7 +1017,14 @@ define([
          */
         inlineRemoveStyle: function(styleKey, range, options) {
 
-            var className, deleteText, editor, lineNumber, self, from, to, triggerChange;
+            var className;
+            var deleteText;
+            var editor;
+            var from;
+            var lineNumber;
+            var self;
+            var to;
+            var triggerChange;
 
             self = this;
 
@@ -1006,7 +1050,10 @@ define([
 
             editor.eachLine(from.line, to.line + 1, function(line) {
 
-                var fromCh, toCh, marks, newMark;
+                var fromCh;
+                var marks;
+                var newMark;
+                var toCh;
 
                 // Get the character ranges to search within this line.
                 // If we're not on the first line, start at the beginning of the line.
@@ -1018,7 +1065,15 @@ define([
                 marks = line.markedSpans || [];
                 marks.slice(0).reverse().forEach(function(mark) {
 
-                    var from, markerOpts, markerOptsNotInclusive, matchesClass, outsideOfSelection, selectionStartsBefore, selectionEndsAfter, styleObj, to;
+                    var from;
+                    var markerOpts;
+                    var markerOptsNotInclusive;
+                    var matchesClass;
+                    var outsideOfSelection;
+                    var selectionEndsAfter;
+                    var selectionStartsBefore;
+                    var styleObj;
+                    var to;
                     
                     // Check if we should remove the class
                     matchesClass = false;
@@ -1255,7 +1310,8 @@ define([
          */
         inlineMakeInclusive: function() {
 
-            var marks, self;
+            var marks;
+            var self;
 
             self = this;
 
@@ -1312,7 +1368,9 @@ define([
          */
         inlineRemoveStyledText: function(styleKey, range) {
             
-            var mark, pos, self, styles;
+            var mark;
+            var pos;
+            var self;
 
             self = this;
             
@@ -1346,13 +1404,11 @@ define([
          */
         inlineIsStyle: function(styleKey, range) {
             
-            var classes, className, self, styles;
+            var self;
+            var styles;
 
             self = this;
-
-            // Check if className is a key into our styles object
-            className = self.styles[styleKey].className;
-            
+        
             range = range || self.getRange();
 
             styles = self.inlineGetStyles(range);
@@ -1370,7 +1426,10 @@ define([
          */
         inlineGetMark: function(styleKey, range) {
 
-            var className, editor, matchingMark, self;
+            var className;
+            var editor;
+            var matchingMark;
+            var self;
 
             self = this;
 
@@ -1406,7 +1465,9 @@ define([
          */
         inlineHasStyle: function(styleKey, range) {
             
-            var self, styles, value;
+            var self;
+            var styles;
+            var value;
 
             self = this;
 
@@ -1439,7 +1500,11 @@ define([
          */
         inlineGetStyles: function(range) {
             
-            var classes, classMap, isClass, editor, lineNumber, self, styles, lineStarting;
+            var classes;
+            var editor;
+            var lineNumber;
+            var self;
+            var styles;
 
             self = this;
             editor = self.codeMirror;
@@ -1449,11 +1514,12 @@ define([
             styles = {};
             classes = {};
             
-            isClass = true;
-
             editor.eachLine(range.from.line, range.to.line + 1, function(line) {
 
-                var charTo, charNumber, charFrom, once, isRange;
+                var charTo;
+                var charNumber;
+                var charFrom;
+                var isRange;
                 
                 charFrom = (lineNumber === range.from.line) ? range.from.ch : 0;
                 charTo = (lineNumber === range.to.line) ? range.to.ch : line.text.length;
@@ -1463,7 +1529,8 @@ define([
                 // Loop through each character in the range
                 for (charNumber = charFrom; charNumber <= charTo; charNumber++) {
 
-                    var classesForChar, marks;
+                    var classesForChar;
+                    var marks;
                     
                     classesForChar = {};
 
@@ -1472,7 +1539,8 @@ define([
 
                     marks.forEach(function(mark) {
                         
-                        var isSingleChar, markPosition;
+                        var isSingleChar;
+                        var markPosition;
                         
                         if (mark.className) {
 
@@ -1557,7 +1625,7 @@ define([
             // but we really want the abstracted style names (like 'bold').
             // Convert the class name into the style name.
             $.each(classes, function(className, value) {
-                var styleKey, styleObj;
+                var styleObj;
                 styleObj = self.classes[className];
                 if (styleObj) {
                     styles[styleObj.key] = value;
@@ -1574,7 +1642,11 @@ define([
          */
         inlineCollapse: function(styleKey, range) {
 
-            var className, editor, marks, marksCollapsed, self;
+            var className;
+            var editor;
+            var marks;
+            var marksCollapsed;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -1606,7 +1678,10 @@ define([
 
             $.each(marks, function(i, mark) {
 
-                var markCollapsed, markPosition, $widget, widgetOptions;
+                var markCollapsed;
+                var markPosition;
+                var $widget;
+                var widgetOptions;
                 
                 // Check if this mark was previously collapsed
                 // (because we saved the collapse mark as a parameter on the original mark)
@@ -1658,13 +1733,11 @@ define([
          */
         inlineUncollapse: function(styleKey, range) {
 
-            var className, editor, self;
+            var editor;
+            var self;
 
             self = this;
             editor = self.codeMirror;
-
-            // Check if className is a key into our styles object
-            className = self.styles[styleKey].className;
             
             range = range || self.getRange();
 
@@ -1683,7 +1756,12 @@ define([
          */
         inlineToggleCollapse: function(styleKey, range) {
 
-            var className, editor, foundUncollapsed, marks, marksCollapsed, self;
+            var className;
+            var editor;
+            var foundUncollapsed;
+            var marks;
+            var marksCollapsed;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -1715,7 +1793,7 @@ define([
 
             $.each(marks, function(i, mark) {
 
-                var markCollapsed, markPosition, $widget, widgetOptions;
+                var markCollapsed;
                 
                 // Check if this mark was previously collapsed
                 // (because we saved the collapse mark as a parameter on the original mark)
@@ -1759,11 +1837,11 @@ define([
         },
         _inlineCleanup: function() {
 
-            var doc, editor, marks, marksByClassName, self;
+            var editor;
+            var self;
 
             self = this;
             editor = self.codeMirror;
-            doc = editor.getDoc();
 
             // Loop through all the marks in the document,
             // find the ones that span across lines and split them
@@ -1780,14 +1858,19 @@ define([
          */
         rawCleanup: function() {
             
-            var editor, self;
+            var editor;
+            var self;
 
             self = this;
             editor = self.codeMirror;
             
             $.each(editor.getAllMarks(), function(i, mark) {
 
-                var pos, styleObj, from, to, marks;
+                var from;
+                var marks;
+                var pos;
+                var styleObj;
+                var to;
                 
                 // Is this a "raw" mark?
                 styleObj = self.classes[mark.className] || {};
@@ -1848,7 +1931,14 @@ define([
          */
         inlineSplitMarkAcrossLines: function(mark) {
 
-            var editor, to, lineNumber, pos, self, singleLine, styleObj, from;
+            var editor;
+            var from;
+            var lineNumber;
+            var pos;
+            var self;
+            var singleLine;
+            var styleObj;
+            var to;
 
             self = this;
             editor = self.codeMirror;
@@ -1874,7 +1964,9 @@ define([
                 // Loop through the lines that this marker spans and create a marker for each line
                 for (lineNumber = from.line; lineNumber <= to.line; lineNumber++) {
 
-                    var fromCh, newMark, toCh;
+                    var fromCh;
+                    var newMark;
+                    var toCh;
                     
                     fromCh = (lineNumber === from.line) ? from.ch : 0;
                     toCh = (lineNumber === to.line) ? to.ch : editor.getLine(lineNumber).length;
@@ -1908,7 +2000,10 @@ define([
          */
         inlineCombineAdjacentMarks: function() {
 
-            var editor, marks, self;
+            var editor;
+            var marks;
+            var marksByClassName;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -1932,7 +2027,8 @@ define([
             // Sort the marks in order of position
             marks = marks.sort(function(a, b){
                 
-                var posA, posB;
+                var posA;
+                var posB;
 
                 posA = a.find();
                 posB = b.find();
@@ -1974,7 +2070,12 @@ define([
             // Next go through all the classes, and combine the marks
             $.each(marksByClassName, function(className, marks) {
 
-                var i, mark, markNext, markNew, pos, posNext;
+                var i;
+                var mark;
+                var markNext;
+                var markNew;
+                var pos;
+                var posNext;
 
                 i = 0;
                 while (marks[i]) {
@@ -2034,7 +2135,8 @@ define([
          */
         blockToggleStyle: function(styleKey, range) {
             
-            var mark, self;
+            var mark;
+            var self;
 
             self = this;
 
@@ -2072,7 +2174,12 @@ define([
          */
         blockSetStyle: function(style, range, options) {
 
-            var className, editor, lineHandle, lineNumber, mark, self, styleObj;
+            var className;
+            var editor;
+            var lineNumber;
+            var mark;
+            var self;
+            var styleObj;
 
             self = this;
             editor = self.codeMirror;
@@ -2145,7 +2252,13 @@ define([
          */
         blockGetLineData: function(styleKey, lineNumber) {
 
-            var data, editor, lineHandle, self, styleObj;
+            var className;
+            var data;
+            var editor;
+            var lineHandle;
+            var self;
+            var styleObj;
+            
             self = this;
             editor = self.codeMirror;
 
@@ -2178,7 +2291,12 @@ define([
          */
         blockSetLineData: function(styleKey, lineNumber, data) {
             
-            var editor, lineHandle, self, styleObj, className;
+            var editor;
+            var lineHandle;
+            var self;
+            var styleObj;
+            var className;
+            
             self = this;
             editor = self.codeMirror;
             
@@ -2253,7 +2371,11 @@ define([
          */
         blockRemoveStyle: function(styleKey, range) {
 
-            var className, classNames, classes, editor, line, lineNumber, self;
+            var className;
+            var editor;
+            var line;
+            var lineNumber;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -2301,10 +2423,10 @@ define([
          */
         blockIsStyle: function(styleKey, range) {
 
-            var classes, editor, self, styles;
+            var self;
+            var styles;
 
             self = this;
-            editor = self.codeMirror;
 
             styles = self.blockGetStyles(range);
             return Boolean(styles[styleKey]);
@@ -2319,7 +2441,10 @@ define([
          */
         blockGetStyles: function(range) {
             
-            var classes, editor, self, styles;
+            var classes;
+            var editor;
+            var self;
+            var styles;
 
             self = this;
             editor = self.codeMirror;
@@ -2329,7 +2454,8 @@ define([
             // Loop through all lines in the range
             editor.eachLine(range.from.line, range.to.line + 1, function(line) {
 
-                var classNames, classesLine;
+                var classNames;
+                var classesLine;
 
                 // There is at least one classname on this line
                 // Split the class string into an array of individual class names and store in an object for easy lookup
@@ -2373,7 +2499,7 @@ define([
             styles = {};
             if (classes) {
                 $.each(classes, function(className, value) {
-                    var styleKey, styleObj;
+                    var styleObj;
                     styleObj = self.classes[className];
                     if (styleObj) {
                         styles[styleObj.key] = value;
@@ -2403,7 +2529,12 @@ define([
          */
         blockGetListType: function(lineNumber) {
 
-            var classNames, editor, line, lineInfo, listType, self;
+            var classNames;
+            var editor;
+            var line;
+            var lineInfo;
+            var listType;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -2440,11 +2571,14 @@ define([
          */
         blockSetPreview: function(styleKey, lineNumber, previewHTML) {
             
-            var data, editor, $preview, self, styleObj;
+            var data;
+            var editor;
+            var $preview;
+            var self;
+            
             self = this;
 
             editor = self.codeMirror;
-            styleObj = self.styles[styleKey] || {};
             
             // Make sure this style is defined on the line,
             // and get the data object attached to the lineHandle
@@ -2488,7 +2622,11 @@ define([
          */
         blockSetPreviewForMark: function(mark, previewHTML) {
             
-            var lineNumber, range, self, styleKey, styleObj;
+            var lineNumber;
+            var range;
+            var self;
+            var styleKey;
+            var styleObj;
             
             self = this;
 
@@ -2513,12 +2651,13 @@ define([
          */
         blockRemovePreview: function(styleKey, lineNumber) {
             
-            var className, data, editor, $preview, self, styleObj;
+            var data;
+            var editor;
+            var self;
+            
             self = this;
 
             editor = self.codeMirror;
-            styleObj = self.styles[styleKey] || {};
-            className = styleObj.className;
             
             // Make sure this style is defined on the line,
             // and get the data object attached to the lineHandle
@@ -2546,7 +2685,9 @@ define([
          * @param {Number} lineNumber
          */
         blockRemovePreviewForClass: function(className, lineNumber) {
-            var self, styleObj;
+            var self;
+            var styleObj;
+            
             self = this;
             styleObj = self.classes[className];
             if (styleObj) {
@@ -2619,7 +2760,11 @@ define([
          */
         enhancementAdd: function(content, lineNumber, options) {
 
-            var editor, mark, range, self, widgetOptions;
+            var editor;
+            var mark;
+            var range;
+            var self;
+            var widgetOptions;
 
             self = this;
             editor = self.codeMirror;
@@ -2648,7 +2793,8 @@ define([
 
                 mark.deleteLineFunction = function(){
 
-                    var content, $content;
+                    var content;
+                    var $content;
 
                     content = self.enhancementGetContent(mark);
                     $content = $(content).detach();
@@ -2709,7 +2855,11 @@ define([
          */
         enhancementMove: function(mark, lineDelta) {
 
-            var content, $content, editor, lineLength, lineNumber, lineMax, position, self;
+            var editor;
+            var lineLength;
+            var lineNumber;
+            var lineMax;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -2755,7 +2905,10 @@ define([
          */
         enhancementMoveToLine: function(mark, lineNumber) {
             
-            var options, self;
+            var content;
+            var $content;
+            var options;
+            var self;
 
             self = this;
 
@@ -2790,7 +2943,9 @@ define([
          */
         enhancementNewlineAdjust: function(changeObj) {
             
-            var lineInfo, lineNumber, self;
+            var lineInfo;
+            var lineNumber;
+            var self;
 
             self = this;
 
@@ -2864,7 +3019,8 @@ define([
          */
         enhancementGetLineNumber: function(mark) {
             
-            var lineNumber, position;
+            var lineNumber;
+            var position;
 
             lineNumber = undefined;
             if (mark.line) {
@@ -2889,7 +3045,10 @@ define([
          */
         enhancementSetInline: function(mark, options) {
             
-            var content, $content, lineNumber, self;
+            var content;
+            var $content;
+            var lineNumber;
+            var self;
 
             self = this;
 
@@ -2917,7 +3076,10 @@ define([
          */
         enhancementSetBlock: function(mark, options) {
 
-            var content, $content, lineNumber, self;
+            var content;
+            var $content;
+            var lineNumber;
+            var self;
 
             self = this;
 
@@ -2978,7 +3140,9 @@ define([
 
         dropdownInit: function() {
             
-            var clicks, editor, self;
+            var clicks;
+            var editor;
+            var self;
 
             self = this;
             
@@ -3026,7 +3190,9 @@ define([
          * imediately popu up the edit form for the first mark located.
          */
         dropdownDoubleClick: function(event) {
-            var marks, self;
+            var marks;
+            var self;
+            
             self = this;
             
             // Get all the marks within a range
@@ -3043,7 +3209,9 @@ define([
         
         dropdownCheckCursor: function() {
 
-            var marks, self;
+            var marks;
+            var self;
+            
             self = this;
 
             if (self.readOnlyGet() || !self.codeMirror.hasFocus()) {
@@ -3070,7 +3238,11 @@ define([
          * Defaults to false, which means it will only return marks if the selection range is a cursor position.
          */
         dropdownGetMarks: function(allowRange) {
-            var editor, lineStyles, marks, range, self;
+            var editor;
+            var lineStyles;
+            var marks;
+            var range;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -3124,7 +3296,9 @@ define([
             
             $.each(marks, function(i, mark) {
                 
-                var $div, label, $li, styleObj;
+                var $div;
+                var label;
+                var styleObj;
 
                 // Get the label to display for this mark.
                 // It defaults to the className of the style.
@@ -3199,7 +3373,12 @@ define([
 
         dropdownSetPosition: function(marks) {
 
-            var ch, chMin, editor, left, line, self, top;
+            var ch;
+            var editor;
+            var line;
+            var pos;
+            var self;
+            
             self = this;
 
             editor = self.codeMirror;
@@ -3263,7 +3442,9 @@ define([
          */
         onClickDoMark: function(event, mark) {
             
-            var range, self, styleObj;
+            var range;
+            var self;
+            var styleObj;
 
             self = this;
 
@@ -3287,7 +3468,8 @@ define([
          */
         trackInit: function() {
             
-            var editor, self;
+            var editor;
+            var self;
 
             self = this;
             
@@ -3348,7 +3530,12 @@ define([
          */
         trackBeforeChange: function(changeObj) {
             
-            var classes, editor, charPosition, cursorPosition, isEmpty, self, textOriginal, textNew;
+            var classes;
+            var editor;
+            var cursorPosition;
+            var isEmpty;
+            var self;
+            var textOriginal;
             
             self = this;
             editor = self.codeMirror;
@@ -3523,7 +3710,8 @@ define([
          */
         trackAfterPaste: function(from, to, textArray) {
 
-            var self, toNew;
+            var self;
+            var toNew;
 
             self = this;
             
@@ -3555,7 +3743,9 @@ define([
          */
         trackMarkDeleted: function(range) {
             
-            var editor, self;
+            var editor;
+            var self;
+            var textOriginal;
 
             self = this;
             editor = self.codeMirror;
@@ -3587,7 +3777,8 @@ define([
          */ 
         trackAcceptRange: function(range) {
             
-            var editor, marks, self;
+            var editor;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -3609,7 +3800,8 @@ define([
          */ 
         trackRejectRange: function(range) {
             
-            var editor, self;
+            var editor;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -3630,7 +3822,9 @@ define([
          */
         trackAcceptMark: function(mark) {
 
-            var editor, position, self;
+            var editor;
+            var position;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -3657,7 +3851,9 @@ define([
          */
         trackRejectMark: function(mark) {
 
-            var editor, position, self;
+            var editor;
+            var position;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -3736,7 +3932,10 @@ define([
          */
         trackDisplayUpdate: function() {
             
-            var editor, pos, self, $wrapper;
+            var editor;
+            var pos;
+            var self;
+            var $wrapper;
 
             self = this;
             editor = self.codeMirror;
@@ -3784,7 +3983,12 @@ define([
         
         clipboardInit: function() {
             
-            var editor, isFirefox, isWindows, self, $wrapper;
+            var editor;
+            var isFirefox;
+            var isWindows;
+            var self;
+            var $wrapper;
+            
             self = this;
 
             editor = self.codeMirror;
@@ -3831,8 +4035,6 @@ define([
                 // the content that is pasted in from Microsoft Word
                 // while the clipboard API does not have access to the text/html.
                 $wrapper.on('keydown', function(e) {
-
-                    var x, y;
                     
                     if ((e.ctrlKey || e.metaKey) && e.keyCode == 86) {
 
@@ -3858,7 +4060,14 @@ define([
          */
         clipboardPaste: function(e) {
             
-            var allowRaw, isWorkaround, self, value, valueHTML, valueRTE, valueText;
+            var allowRaw;
+            var isWorkaround;
+            var self;
+            var value;
+            var valueHTML;
+            var valueRTE;
+            var valueText;
+            
             self = this;
 
             // If we are using the workaround:
@@ -3970,7 +4179,9 @@ define([
          */
         clipboardSanitize: function(html) {
             
-            var dom, $el, self;
+            var dom;
+            var $el;
+            var self;
             
             self = this;
             dom = self.htmlParse(html);
@@ -4021,7 +4232,8 @@ define([
             $.each(rules, function(selector, style) {
                 
                 $content.find(selector).each(function(){
-                    var $match, $replacement;
+                    var $match;
+                    var $replacement;
 
                     $match = $(this);
                     
@@ -4046,7 +4258,12 @@ define([
          */
         clipboardCopy: function(e) {
             
-            var editor, html, range, self, text;
+            var editor;
+            var html;
+            var range;
+            var self;
+            var text;
+            
             self = this;
             editor = self.codeMirror;
             
@@ -4123,7 +4340,12 @@ define([
          */
         spellcheckUpdate: function() {
 
-            var self, text, wordsArray, wordsArrayUnique, wordsRegexp, wordsUnique;
+            var self;
+            var text;
+            var wordsArray;
+            var wordsArrayUnique;
+            var wordsRegexp;
+            var wordsUnique;
 
             self = this;
             
@@ -4159,7 +4381,15 @@ define([
                     
                     $.each(wordsArrayUnique, function(i,word) {
                         
-                        var adjacent, range, result, index, indexStart, indexWord, range, split, wordLength;
+                        var adjacent;
+                        var ch;
+                        var index;
+                        var indexStart;
+                        var line;
+                        var range;
+                        var result;
+                        var split;
+                        var wordLength;
 
                         wordLength = word.length;
                         
@@ -4232,7 +4462,10 @@ define([
          */
         spellcheckMarkText: function(range, result) {
 
-            var editor, markOptions, self;
+            var editor;
+            var mark;
+            var markOptions;
+            var self;
 
             self = this;
             
@@ -4258,7 +4491,8 @@ define([
          */
         spellcheckClear: function() {
 
-            var editor, self;
+            var editor;
+            var self;
 
             self = this;
 
@@ -4291,7 +4525,11 @@ define([
          */
         spellcheckShow: function(range) {
 
-            var editor, marks, pos, range, self, suggestions;
+            var editor;
+            var marks;
+            var pos;
+            var self;
+            var suggestions;
 
             self = this;
 
@@ -4451,7 +4689,10 @@ define([
          */
         caseToggleSmart: function(range) {
             
-            var editor, self, text, textUpper;
+            var editor;
+            var self;
+            var text;
+            var textUpper;
 
             self = this;
             
@@ -4491,7 +4732,7 @@ define([
          */
         caseToUpper: function(range) {
             
-            var html, node, self;
+            var self;
 
             self = this;
 
@@ -4509,7 +4750,16 @@ define([
          */
         caseChange: function(range, direction) {
             
-            var chEnd, chStart, editor, html, line, lineRange, lineText, node, self;
+            var chEnd;
+            var chMax;
+            var chStart;
+            var editor;
+            var html;
+            var line;
+            var lineRange;
+            var lineText;
+            var node;
+            var self;
             
             self = this;
             editor = self.codeMirror;
@@ -4582,7 +4832,8 @@ define([
          * @param {String|DOM} html
          */
         htmlChangeCase: function(html, upper) {
-            var node, self;
+            var node;
+            var self;
             
             self = this;
             
@@ -4601,7 +4852,11 @@ define([
          * Set to true for upper case, or false for lower case.
          */
         htmlChangeCaseProcessNode: function(node, upper) {
-            var childNodes, i, length, self;
+            var childNodes;
+            var i;
+            var length;
+            var self;
+            
             self = this;
             
             if (node.nodeType === 3) {
@@ -4641,7 +4896,10 @@ define([
 
 
         isLineBlank: function(lineNumber) {
-            var editor, self, text;
+            var editor;
+            var self;
+            var text;
+
             self = this;
             editor = self.codeMirror;
 
@@ -4657,7 +4915,10 @@ define([
          */
         moveToNonBlank: function() {
             
-            var editor, line, max, self;
+            var editor;
+            var line;
+            var max;
+            var self;
 
             self = this;
             editor = self.codeMirror;
@@ -4681,7 +4942,7 @@ define([
          * @returns Number
          */
         getCount: function() {
-            var count, self;
+            var self;
             self = this;
             return self.toText().length;
         },
@@ -4696,7 +4957,9 @@ define([
          */
         getRange: function(){
 
-            var from, self, to;
+            var from;
+            var self;
+            var to;
 
             self = this;
 
@@ -4714,7 +4977,8 @@ define([
          */
         setSelection: function(range){
 
-            var editor, self;
+            var editor;
+            var self;
 
             self = this;
 
@@ -4732,7 +4996,8 @@ define([
          */
         getRangeAll: function(){
 
-            var self, totalLines;
+            var self;
+            var totalLines;
 
             self = this;
 
@@ -4762,7 +5027,8 @@ define([
          */
         getClassNameMap: function() {
             
-            var self, map;
+            var map;
+            var self;
 
             self = this;
 
@@ -4800,7 +5066,8 @@ define([
          */
         getElementMap: function() {
             
-            var self, map;
+            var map;
+            var self;
 
             self = this;
 
@@ -4836,7 +5103,7 @@ define([
          * Empty the editor and clear all marks and enhancements.
          */
         empty: function() {
-            var editor, self;
+            var self;
             self = this;
             
             // Destroy all enhancements
@@ -4874,7 +5141,9 @@ define([
          * or an empty object if the mark has been cleared.
          */
         markGetRange: function(mark) {
-            var pos, self;
+            var pos;
+            var self;
+            
             self = this;
             pos = {};
             if (mark.find) {
@@ -4907,7 +5176,8 @@ define([
          * the mark would be destroyed.
          */
         replaceMarkText: function(mark, text) {
-            var pos, self;
+            var pos;
+            var self;
 
             self = this;
 
@@ -4934,7 +5204,9 @@ define([
          * @return {Boolean}
          */
         elementIsContainer: function(elementName) {
-            var isContainer, self;
+            var isContainer;
+            var self;
+
             self = this;
             isContainer = false;
             $.each(self.styles, function(styleKey, styleObj){
@@ -4955,7 +5227,8 @@ define([
          */
         getKeys: function() {
             
-            var keymap, self;
+            var keymap;
+            var self;
 
             self = this;
 
@@ -5011,7 +5284,7 @@ define([
          * @returns String
          */
         toText: function() {
-            var count, self;
+            var self;
             self = this;
             return self.codeMirror.getValue();
         },
@@ -5073,7 +5346,13 @@ define([
                 return html;
             }
 
-            var blockElementsToClose, blockActive, doc, enhancementsByLine, html, rangeWasSpecified, self;
+            var blockActive;
+            var blockElementsToClose;
+            var doc;
+            var enhancementsByLine;
+            var html;
+            var rangeWasSpecified;
+            var self;
 
             self = this;
 
@@ -5133,7 +5412,22 @@ define([
             // Loop through the content one line at a time
             doc.eachLine(function(line) {
 
-                var annotationStart, annotationEnd, blockOnThisLine, charNum, charInRange, htmlStartOfLine, htmlEndOfLine, inlineActive, inlineActiveIndex, inlineActiveIndexLast, inlineElementsToClose, isVoid, lineNo, lineInRange, outputChar, raw, rawLastChar;
+                var annotationEnd;
+                var annotationStart;
+                var blockOnThisLine;
+                var charInRange;
+                var charNum;
+                var htmlEndOfLine;
+                var htmlStartOfLine;
+                var inlineActive;
+                var inlineActiveIndex;
+                var inlineActiveIndexLast;
+                var inlineElementsToClose;
+                var isVoid;
+                var lineNo;
+                var outputChar;
+                var raw;
+                var rawLastChar;
 
                 lineNo = line.lineNo();
                 
@@ -5166,7 +5460,9 @@ define([
                         
                         $.each(line.textClass.split(' '), function() {
                             
-                            var container, lineStyleData, styleObj;
+                            var container;
+                            var lineStyleData;
+                            var styleObj;
 
                             // From a line style (like "rte2-style-ul"), determine the style name it maps to (like "ul")
                             styleObj = self.classes[this];
@@ -5230,7 +5526,7 @@ define([
                     
                     $.each(enhancementsByLine[lineNo], function(i,mark) {
 
-                        var enhancmentHTML;
+                        var enhancementHTML;
 
                         // Only include the enhancement if the first character of this line is within the selected range
                         charInRange = (lineNo >= range.from.line) && (lineNo <= range.to.line);
@@ -5267,7 +5563,11 @@ define([
 
                     $.each(self.toHTMLSortSpans(line), function(key, markedSpan) {
 
-                        var className, endArray, endCh, mark, startArray, startCh, styleObj;
+                        var className;
+                        var endCh;
+                        var mark;
+                        var startCh;
+                        var styleObj;
 
                         startCh = markedSpan.from;
                         endCh = markedSpan.to;
@@ -5355,7 +5655,6 @@ define([
                     if (lineNo === range.from.line && charNum === range.from.ch) {
 
                             $.each(inlineActive, function(i, styleObj) {
-                                var element;
                                 if (!self.voidElements[ styleObj.element ]) {
                                     inlineElementsToClose.push(styleObj);
                                     html += openElement(styleObj);
@@ -5372,7 +5671,8 @@ define([
                         // Find out which elements are no longer active
                         $.each(annotationEnd[charNum] || [], function(i, styleObj) {
 
-                            var element, styleToClose;
+                            var element;
+                            var styleToClose;
                             
                             // If any of the styles is "raw" mode, clear the raw flag
                             if (styleObj.raw) {
@@ -5406,7 +5706,7 @@ define([
                                 
                                 // Close all the active elements in the reverse order they were created
                                 // Only close the style that needs to be closed plus anything after it in the active list
-                                while (styleToClose = inlineElementsToClose.pop()) {
+                                while ((styleToClose = inlineElementsToClose.pop())) {
                                     
                                     element = styleToClose.element;
                                     if (element && !self.voidElements[element]) {
@@ -5426,8 +5726,6 @@ define([
 
                             $.each(inlineActive, function(i, styleObj) {
                                 
-                                var element;
-
                                 // Only re-open elements after the last element closed
                                 if (i <= inlineActiveIndexLast) {
                                     return;
@@ -5592,7 +5890,9 @@ define([
          */
         toHTMLSortSpans: function(line) {
             
-            var self, spans, spansSorted, spansByChar;
+            var self;
+            var spans;
+            var spansByChar;
             
             self = this;
 
@@ -5602,7 +5902,8 @@ define([
             // Group the marks by starting character so we can tell if multiple marks start on the same character
             spansByChar = [];
             $.each(spans, function() {
-                var char, span;
+                var char;
+                var span;
                 span = this;
                 char = span.from;
                 spansByChar[char] = spansByChar[char] || [];
@@ -5612,7 +5913,11 @@ define([
             // Bubble sort the marks for each character based on the context
             $.each(spansByChar, function() {
                 
-                var compare, spans, swapped, temp;
+                var compare;
+                var spans;
+                var swapped;
+                var temp;
+                
                 spans = this;
                 if (spans.length > 1) {
                     do {
@@ -5652,7 +5957,15 @@ define([
          */
         toHTMLSpanCompare: function(a, b) {
                 
-            var classA, classB, markerA, markerB, outsideB, outsideA, self, styleA, styleB;
+            var classA;
+            var classB;
+            var markerA;
+            var markerB;
+            var outsideA;
+            var outsideB;
+            var self;
+            var styleA;
+            var styleB;
 
             self = this;
 
@@ -5737,7 +6050,13 @@ define([
         },
         _fromHTML: function(html, range, allowRaw, retainStyles) {
 
-            var annotations, editor, enhancements, el, history, map, self, val;
+            var annotations;
+            var editor;
+            var enhancements;
+            var el;
+            var history;
+            var self;
+            var val;
 
             self = this;
             
@@ -5757,7 +6076,18 @@ define([
             
             function processNode(n, rawParent) {
                 
-                var elementAttributes, elementName, elementClose, from, isContainer, matchStyleObj, next, raw, rawChildren, split, to, text;
+                var elementAttributes;
+                var elementClose;
+                var elementName;
+                var from;
+                var isContainer;
+                var matchStyleObj;
+                var next;
+                var raw;
+                var rawChildren;
+                var split;
+                var text;
+                var to;
 
                 next = n.childNodes[0];
 
@@ -5779,7 +6109,9 @@ define([
                             // Convert newlines to a carriage return character and annotate it
                             text = text.replace(/[\n\r]/g, function(match, offset, string){
 
-                                var from, split, to;
+                                var from;
+                                var split;
+                                var to;
                                 
                                 // Create an annotation to mark the newline so we can distinguish it
                                 // from any other user of the carriage return character
@@ -6139,7 +6471,12 @@ define([
          */
         getStyleForElement: function(el) {
 
-            var elementName, elementAttributes, map, matchStyleObj, self;
+            var elementName;
+            var map;
+            var matchArray;
+            var matchStyleObj;
+            var self;
+
             self = this;
 
             // Convert the styles object to an object that is indexed by element,
@@ -6152,7 +6489,6 @@ define([
             
             // We got an element
             elementName = el.tagName.toLowerCase();
-            elementAttributes = self.getAttributes(el);
 
             // Determine if the element maps to one of our defined styles
             matchStyleObj = undefined;
@@ -6244,16 +6580,12 @@ define([
          */
         limitHTML: function(html) {
 
-            var el, map, self, val;
+            var el;
+            var self;
+            var val;
 
             self = this;
             
-            // Convert the styles object to an object that is indexed by element,
-            // so we can quickly map an element to a style.
-            // Note there might be more than one style for an element, in which
-            // case we will use attributes to determine if we have a match.
-            map = self.getElementMap();
-
             // Convert HTML into a DOM element so we can parse it using the browser node functions
             el = self.htmlParse(html);
                 
@@ -6262,13 +6594,16 @@ define([
             
             function processNode(n) {
                 
-                var elementAttributes, elementClose, elementName, matchStyleObj, next, split, to, text;
+                var elementClose;
+                var elementName;
+                var matchStyleObj;
+                var next;
+                var text;
 
                 next = n.childNodes[0];
 
                 while (next) {
 
-                    elementAttributes = {};
                     elementClose = '';
 
                     // Check if we got a text node or an element
@@ -6293,7 +6628,6 @@ define([
 
                         // We got an element
                         elementName = next.tagName.toLowerCase();
-                        elementAttributes = self.getAttributes(next);
 
                         // Determine if the element maps to one of our defined styles
                         matchStyleObj = self.getStyleForElement(next);
@@ -6388,7 +6722,9 @@ define([
          */
         insert: function(value, styleKey) {
             
-            var range, self, mark;
+            var range;
+            var self;
+            var mark;
 
             self = this;
 
@@ -6431,7 +6767,9 @@ define([
          * @returns {DOM}
          */
         htmlParse: function(html) {
-            var dom, self;
+            var dom;
+            var self;
+            
             self = this;
 
             if ($.type(html) === 'string') {
@@ -6479,7 +6817,9 @@ define([
          */
         getAttributes: function(el) {
             
-            var attr, $el, self;
+            var attr;
+            var $el;
+            var self;
             
             self = this;
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4226,8 +4226,6 @@ define([
          * @param {Object} rules
          */
         clipboardSanitizeApplyRules: function($content, rules) {
-            var self;
-            self = this;
             
             $.each(rules, function(selector, style) {
                 
@@ -5142,9 +5140,7 @@ define([
          */
         markGetRange: function(mark) {
             var pos;
-            var self;
-            
-            self = this;
+
             pos = {};
             if (mark.find) {
                 pos = mark.find() || {};
@@ -6768,9 +6764,6 @@ define([
          */
         htmlParse: function(html) {
             var dom;
-            var self;
-            
-            self = this;
 
             if ($.type(html) === 'string') {
                 dom = new DOMParser().parseFromString(html, "text/html").body;     
@@ -6819,9 +6812,7 @@ define([
             
             var attr;
             var $el;
-            var self;
-            
-            self = this;
+
 
             attr = {};
 

--- a/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
+++ b/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
@@ -1,5 +1,5 @@
 /* jshint undef: true, unused: true, browser: true, jquery: true, devel: true */
-/* global define */
+/* global define document */
 
 define(['jquery'], function($) {
 
@@ -490,10 +490,9 @@ define(['jquery'], function($) {
             $table = $cell.closest('table');
             $table.find('> * > tr').each(function() {
                 
-                var $td, $tds, $tr;
+                var $td, $tr;
 
                 $tr = $(this);
-                $tds = $tr.find('> td, > th');
 
                 // Now add a new cell at the insertion point
                 $td = self.cellCreate();


### PR DESCRIPTION
Running a javascript linter (ESLint) revealed numerous problems with the RTE code. None of the problems appeared to affect functionality; however, to allow continued use of a real-time linter for identifying problems, they should be cleaned up. Also standardized the declaration of variables (one var per line vs multiple vars on a single line) for better consistency.