### PR TITLE
RTE bugfix for imported HTML text before block elements (BSP-2038)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -6958,7 +6958,12 @@ define([
 
                             // Determine if the element maps to one of our defined styles
                             matchStyleObj = self.getStyleForElement(next);
-
+                            
+                            // Create new line if this is a block element and the previous text did not end the line.
+                            if (matchStyleObj && matchStyleObj.line && val[ val.length - 1 ] !== '\n') {
+                                // Note in this case, when exporting HTML a <br/> element will be added.
+                                val += '\n';
+                            }
                         }
 
                         // Figure out which line and character for the start of our element

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -6977,6 +6977,13 @@ define([
                         // Note we are treating tables as an enhancement as well.
                         if ((elementName === 'table') || ((elementName === 'span' || elementName === 'button') && $(next).hasClass('enhancement'))) {
 
+                            // End the last line if necessary
+                            if (val[ val.length - 1] !== '\n') {
+                                val += '\n';
+                                from.line++;
+                                from.ch = 0;
+                            }
+                            
                             enhancements.push({
                                 line: from.line,
                                 $content: $(next)


### PR DESCRIPTION
When the RTE imports HTML from outside sources, if some text was immediately followed by a block element, the text was being rendered inside the block element. For example, `some text<h1>block</h1>` was becoming `<h1>some textblock</h1>`

This pull request adds a newline when necessary before the block element, so the imported content will render correctly within the RTE. Note that when the RTE saves the content, the newline will become a `<br>` element, so the output HTML would be `some text<br/><h1>block</h1>`, and the next time that was imported into the RTE there would be no need to add a newline.

In addition, for tables and enhancements, a similar problem caused text before the table to be moved to after the table: `some text<table>...</table>` became `<table>...</table>some text`. This pull request performs a similar change by adding a newline to prevent that from happening.