### PR TITLE
RTE do not export BR element before block element (BSP-2038)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -6447,6 +6447,7 @@ define([
             var enhancementsByLine;
             var html;
             var lineNo;
+            var needBR;
             var rangeWasSpecified;
             var self;
 
@@ -6653,6 +6654,9 @@ define([
                             // Now determine which element to create for the line.
                             // For example, if it is a list then we would create an 'LI' element.
                             htmlStartOfLine += openElement(styleObj, lineStyleData.attributes);
+                            
+                            // Since this is a block element, we do not need a BR to end the previous line
+                            needBR = false;
                         }
                     }); // .each(lineClasses)
 
@@ -6679,11 +6683,18 @@ define([
                             // list text: <li>previous_text<br/>this_text
                             if (!containerClosed) {
                                 html += '<br/>';
+                                needBR = false;
                             }
                         }
                     }
                 } // if lineNo is in range
  
+                // Does the previous line need to end with a line break?
+                if (needBR) {
+                    html += '<br/>';
+                    needBR = false;
+                }
+                
                 // Determine if there are any enhancements on this line
                 if (enhancementsByLine[lineNo] && options.enhancements !== false) {
                     
@@ -7002,8 +7013,9 @@ define([
                     } else if (charInRange && rawLastChar && !self.rawBr) {
                         html += '\n';
                     } else if (charInRange && containerActive.length === 0) {
-                        // No block elements so add a line break
-                        html += '<br/>';
+                        // There is no block element on this line, so set a flag to add a BR element at the start
+                        // of the next line (unless that next line contains a block element)
+                        needBR = true;
                     }
 
                     // Add any content that needs to go after the line


### PR DESCRIPTION
Change HTML export to avoid adding a BR element before a block element.