### PR TITLE
RTE change behavior of BR before block element (BSP-2038)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -6712,7 +6712,11 @@ define([
                 }
 
                 // Now add the html for the beginning of the line.
-                html += htmlStartOfLine;
+                if (htmlStartOfLine) {
+                    // Kill the last <br> since it's not needed before a block element
+                    html = html.replace(/<br\/?>$/, '');
+                    html += htmlStartOfLine;
+                }
                 
                 // Get the start/end points of all the marks on this line
                 // For these objects the key is the character number,
@@ -7370,9 +7374,8 @@ define([
                             // Determine if the element maps to one of our defined styles
                             matchStyleObj = self.getStyleForElement(next);
                             
-                            // Create new line if this is a block element and the previous text did not end the line.
-                            if (matchStyleObj && matchStyleObj.line && val[ val.length - 1 ] !== '\n') {
-                                // Note in this case, when exporting HTML a <br/> element will be added.
+                            // Create new line if this is a block element
+                            if (matchStyleObj && matchStyleObj.line) {
                                 val += '\n';
                             }
                         }


### PR DESCRIPTION
For the RTE, modify import/export of HTML to handle cases where BR elements might or might not be in front of block elements.

Examples:

HTML 1:

    test<h1>head</h1>

RTE 1

    test
    head

HTML 2:

    test<br><h1>head</h1>

RTE 2:

    test
    <blank line>
    head

HTML 3:

    test<br><br><h1>head</h1>

RTE 3:

    test
    <blank>
    <blank>
    head

The output HTML should remain the same as the input HTML. However, when editing content that was previously entered using an older version of the RTE there might be some confusion, because the previous content:

    test<br><h1>head</h1>

was previously displayed in the RTE without a blank line between test and head, and now it will be displayed with a blank line in the RTE (even though the resulting HTML output will be the same).