### PR TITLE
Search carousel previous not working (BSP-2182)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/carousel.js
+++ b/tool-ui/src/main/webapp/script/v3/input/carousel.js
@@ -689,7 +689,9 @@ function($, bsp_utils) {
                     carousel: self
                 });
 
-            } else if (layout.atMin) {
+            }
+            
+            if (layout.atMin) {
 
                 self.element.trigger(self.eventBegin, {
                     carousel: self


### PR DESCRIPTION
When the search results contain greater than 10 results, when you get to the last “page” of results in the carousel, sometimes the “previous” button does not work to fetch previous results for the carousel tiles. This commit corrects the logic in the carousel so it will trigger both a carousel.end and carousel.begin event when necessary, so the search results code is notified to fetch more results.
