### PR TITLE
RTE prevent blur event from popup enhancement form (BSP-2225)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -775,9 +775,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 return false;
             });
             self.$editor.on('rteBlur', function(){
+                
+                // Set a timeout before performing the blur event.
+                // This is to let other code cancel the blur before it occurs
+                // (such as clicking a toolbar button)
                 self.rteBlurTimeout = setTimeout(function(){
                     self.$el.trigger('rteBlur', [self]);
                 }, 200);
+                
                 return false;
             });
             self.$editor.on('rteChange', function(){
@@ -1332,7 +1337,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             $button.on('click', function(event) {
                 event.preventDefault();
-                clearTimeout(self.rteBlurTimeout);
+                self.blurCancel();
                 self.toolbarHandleClick(item, event);
             });
 
@@ -3459,6 +3464,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 }
             });
 
+            // Prevent the rteBlur event from occurring since technically we will still be in the RTE
+            // even though CodeMirror will lose focus
+            self.blurCancel();
+
             // Do a fake "click" on the link so it will trigger the popup
             // but first wait for the current click to finish so it doesn't interfere
             // with any popups
@@ -4571,6 +4580,19 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
+
+        /**
+         * Cancel the rteBlur event.
+         * This is used in some instances where CodeMirror will lose focus,
+         * but we have additional work to do, so we don't want to fire a blur event.
+         */
+        blurCancel: function() {
+            var self;
+            self = this;
+            clearTimeout(self.rteBlurTimeout);
+        },
+        
+        
         refresh: function() {
             var self;
             self = this;

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -894,6 +894,9 @@ li.CodeMirror-hint-active {
 
 .rte2-placeholder-showing .CodeMirror pre {
   color: @color-placeholder;
+  span {
+    color: @color-placeholder !important;
+  }
 }
 
 .rte2-wrapper .CodeMirror {


### PR DESCRIPTION
When user edits an inline enhancement, the rteBlur event is still firing (which causes some problems due to editable placeholders). This commit cancels the blur even when the popup enhancement form appears.