### PR TITLE
BSP-1349 Adds more data to WorkStreamUsers popup

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/WorkStream.java
+++ b/db/src/main/java/com/psddev/cms/db/WorkStream.java
@@ -68,6 +68,10 @@ public class WorkStream extends Record {
         this.assignedEntities = assignedEntities;
     }
 
+    public Map<String, List<UUID>> getSkippedItems() {
+        return skippedItems;
+    }
+
     /** Returns the tool search that can return all items to be worked on. */
     public com.psddev.cms.tool.Search getSearch() {
         return search;

--- a/db/src/main/java/com/psddev/cms/tool/page/WorkStreamUsers.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/WorkStreamUsers.java
@@ -1,8 +1,11 @@
 package com.psddev.cms.tool.page;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.servlet.ServletException;
@@ -11,8 +14,12 @@ import com.psddev.cms.db.ToolUser;
 import com.psddev.cms.db.WorkStream;
 import com.psddev.cms.tool.PageServlet;
 import com.psddev.cms.tool.ToolPageContext;
+import com.psddev.cms.tool.widget.AbstractPaginatedResultWidget;
 import com.psddev.dari.db.Query;
+import com.psddev.dari.db.Record;
+import com.psddev.dari.util.ObjectUtils;
 import com.psddev.dari.util.RoutingFilter;
+import com.psddev.dari.util.StringUtils;
 
 @RoutingFilter.Path(application = "cms", value = "/workStreamUsers")
 @SuppressWarnings("serial")
@@ -45,51 +52,199 @@ public class WorkStreamUsers extends PageServlet {
                 page.writeEnd();
 
             } else {
-                page.writeStart("table", "class", "table-striped");
-                    page.writeStart("thead");
-                        page.writeStart("tr");
-                            page.writeStart("th");
-                                page.writeHtml(page.localize(WorkStreamUsers.class, "label.user"));
-                            page.writeEnd();
-                            page.writeStart("th");
-                                page.writeHtml(page.localize(WorkStreamUsers.class, "label.currentlyOn"));
-                            page.writeEnd();
-                            page.writeStart("th");
-                                page.writeHtml(page.localize(WorkStreamUsers.class, "label.completed"));
-                            page.writeEnd();
-                        page.writeEnd();
-                    page.writeEnd();
 
-                    page.writeStart("tbody");
-                        for (ToolUser user : users) {
-                            page.writeStart("tr");
-                                page.writeStart("td");
-                                    page.writeObjectLabel(user);
-                                page.writeEnd();
+                page.writeStart("div", "class", "tabbed");
 
-                                page.writeStart("td");
-                                    Object currentItem = workStream.getCurrentItem(user);
+                    writeStatusTabHtml(page, workStream, users);
+                    writeCompleteTabHtml(page);
+                    writeSkippedTabHtml(page);
 
-                                    if (currentItem == null) {
-                                        page.writeHtml("N/A");
-
-                                    } else {
-                                        page.writeStart("a",
-                                                "href", page.objectUrl("/content/edit.jsp", currentItem),
-                                                "target", "_top");
-                                            page.writeObjectLabel(currentItem);
-                                        page.writeEnd();
-                                    }
-                                page.writeEnd();
-
-                                page.writeStart("td");
-                                    page.writeHtml(workStream.countComplete(user));
-                                page.writeEnd();
-                            page.writeEnd();
-                        }
-                    page.writeEnd();
                 page.writeEnd();
             }
         page.writeEnd();
+    }
+
+    private void writeStatusTabHtml(ToolPageContext page, WorkStream workStream, List<ToolUser> users) throws IOException {
+        page.writeStart("div",
+                "data-tab", "Status");
+
+            page.writeStart("table", "class", "table-striped");
+                page.writeStart("thead");
+                    page.writeStart("tr");
+                        page.writeStart("th");
+                            page.writeHtml(page.localize(WorkStreamUsers.class, "label.user"));
+                        page.writeEnd();
+                        page.writeStart("th");
+                            page.writeHtml(page.localize(WorkStreamUsers.class, "label.currentlyOn"));
+                        page.writeEnd();
+                        page.writeStart("th");
+                            page.writeHtml(page.localize(WorkStreamUsers.class, "label.completed"));
+                        page.writeEnd();
+                    page.writeEnd();
+                page.writeEnd();
+
+                page.writeStart("tbody");
+                    for (ToolUser user : users) {
+                        page.writeStart("tr");
+                            page.writeStart("td");
+                                page.writeObjectLabel(user);
+                            page.writeEnd();
+
+                            page.writeStart("td");
+                            Object currentItem = workStream.getCurrentItem(user);
+
+                            if (currentItem == null) {
+                                page.writeHtml("N/A");
+
+                            } else {
+                                page.writeStart("a",
+                                        "href", page.objectUrl("/content/edit.jsp", currentItem),
+                                        "target", "_top");
+                                page.writeObjectLabel(currentItem);
+                                page.writeEnd();
+                            }
+                            page.writeEnd();
+
+                            page.writeStart("td");
+                                page.writeHtml(workStream.countComplete(user));
+                            page.writeEnd();
+                        page.writeEnd();
+                    }
+                page.writeEnd();
+            page.writeEnd();
+
+        page.writeEnd();
+    }
+
+    private void writeCompleteTabHtml(ToolPageContext page) throws IOException, ServletException {
+        page.writeStart("div",
+                "data-tab", "Completed");
+
+            new WorkStreamStatusView() {
+
+                @Override
+                public Query<Record> getQuery(ToolPageContext page) {
+                    ToolUser user = getSelectedUser(page);
+
+                    if (user == null) {
+                        return null;
+                    }
+
+                    return Query.from(Record.class)
+                            .resolveInvisible()
+                            .where("cms.workstream.completeIds = ?", page.param(UUID.class, "id") + "," + user.getId().toString());
+                }
+
+            }.writeHtml(page, null);
+
+        page.writeEnd();
+    }
+
+    private void writeSkippedTabHtml(ToolPageContext page) throws IOException, ServletException {
+        page.writeStart("div",
+                "data-tab", "Skipped");
+
+            new WorkStreamStatusView() {
+
+                @Override
+                public Query<Record> getQuery(ToolPageContext page) {
+                    WorkStream workStream = Query.from(WorkStream.class).where("_id = ?", page.param(UUID.class, "id")).first();
+                    ToolUser user = getSelectedUser(page);
+
+                    if (user == null) {
+                        return null;
+                    }
+
+                    Map<String, List<UUID>> skippedMap = workStream.getSkippedItems();
+
+                    if (ObjectUtils.isBlank(skippedMap)) {
+                        return null;
+                    }
+
+                    List<UUID> objectIds = skippedMap.get(user.getId().toString());
+                    if (objectIds == null) {
+                        return null;
+                    }
+
+                    return Query.from(Record.class).where("_id = ?", objectIds).resolveInvisible();
+                }
+
+            }.writeHtml(page, null);
+
+        page.writeEnd();
+    }
+
+    private abstract static class WorkStreamStatusView extends AbstractPaginatedResultWidget<Record> {
+
+        private static final String USER_ID_PARAMETER = "userId";
+
+        private transient ToolUser user;
+        private transient WorkStream workStream;
+
+        ToolUser getSelectedUser(ToolPageContext page) {
+            if (user == null) {
+                String userId = page.param(String.class, USER_ID_PARAMETER);
+
+                if (StringUtils.isBlank(userId)) {
+                    return page.getUser();
+                }
+
+                user = ObjectUtils.firstNonNull(Query.from(ToolUser.class).where("_id = ?", userId).first(), page.getUser());
+            }
+
+            return user;
+        }
+
+        WorkStream getWorkStream(ToolPageContext page) {
+            if (workStream == null) {
+                workStream = Query.from(WorkStream.class).where("_id = ?", page.param(String.class, "id")).first();
+            }
+
+            return workStream;
+        }
+
+        @Override
+        public String getTitle(ToolPageContext page) throws IOException {
+            return null;
+        }
+
+        @Override
+        public String getUrl(ToolPageContext page, String path, Object... parameters) {
+            List<Object> parameterList = new ArrayList<>(Arrays.asList(parameters));
+            parameterList.add("id");
+            parameterList.add(page.param(UUID.class, "id"));
+
+            return page.url(path, parameterList.toArray());
+        }
+
+        @Override
+        public void writeFiltersHtml(ToolPageContext page) throws IOException {
+
+            WorkStream workStream = getWorkStream(page);
+
+            if (workStream == null) {
+                return;
+            }
+
+            List<ToolUser> users = workStream.getUsers();
+            if (ObjectUtils.isBlank(users)) {
+                return;
+            }
+
+            page.writeStart("select",
+                    "name", USER_ID_PARAMETER,
+                    "data-bsp-autosubmit", "",
+                    "data-searchable", true);
+                for (ToolUser user : users) {
+
+                    page.writeStart("option",
+                            "value", user.getId(),
+                            "selected", user.equals(getSelectedUser(page)) ? "selected" : null);
+                        page.writeHtml(user.getLabel());
+                    page.writeEnd();
+
+                }
+            page.writeEnd();
+        }
     }
 }

