### PR TITLE
BSP-2237: Fixes Firefox placeholder color to be same as other browsers.

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/reset.less
+++ b/tool-ui/src/main/webapp/style/v3/reset.less
@@ -318,6 +318,8 @@ ul {
 
 ::placeholder {
   .state-placeholder;
+
+  opacity: 1;
 }
 
 [data-editable-placeholder]::placeholder {


### PR DESCRIPTION
Caused by https://bugzilla.mozilla.org/show_bug.cgi?id=556145