### PR TITLE
RTE update toolbar after an undo/redo (BSP-2268)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1117,8 +1117,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // Process all the toolbar entries
             toolbarProcess(self.toolbarConfig, $toolbar);
 
-            // Whenever the cursor moves, update the toolbar to show which styles are selected
-            self.$container.on("rteCursorActivity",
+            // Whenever the cursor moves, update the toolbar to show which styles are selected.
+            // Also update after an undo/redo occurs
+            self.$container.on("rteCursorActivity rteHistory",
                                $.debounce(200, function() {
                                    self.toolbarUpdate();
                                })


### PR DESCRIPTION
After performing an undo or redo, the toolbar should be updated so the correct buttons will be active.