### PR TITLE
RTE bugfix table not saving changes (BSP-2127)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -589,6 +589,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.inlineEnhancementInit();
             self.tableInit();
             self.initRte();
+            self.tableInitChangeEvent(); // must be after initRte
             self.toolbarInit();
             self.linkInit();
             self.trackChangesInit();
@@ -3396,6 +3397,22 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         /**
+         * Initialize a listener for table editor changes, so we
+         * can in turn trigger an RTE change (to ensure the html gets updated).
+         * Note this must be called after initRte because the container element
+         * must exist before we can attach the event listener.
+         */
+        tableInitChangeEvent: function() {
+            var self = this;
+            // Add a listener for table changes so we know when the content changes
+            self.$container.on('tableEditorChange', function() {
+                // Trigger a content change so the final html gets updated
+                self.rte.triggerChange();
+            });
+        },
+
+
+        /**
          * 
          */
         tableCreate: function($content, line) {
@@ -3810,6 +3827,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                  } else {
                      value = self.tableEditRte.toHTML();
                      $el.html(value);
+                     self.rte.triggerChange();
                  }
 
             });

--- a/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
+++ b/tool-ui/src/main/webapp/script/v3/input/tableEditor.js
@@ -401,6 +401,8 @@ define(['jquery'], function($) {
             } else {
                 $rowNew.insertAfter($row);
             }
+            
+            self.triggerChange();
         },
 
         
@@ -431,6 +433,8 @@ define(['jquery'], function($) {
             
             $row = $cell.closest('tr');
             $row.remove();
+            
+            self.triggerChange();
         },
 
 
@@ -503,6 +507,8 @@ define(['jquery'], function($) {
                     $td.insertBefore( $tr.find('> td, > th').eq(colNumber) );
                 }
             });
+            
+            self.triggerChange();
         },
 
         
@@ -548,6 +554,8 @@ define(['jquery'], function($) {
                 // Delete the cell for the column
                 $tds.eq(colNumber).remove();
             });
+            
+            self.triggerChange();
         },
 
         
@@ -672,6 +680,8 @@ define(['jquery'], function($) {
             $cell = options.cell ? $(options.cell) : self.selectedGet();
 
             $cell.html(content);
+            
+            self.triggerChange();
         },
 
         
@@ -732,6 +742,16 @@ define(['jquery'], function($) {
             // Remove any empty 'class' attributes because jquery leaves those around after setting and removing the active classes
             $cloned.find('[class=""]').removeAttr('class');
             return options.html ? $cloned.html() : self.$table;
+        },
+        
+        
+        /**
+         * Trigger a change event. To be used whenever the table is modified.
+         */  
+        triggerChange: function() {
+            var self;
+            self = this;
+            self.$table.trigger('tableEditorChange', [self]);
         }
     };
     


### PR DESCRIPTION
There is a bug where changes to an existing table are not saved when the page is published. This occurred because the RTE did not recognize that changes were made, and did not update the HTML output.

This pull request adds an event to the table editor to indicate when the table is changed, and an event listener to the RTE.
