### PR TITLE
RTE link change is not saving on publish (BSP-2426)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -181,12 +181,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                                 // Update the link attributes
                                 mark.attributes = attributes;
                             }
+                            self.rte.triggerChange();
                         }).fail(function(){
 
                             // If the popup was closed without saving and there is no href already the link,
                             // then remove the link.
                             if (!mark.attributes) {
                                 mark.clear();
+                                self.rte.triggerChange();
                             }
                         });
                         


### PR DESCRIPTION
If the RTE already contains a link and you edit the link URL then publish the page, the link is not saved if you have not made other changes. This commit triggers a change event when the link is edited so the changes will be processed.