### PR TITLE
RTE support limited pasting from adobe reader (BSP-2454)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -346,6 +346,26 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     }
 
                 }
+            },
+            
+            'adobeReader': {
+                // Adobe Reader pastes html that is mostly junk: each word is surrounded by a P element.
+                // The best we can do is put a space between each word and output all words without line breaks.
+                isType: function(content, html) {
+                    return Boolean(html && html.indexOf('Cocoa HTML Writer') !== -1);
+                },
+                
+                rules: {
+                    'p': function($el) {
+                        var $replacement;
+                        $replacement = $('<span>');
+                        $replacement.append( $el.contents() );
+                        if ($el.is(':not(:last-child)')) {
+                            $replacement.append(' ');
+                        }
+                        $el.replaceWith( $replacement );
+                    }
+                }
             }
         },
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4483,7 +4483,7 @@ define([
             $.each(self.clipboardSanitizeTypes, function(typeName, typeConf) {
                 var isType;
                 if (typeConf.isType && typeConf.rules) {
-                    isType = typeConf.isType($el);
+                    isType = typeConf.isType($el, html);
                     if (isType) {
                         // The pasted content matches this type, so apply these rules
                         self.clipboardSanitizeApplyRules($el, typeConf.rules);


### PR DESCRIPTION
Adobe Reader produces HTML that is mostly junk, with each word surrounded by a P element. These paste rules try to make that slightly more useable by combining the words with no linebreaks but a space between each word. It is recommended for users to avoid Adobe Reader and use another PDF reader that provides better HTML paste support (such as the built-in Mac Preview).