### PR TITLE
RTE enhancement span changes to button (BSP-1721)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -2241,6 +2241,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     self.enhancementSetPosition($enhancement, config.alignment);
                 }
 
+                if (config.element) {
+                    self.enhancementSetElement($enhancement, config.element);
+                }
                 self.enhancementUpdate($enhancement);
 
             } else {
@@ -3189,6 +3192,44 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         /**
+         * Get the element type (span or button) for the enhancement.
+         * @returns {String}
+         */
+        enhancementGetElement: function(el) {
+
+            var element;
+            var $enhancement;
+            var self;
+
+            self = this;
+
+            $enhancement = self.enhancementGetWrapper(el);
+
+            element = $enhancement.data('enhancementElement') || 'button';
+
+            return element;
+        },
+
+
+        /**
+         * Set the reference object for the enhancement.
+         */
+        enhancementSetElement: function(el, element) {
+
+            var $enhancement;
+            var self;
+
+            self = this;
+
+            $enhancement = self.enhancementGetWrapper(el);
+
+            $enhancement.data('enhancementElement', element);
+
+            self.rte.triggerChange();
+        },
+
+
+        /**
          * Convert an enhancement into HTML for output.
          *
          * @param {Element} el
@@ -3200,6 +3241,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
         enhancementToHTML: function(el) {
 
             var alignment;
+            var element;
             var reference;
             var $enhancement;
             var html;
@@ -3231,9 +3273,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 reference.alignment = alignment;
             }
 
+            element = self.enhancementGetElement(el);
+            
             if (id) {
 
-                $html = $('<button/>', {
+                $html = $('<' + element + '/>', {
                     'class': 'enhancement',
                     'data-id': id,
                     'data-reference': JSON.stringify(reference),
@@ -3297,6 +3341,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 config.preview = $content.attr('data-preview');
                 config.text = $content.text();
 
+                // Output html should maintain 'span' or 'button' for the enhancement
+                config.element = $content.is('span') ? 'span' : 'button';
+                
                 self.enhancementCreate(config, line);
             }
         },


### PR DESCRIPTION
If the HTML input for the RTE contains a SPAN element for an enhancement, currently it will be changed to a BUTTON element. This commit maintains the SPAN element for the enhancement. New enhancements created within the RTE will continue using a BUTTON element.