### PR TITLE
BSP-2266 Fixes Scheduling a Change to an Asset Changing the Publish Date to th…

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/Schedule.java
+++ b/db/src/main/java/com/psddev/cms/db/Schedule.java
@@ -127,8 +127,11 @@ public class Schedule extends Record {
                     }
 
                     contentData.setDraft(false);
-                    contentData.setPublishDate(triggerDate);
-                    contentData.setPublishUser(triggerUser);
+
+                    if (contentData.getPublishDate() == null) {
+                        contentData.setPublishDate(triggerDate);
+                    }
+
                     state.as(BulkUploadDraft.class).setRunAfterSave(true);
                     Content.Static.publish(object, getTriggerSite(), triggerUser);
                 }


### PR DESCRIPTION
…e Last Updated Date. Also removes setting publish user to triggerUser as Content.Static.publish handles setting the passed ToolUser to publishUser/updateUser when appropriate.