### PR TITLE
RTE paste from MSWord paragraph spacing (BSP-2444)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -333,6 +333,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                         if (t.match(/^\s*$/)) {
                             $el.text('');
                         }
+                        // If the P element has a margin-bottom style add a blank line after
+                        // so it more closely reprents a paragraph with space after it.
+                        if ($el.is('[style*="margin-bottom"]')) {
+                            $el.after('<br/>');
+                        }
                         $replacement = $('<span>', {'data-rte2-sanitize': 'linebreakSingle'});
                         $replacement.append( $el.contents() );
                         $el.replaceWith( $replacement );


### PR DESCRIPTION
Currently pasting from MSWord, paragraphs are converted into single lines within the RTE with no space between paragraphs. This works fine for the default word style, but in some cases where paragraph styles have been applied, the Word file appears with spaces between the paragraphs. In those cases when pasting into the RTE, we lose the space between paragraphs and it is confusing to the user. This commit checks the pasted HTML that comes from word, and if the paragraph has a margin-bottom style attribute, then we assume a blank line should be placed after the paragraph, so the content in the RTE will more closely reflect the Word document.