### PR TITLE
BSP-2165: Disables WIP on error during save.

### DIFF
--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -436,6 +436,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                 wp.include("/WEB-INF/objectMessage.jsp", "object", editing);
 
                 if (history == null
+                        && !editingState.hasAnyErrors()
                         && !user.isDisableWorkInProgress()
                         && !wp.getCmsTool().isDisableWorkInProgress()) {
 


### PR DESCRIPTION
When WIP was overlaid on top of the content and it contained errors,
the errors were lost.