### PR TITLE
RTE performance improvement for list items (BSP-2023)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2231,7 +2231,7 @@ define([
 
             // Refresh the editor display since our line classes
             // might have padding that messes with the cursor position
-            editor.refresh();
+            self.refresh();
 
             if (options.triggerChange !== false) {
                 self.triggerChange();
@@ -2421,7 +2421,7 @@ define([
             
             // Refresh the editor display since our line classes
             // might have padding that messes with the cursor position
-            editor.refresh();
+            self.refresh();
             
             self.triggerChange();
         },
@@ -5695,10 +5695,18 @@ define([
          * You should call this if you modify the size of any enhancement content
          * that is in the editor.
          */
-        refresh: function(mark) {
+        refresh: function() {
             var self;
             self = this;
-            self.codeMirror.refresh();
+            
+            // Set up a debounced refresh so it is not called too often
+            if (!self._refresh) {
+                self._refresh = $.debounce(200, function(){
+                    self.codeMirror.refresh();
+                });
+            }
+            
+            self._refresh();
         },
 
 


### PR DESCRIPTION
When a list item style is set on a line, the RTE also checks to see if there are other styles that need to be removed. For example, if you set a line to a bulleted list, it must remove the numbered list style to avoid conflicts.

When doing so, the RTE was also calling refresh() on the editor for each style removed, and for documents with many list items, this caused the editor to refresh the DOM too often, and performance suffered.

This commit wraps the refresh() function within a debounced timer, so it will not be called too frequently when importing HTML.