### PR TITLE
added support for @ToolUi.RichText(block=true)

### DIFF
--- a/db/etc/clirr-ignored.xml
+++ b/db/etc/clirr-ignored.xml
@@ -50,4 +50,10 @@
         <method>boolean clearOnChange()</method>
     </difference>
 
+    <difference>
+        <className>com/psddev/cms/db/ToolUi$RichText</className>
+        <differenceType>7012</differenceType>
+        <method>boolean block()</method>
+    </difference>
+
 </differences>

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -79,6 +79,7 @@ public class ToolUi extends Modification<Object> {
     private String referenceableViaClassName;
     private Boolean readOnly;
     private boolean richText;
+    private boolean richTextBlock;
     private String richTextElementTagName;
     private Set<String> richTextElementClassNames;
     private boolean secret;
@@ -551,6 +552,14 @@ public class ToolUi extends Modification<Object> {
 
     public void setRichText(boolean richText) {
         this.richText = richText;
+    }
+
+    public boolean isRichTextBlock() {
+       return this.richTextBlock;
+    }
+
+    public void setRichTextBlock(boolean richTextBlock) {
+        this.richTextBlock = richTextBlock;
     }
 
     public String getRichTextElementTagName() {
@@ -1631,6 +1640,7 @@ public class ToolUi extends Modification<Object> {
     @Target({ ElementType.FIELD, ElementType.METHOD })
     public @interface RichText {
         boolean value() default true;
+        boolean block() default false;
     }
 
     private static class RichTextProcessor implements ObjectField.AnnotationProcessor<RichText> {
@@ -1638,6 +1648,7 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, ObjectField field, RichText annotation) {
             field.as(ToolUi.class).setRichText(annotation.value());
+            field.as(ToolUi.class).setRichTextBlock(annotation.block());
         }
     }
 

--- a/tool-ui/src/main/webapp/WEB-INF/field/referentialText.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/referentialText.jsp
@@ -56,6 +56,7 @@ ToolUi ui = field.as(ToolUi.class);
 Set<String> rteTags = ui.findRichTextElementTags();
 Number suggestedMinimum = ui.getSuggestedMinimum();
 Number suggestedMaximum = ui.getSuggestedMaximum();
+boolean renderBlockElements = ui.isRichTextBlock();
 
 wp.writeStart("div", "class", "inputSmall inputSmall-text");
 wp.writeStart("textarea",
@@ -69,7 +70,8 @@ wp.writeStart("textarea",
         "data-user", wp.getObjectLabel(wp.getUser()),
         "data-user-id", wp.getUser() != null ? wp.getUser().getId() : null,
         "data-first-draft", Boolean.TRUE.equals(request.getAttribute("firstDraft")),
-        "data-final-draft", Boolean.TRUE.equals(request.getAttribute("finalDraft")));
+        "data-final-draft", Boolean.TRUE.equals(request.getAttribute("finalDraft")),
+        "data-render-block-elements", renderBlockElements);
 
 if (fieldValue != null) {
     for (Object item : fieldValue) {

--- a/tool-ui/src/main/webapp/WEB-INF/field/text.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/text.jsp
@@ -122,7 +122,8 @@ if (validValues != null) {
             "data-user", wp.getObjectLabel(wp.getUser()),
             "data-user-id", wp.getUser() != null ? wp.getUser().getId() : null,
             "data-first-draft", Boolean.TRUE.equals(request.getAttribute("firstDraft")),
-            "data-track-changes", !Boolean.TRUE.equals(request.getAttribute("finalDraft")));
+            "data-track-changes", !Boolean.TRUE.equals(request.getAttribute("finalDraft")),
+            "data-render-block-elements",  ui.isRichTextBlock());
         wp.writeHtml(fieldValue);
     wp.writeEnd();
 }

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1074,6 +1074,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 
                 var $submenu;
 
+                if (self.$el.attr('data-render-block-elements') === 'true') {
+                    // If ToolUi.RichText(block=true) is used, turn off inline
+                    self.inline = false;
+                }
+
                 // Loop through the toolbar config to set up buttons
                 $.each(config, function(i, item) {
 


### PR DESCRIPTION
This PR add the ability to specify block=true to the @ToolUi.RichText annotation.
When block=true is specified all inline RTE controls will be displayed