### PR TITLE
Bugfix RTE enhancement movement (BSP-1805)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -6216,6 +6216,7 @@ define([
             var doc;
             var enhancementsByLine;
             var html;
+            var lineNo;
             var rangeWasSpecified;
             var self;
 
@@ -6255,20 +6256,9 @@ define([
             enhancementsByLine = {};
             if (!(rangeWasSpecified && range.from.line === range.to.line)) {
                 
-                $.each(self.enhancementCache, function(i, mark) {
-
-                    var lineNo;
-
-                    lineNo = self.enhancementGetLineNumber(mark);
-                
-                    if (lineNo !== undefined) {
-                    
-                        // Create an array to hold the enhancements for this line, then add the current enhancement
-                        enhancementsByLine[lineNo] = enhancementsByLine[lineNo] || [];
-                
-                        enhancementsByLine[lineNo].push(mark);
-                    }
-                });
+                for (lineNo = range.from.line; lineNo <= range.to.line; lineNo++) {
+                    enhancementsByLine[lineNo] = self.enhancementGetFromLine(lineNo);
+                }
             }
             
             // Start the HTML!


### PR DESCRIPTION
Modify the RTE enhancement code to account for multiple enhancements on a single line.

When moving an enhancement up or down, if there are multiple enhancements on the line, the movement should re-order the enhancements as necessary to give a more intuitive user experience. For example, if the line has enhancements "A B C" and you move "B" up, the enhancements should change order "B A C". If you move "B" up again, then it would move up to the previous line and leave "A C" on the current line.
