### PR TITLE
RTE prevent track changes within comments (BSP-2474)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -95,6 +95,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 
                 // Don't let this style be removed by the "Clear" toolbar button
                 internal: true,
+                
+                // Don't allow tracked changes within this style
+                trackChanges: false,
 
                 onCreate: function (mark) {
                     var $html = $('html');


### PR DESCRIPTION
When track changes is active, changes to comments should not be marked as insertions or deletions.