### PR TITLE
BSP-2267: Potential workaround for IllegalAccessError in Draft.

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/Draft.java
+++ b/db/src/main/java/com/psddev/cms/db/Draft.java
@@ -198,7 +198,7 @@ public class Draft extends Content {
         } else if (value instanceof Collection) {
             return ((Collection<Object>) value)
                     .stream()
-                    .map(Draft::minifyValue)
+                    .map(v -> minifyValue(v))
                     .collect(Collectors.toList());
 
         } else {


### PR DESCRIPTION
This might be caused by https://bugs.openjdk.java.net/browse/JDK-8138667