### PR TITLE
Adds capability to localize "Back to" text on Publish widget.  BSP-2446

### DIFF
--- a/db/src/main/resources/FallbackDefault_en.properties
+++ b/db/src/main/resources/FallbackDefault_en.properties
@@ -1,4 +1,6 @@
 action.archive=Archive
+action.backToInitialDraft=Back to Initial Draft
+action.backToLive=Back to Live
 action.cancel=Cancel
 action.clear=Clear
 action.copy=Copy This {displayName}
@@ -76,6 +78,8 @@ placeholder.required=(Required)
 search.filters=Filters
 search.label=Search
 
+subtitle.initialDraft=Initial Draft
+subtitle.live=Live
 subtitle.settings=Settings
 subtitle.tools=Tools
 

--- a/db/src/main/resources/FallbackDefault_es.properties
+++ b/db/src/main/resources/FallbackDefault_es.properties
@@ -1,4 +1,6 @@
 action.archive=Archivar
+action.backToInitialDraft=Volver a borrador inicial
+action.backToLive=Volver a en vivo
 action.cancel=Cancelar
 action.clear=Borrar
 action.copy=Copiar {displayName}
@@ -70,6 +72,8 @@ placeholder.required=(Obligatorio)
 search.filters=Filtros
 search.label=Busqueda
 
+subtitle.initialDraft=Borrador inicial
+subtitle.live=En vivo
 subtitle.settings=Configuración
 subtitle.tools=Herramientas
 

--- a/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_en.properties
@@ -1,5 +1,3 @@
-action.backToLive=Back to Live
-action.backToInitialDraft=Back to Initial Draft
 action.editFull=Edit In Full
 action.ignoreLock=Ignore Lock
 action.lock=Lock
@@ -14,7 +12,5 @@ message.missing=No content found that matches {queryString}!
 message.notAccessible={typeLabel}: {objectLabel} can't be accessed from {siteName}!
 
 subtitle.current=Current
-subtitle.initialDraft=Initial Draft
-subtitle.live=Live
 
 title.preview=Preview

--- a/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_en.properties
@@ -1,4 +1,5 @@
-action.backTo=Back to
+action.backToLive=Back to Live
+action.backToInitialDraft=Back to Initial Draft
 action.editFull=Edit In Full
 action.ignoreLock=Ignore Lock
 action.lock=Lock

--- a/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_en.properties
@@ -1,3 +1,4 @@
+action.backTo=Back to
 action.editFull=Edit In Full
 action.ignoreLock=Ignore Lock
 action.lock=Lock

--- a/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_es.properties
@@ -1,5 +1,3 @@
-action.backToLive=Volver a en vivo
-action.backToInitialDraft=Volver a borrador inicial
 action.editFull=Editar en pantalla completa
 action.ignoreLock=Ignorar bloqueo
 action.lock=Bloquear
@@ -14,7 +12,5 @@ message.missing=No se encontró contenido correspondiente {queryString}!
 message.notAccessible={typeLabel}: {objectLabel} no puede ser accesado desde {siteName}!
 
 subtitle.current=Actual
-subtitle.initialDraft=Borrador inicial
-subtitle.live=En vivo
 
 title.preview=Vista Previa

--- a/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/EditDefault_es.properties
@@ -1,3 +1,5 @@
+action.backToLive=Volver a en vivo
+action.backToInitialDraft=Volver a borrador inicial
 action.editFull=Editar en pantalla completa
 action.ignoreLock=Ignorar bloqueo
 action.lock=Bloquear

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -1051,8 +1051,9 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                                         wp.writeStart("a",
                                                 "class", "icon icon-arrow-left",
                                                 "href", wp.url("", "draftId", null));
-                                            wp.writeHtml("Back to ");
-                                            wp.writeHtml(!visible ? "Initial Draft" : "Live");
+                                            wp.writeHtml(wp.localize("com.psddev.cms.tool.page.content.Edit", "action.backTo"));
+                                            wp.writeHtml(" ");
+                                            wp.writeHtml(wp.localize("com.psddev.cms.tool.page.content.Edit", !visible ? "subtitle.initialDraft" : "subtitle.live"));
                                         wp.writeEnd();
                                     wp.writeEnd();
                                 }

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -1051,7 +1051,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                                         wp.writeStart("a",
                                                 "class", "icon icon-arrow-left",
                                                 "href", wp.url("", "draftId", null));
-                                            wp.writeHtml(wp.localize("com.psddev.cms.tool.page.content.Edit",
+                                            wp.writeHtml(wp.localize(editingState.getType(),
                                                     !visible ? "action.backToInitialDraft" : "action.backToLive"));
                                         wp.writeEnd();
                                     wp.writeEnd();

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -500,7 +500,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                                 wp.writeStart("div", "class", "contentDiffCurrent " + (history != null ? "contentDiffRight" : "contentDiffLeft"));
                                     wp.writeStart("h2");
                                         wp.writeHtml(wp.localize(
-                                                "com.psddev.cms.tool.page.content.Edit",
+                                                editingState.getType(),
                                                 !visible ? "subtitle.initialDraft" : "subtitle.live"));
                                     wp.writeEnd();
                                     wp.writeSomeFormFields(original.getOriginalObject(), true, null, null);

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -1051,9 +1051,8 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                                         wp.writeStart("a",
                                                 "class", "icon icon-arrow-left",
                                                 "href", wp.url("", "draftId", null));
-                                            wp.writeHtml(wp.localize("com.psddev.cms.tool.page.content.Edit", "action.backTo"));
-                                            wp.writeHtml(" ");
-                                            wp.writeHtml(wp.localize("com.psddev.cms.tool.page.content.Edit", !visible ? "subtitle.initialDraft" : "subtitle.live"));
+                                            wp.writeHtml(wp.localize("com.psddev.cms.tool.page.content.Edit",
+                                                    !visible ? "action.backToInitialDraft" : "action.backToLive"));
                                         wp.writeEnd();
                                     wp.writeEnd();
                                 }


### PR DESCRIPTION
"Back to Live" and "Back to Initial Draft" can both be localized independently with this pull request.

<img width="345" alt="screen shot 2016-08-10 at 9 38 01 pm" src="https://cloud.githubusercontent.com/assets/400882/17576687/598a1dd8-5f43-11e6-961f-d15dc8403733.png">
