### PR TITLE
RTE multi-line block style clear other styles (BSP-2436)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2239,8 +2239,17 @@ define([
             // If this is a set of mutually exclusive styles, clear the other styles
             if (styleObj.clear) {
                 $.each(styleObj.clear, function(i, styleKey) {
-                    if (self.blockIsStyle(styleKey, range)) {
-                        self.blockRemoveStyle(styleKey, range);
+                    var lineNumber;
+                    var lineRange;
+
+                    for (lineNumber = range.from.line; lineNumber <= range.to.line; lineNumber++) {
+                        lineRange = {
+                            from: {line: lineNumber, ch:0},
+                            to: {line: lineNumber, ch:0}
+                        };
+                        if (self.blockIsStyle(styleKey, lineRange)) {
+                            self.blockRemoveStyle(styleKey, lineRange);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
When a block style contains a list of other elements that should be cleared, the clearing code was not working if the selected range went over multiple lines.