--- a/db/src/main/java/com/psddev/cms/tool/page/WorkStreamUsers.java
+++ b/db/src/main/java/com/psddev/cms/tool/page/WorkStreamUsers.java
@@ -53,7 +53,9 @@ public class WorkStreamUsers extends PageServlet {
 
             } else {
 
-                page.writeStart("div", "class", "tabbed");
+                page.writeStart("div",
+                        "class", "tabbed",
+                        "data-id", "workStreamUsers");
 
                     writeStatusTabHtml(page, workStream, users);
                     writeCompleteTabHtml(page);

--- a/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
@@ -12,6 +12,7 @@ import com.psddev.cms.tool.ToolPageContext;
 import com.psddev.dari.db.Query;
 import com.psddev.dari.db.Record;
 import com.psddev.dari.util.PaginatedResult;
+import com.psddev.dari.util.StringUtils;
 
 /**
  * Provides an extensible base implementation of a {@link DashboardWidget} displaying a {@link PaginatedResult}.
@@ -146,9 +147,12 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
 
         page.writeStart("div", "class", "widget");
 
-            page.writeStart("h1");
-                page.writeHtml(getTitle(page));
-            page.writeEnd();
+            String title = getTitle(page);
+            if (!StringUtils.isBlank(title)) {
+                page.writeStart("h1");
+                    page.writeHtml(title);
+                page.writeEnd();
+            }
 
             page.writeStart("div", "class", "widget-filters");
                 page.writeStart("form",

--- a/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
@@ -48,6 +48,19 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
     public abstract Query<T> getQuery(ToolPageContext page);
 
     /**
+     * Optionally override to control the url used for the <form> and <a> elements in this widget.
+     *
+     * @param page Used to create the url.
+     * @param path The base path from which to create the url.
+     * @param parameters The parameters to use for the url query string.
+     *
+     * @return the {@code String} url with any query string.
+     */
+    public String getUrl(ToolPageContext page, String path, Object... parameters) {
+        return page.url(path, parameters);
+    }
+
+    /**
      * Optionally override for more control over the creation of
      * the {@link PaginatedResult}.
      *
@@ -140,7 +153,7 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
             page.writeStart("div", "class", "widget-filters");
                 page.writeStart("form",
                         "method", "get",
-                        "action", page.url(null));
+                        "action", getUrl(page, null));
                     writeFiltersHtml(page);
                 page.writeEnd();
             page.writeEnd();
@@ -165,13 +178,13 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
 
             if (result.hasPrevious()) {
                 page.writeStart("li", "class", "first");
-                    page.writeStart("a", "href", page.url("", OFFSET_PARAMETER, result.getFirstOffset()));
+                    page.writeStart("a", "href", getUrl(page, "", OFFSET_PARAMETER, result.getFirstOffset()));
                         page.writeHtml(page.localize(AbstractPaginatedResultWidget.class, "pagination.newest"));
                     page.writeEnd();
                 page.writeEnd();
 
                 page.writeStart("li", "class", "previous");
-                    page.writeStart("a", "href", page.url("", OFFSET_PARAMETER, result.getPreviousOffset()));
+                    page.writeStart("a", "href", getUrl(page, "", OFFSET_PARAMETER, result.getPreviousOffset()));
                         page.writeHtml(page.localize(ImmutableMap.of("count", limit), "pagination.newerCount"));
                     page.writeEnd();
                 page.writeEnd();
@@ -182,7 +195,7 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
                     page.writeStart("form",
                             "data-bsp-autosubmit", "",
                             "method", "get",
-                            "action", page.url(null));
+                            "action", getUrl(page, null));
                         page.writeStart("select", "name", LIMIT_PARAMETER);
                         for (int l : LIMITS) {
                             page.writeStart("option",
@@ -198,7 +211,7 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
 
             if (result.hasNext()) {
                 page.writeStart("li", "class", "next");
-                    page.writeStart("a", "href", page.url("", "offset", result.getNextOffset()));
+                    page.writeStart("a", "href", getUrl(page, "", OFFSET_PARAMETER, result.getNextOffset()));
                         page.writeHtml(page.localize(AbstractPaginatedResultWidget.class, ImmutableMap.of("count", limit), "pagination.olderCount"));
                     page.writeEnd();
                 page.writeEnd();

--- a/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
+++ b/db/src/main/java/com/psddev/cms/tool/widget/AbstractPaginatedResultWidget.java
@@ -69,6 +69,12 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
      * @return the {@link PaginatedResult} to be displayed by the widget.
      */
     public PaginatedResult<T> getPaginatedResult(ToolPageContext page) {
+        Query<T> query = getQuery(page);
+
+        if (query == null) {
+            return null;
+        }
+
         return getQuery(page).select(page.param(long.class, OFFSET_PARAMETER), page.paramOrDefault(int.class, LIMIT_PARAMETER, LIMITS[0]));
     }
 
@@ -164,9 +170,11 @@ public abstract class AbstractPaginatedResultWidget<T extends Record> extends Da
 
             PaginatedResult<T> result = getPaginatedResult(page);
 
-            writePaginationHtml(page, result, page.paramOrDefault(int.class, LIMIT_PARAMETER, LIMITS[0]));
+            if (result != null) {
+                writePaginationHtml(page, result, page.paramOrDefault(int.class, LIMIT_PARAMETER, LIMITS[0]));
+            }
 
-            if (result.hasPages()) {
+            if (result != null && result.hasPages()) {
                 writeResultsHtml(page, result);
             } else {
                 writeEmptyHtml(page);

--- a/tool-ui/src/main/webapp/style/v3/pagination.less
+++ b/tool-ui/src/main/webapp/style/v3/pagination.less
@@ -9,7 +9,7 @@
   padding: 0;
 
   &:empty {
-    border: none;
+    display: none;
   }
 }
 

--- a/tool-ui/src/main/webapp/style/v3/widget.less
+++ b/tool-ui/src/main/webapp/style/v3/widget.less
@@ -71,6 +71,10 @@
 .widget-filters {
   display: inline-block;
 
+  &:empty {
+    display: none;
+  }
+
   form {
     display: inline-block;
     margin-bottom: 0;


### PR DESCRIPTION
Updates the WorkStreamUsers Popup with additional information regarding completed and skipped items. Includes the ability to filter Skipped/Completed items by ToolUser.

Old Popup:

![image](https://cloud.githubusercontent.com/assets/1299507/16694870/8a1b0cda-450a-11e6-9f39-25a35bab1d8e.png)


New Popup:

![image](https://cloud.githubusercontent.com/assets/1299507/16694825/43abe8c8-450a-11e6-8b1f-916b1ec0c773.png)

![image](https://cloud.githubusercontent.com/assets/1299507/16694836/4da5765a-450a-11e6-863d-db530813e5bd.png)


