### PR TITLE
BSP-2510 Adds `calculated` flag to @ToolUi.CollectionItemWeight

### DIFF
--- a/db/etc/clirr-ignored.xml
+++ b/db/etc/clirr-ignored.xml
@@ -51,6 +51,12 @@
     </difference>
 
     <difference>
+        <className>com/psddev/cms/db/ToolUi$CollectionItemWeight</className>
+        <differenceType>7012</differenceType>
+        <method>boolean draggable()</method>
+    </difference>
+
+    <difference>
         <className>com/psddev/cms/db/ToolUi$Placeholder</className>
         <differenceType>7012</differenceType>
         <method>boolean clearOnChange()</method>

--- a/db/etc/clirr-ignored.xml
+++ b/db/etc/clirr-ignored.xml
@@ -53,7 +53,7 @@
     <difference>
         <className>com/psddev/cms/db/ToolUi$CollectionItemWeight</className>
         <differenceType>7012</differenceType>
-        <method>boolean draggable()</method>
+        <method>boolean calculated()</method>
     </difference>
 
     <difference>

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -41,6 +41,7 @@ public class ToolUi extends Modification<Object> {
     private Boolean collectionItemProgress;
     private Boolean collectionItemToggle;
     private Boolean collectionItemWeight;
+    private Boolean collectionItemWeightDraggable;
     private Boolean colorPicker;
     private String cssClass;
     private Boolean defaultSearchResult;
@@ -133,6 +134,14 @@ public class ToolUi extends Modification<Object> {
 
     public void setCollectionItemWeight(boolean collectionItemWeight) {
         this.collectionItemWeight = collectionItemWeight ? Boolean.TRUE : null;
+    }
+
+    public boolean isCollectionItemWeightDraggable() {
+        return Boolean.TRUE.equals(collectionItemWeightDraggable);
+    }
+
+    public void setCollectionItemWeightDraggable(boolean collectionItemWeightDraggable) {
+        this.collectionItemWeightDraggable = collectionItemWeightDraggable ? Boolean.TRUE : null;
     }
 
     public boolean isColorPicker() {
@@ -890,6 +899,7 @@ public class ToolUi extends Modification<Object> {
     @Target(ElementType.FIELD)
     public @interface CollectionItemWeight {
         boolean value() default true;
+        boolean draggable() default true;
     }
 
     private static class CollectionItemWeightProcessor implements ObjectField.AnnotationProcessor<CollectionItemWeight> {
@@ -897,6 +907,7 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, ObjectField field, CollectionItemWeight annotation) {
             field.as(ToolUi.class).setCollectionItemWeight(annotation.value());
+            field.as(ToolUi.class).setCollectionItemWeightDraggable(annotation.draggable());
         }
     }
 

--- a/db/src/main/java/com/psddev/cms/db/ToolUi.java
+++ b/db/src/main/java/com/psddev/cms/db/ToolUi.java
@@ -41,7 +41,7 @@ public class ToolUi extends Modification<Object> {
     private Boolean collectionItemProgress;
     private Boolean collectionItemToggle;
     private Boolean collectionItemWeight;
-    private Boolean collectionItemWeightDraggable;
+    private Boolean collectionItemWeightCalculated;
     private Boolean colorPicker;
     private String cssClass;
     private Boolean defaultSearchResult;
@@ -136,12 +136,12 @@ public class ToolUi extends Modification<Object> {
         this.collectionItemWeight = collectionItemWeight ? Boolean.TRUE : null;
     }
 
-    public boolean isCollectionItemWeightDraggable() {
-        return Boolean.TRUE.equals(collectionItemWeightDraggable);
+    public boolean isCollectionItemWeightCalculated() {
+        return Boolean.TRUE.equals(collectionItemWeightCalculated);
     }
 
-    public void setCollectionItemWeightDraggable(boolean collectionItemWeightDraggable) {
-        this.collectionItemWeightDraggable = collectionItemWeightDraggable ? Boolean.TRUE : null;
+    public void setCollectionItemWeightCalculated(boolean collectionItemWeightCalculated) {
+        this.collectionItemWeightCalculated = collectionItemWeightCalculated ? Boolean.TRUE : null;
     }
 
     public boolean isColorPicker() {
@@ -891,7 +891,9 @@ public class ToolUi extends Modification<Object> {
 
     /**
      * Specifies whether the target field should be displayed using the weighted collection UI.
-     * Expected field values are between 0.0 and 1.0.
+     * Expected field values are between 0.0 and 1.0. Fields that are {@code calculated} will
+     * not allow weights to be edited through the default UI.
+     *
      */
     @Documented
     @ObjectField.AnnotationProcessorClass(CollectionItemWeightProcessor.class)
@@ -899,7 +901,7 @@ public class ToolUi extends Modification<Object> {
     @Target(ElementType.FIELD)
     public @interface CollectionItemWeight {
         boolean value() default true;
-        boolean draggable() default true;
+        boolean calculated() default false;
     }
 
     private static class CollectionItemWeightProcessor implements ObjectField.AnnotationProcessor<CollectionItemWeight> {
@@ -907,7 +909,7 @@ public class ToolUi extends Modification<Object> {
         @Override
         public void process(ObjectType type, ObjectField field, CollectionItemWeight annotation) {
             field.as(ToolUi.class).setCollectionItemWeight(annotation.value());
-            field.as(ToolUi.class).setCollectionItemWeightDraggable(annotation.draggable());
+            field.as(ToolUi.class).setCollectionItemWeightCalculated(annotation.calculated());
         }
     }
 

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -555,7 +555,7 @@ UUID containerObjectId = State.getInstance(request.getAttribute("containerObject
 
 if (!isValueExternal) {
     Set<ObjectType> bulkUploadTypes = new HashSet<ObjectType>();
-    Map<ObjectType, String> weightedTypesandFieldsMap = new CompactMap<ObjectType, String>();
+    Map<ObjectType, String> weightedTypesAndFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> toggleTypesAndFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> progressTypesAndFieldsMap = new CompactMap<ObjectType, String>();
 
@@ -568,7 +568,7 @@ if (!isValueExternal) {
                 }
             }
             if (ui.isCollectionItemWeight()) {
-                weightedTypesandFieldsMap.put(t, f.getInternalName());
+                weightedTypesAndFieldsMap.put(t, f.getInternalName());
             }
             if (ui.isCollectionItemToggle()) {
                 toggleTypesAndFieldsMap.put(t, f.getInternalName());
@@ -582,7 +582,7 @@ if (!isValueExternal) {
     boolean displayGrid = field.as(ToolUi.class).isDisplayGrid();
 
     // Only display weights if all valid types have a @ToolUi.CollectionItemWeight annotated field
-    boolean displayWeights = weightedTypesandFieldsMap.size() == validTypes.size();
+    boolean displayWeights = weightedTypesAndFieldsMap.size() == validTypes.size();
     boolean displayAlternateListUi = displayWeights || toggleTypesAndFieldsMap.size() > 0 || progressTypesAndFieldsMap.size() > 0;
 
     StringBuilder genericArgumentsString = new StringBuilder();
@@ -630,7 +630,7 @@ if (!isValueExternal) {
 
                 String progressFieldName = progressTypesAndFieldsMap.get(itemType);
                 String toggleFieldName = toggleTypesAndFieldsMap.get(itemType);
-                String weightFieldName = weightedTypesandFieldsMap.get(itemType);
+                String weightFieldName = weightedTypesAndFieldsMap.get(itemType);
 
                 wp.writeStart("li",
                         "class", expanded ? "expanded" : null,
@@ -692,7 +692,7 @@ if (!isValueExternal) {
 
                 String progressFieldName = progressTypesAndFieldsMap.get(type);
                 String toggleFieldName = toggleTypesAndFieldsMap.get(type);
-                String weightFieldName = weightedTypesandFieldsMap.get(type);
+                String weightFieldName = weightedTypesAndFieldsMap.get(type);
 
                 wp.writeStart("script", "type", "text/template");
                     wp.writeStart("li",

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -558,7 +558,7 @@ if (!isValueExternal) {
     Map<ObjectType, String> weightedTypesAndFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> toggleTypesAndFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> progressTypesAndFieldsMap = new CompactMap<ObjectType, String>();
-    int weightedAndDraggableFieldsCount = 0;
+    int calculatedWeightsFieldCount = 0;
 
     for (ObjectType t : validTypes) {
         for (ObjectField f : t.getFields()) {
@@ -570,8 +570,8 @@ if (!isValueExternal) {
             }
             if (ui.isCollectionItemWeight()) {
                 weightedTypesAndFieldsMap.put(t, f.getInternalName());
-                if (ui.isCollectionItemWeightDraggable()) {
-                    weightedAndDraggableFieldsCount ++;
+                if (ui.isCollectionItemWeightCalculated()) {
+                    calculatedWeightsFieldCount ++;
                 }
             }
             if (ui.isCollectionItemToggle()) {
@@ -588,7 +588,7 @@ if (!isValueExternal) {
     // Only display weights if all valid types have a @ToolUi.CollectionItemWeight annotated field
     int validTypesSize = validTypes.size();
     boolean displayWeights = weightedTypesAndFieldsMap.size() == validTypesSize;
-    boolean weightsDraggable = weightedAndDraggableFieldsCount == validTypesSize;
+    boolean weightsCalculated = calculatedWeightsFieldCount == validTypesSize;
     boolean displayAlternateListUi = displayWeights || toggleTypesAndFieldsMap.size() > 0 || progressTypesAndFieldsMap.size() > 0;
 
     StringBuilder genericArgumentsString = new StringBuilder();
@@ -614,7 +614,7 @@ if (!isValueExternal) {
         if (displayWeights) {
             wp.writeStart("div",
                     "class", "repeatableForm-itemWeights",
-                    "data-draggable", weightsDraggable);
+                    "data-calculated", weightsCalculated);
 
             wp.writeEnd();
         }

--- a/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/field/list/record.jsp
@@ -558,6 +558,7 @@ if (!isValueExternal) {
     Map<ObjectType, String> weightedTypesAndFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> toggleTypesAndFieldsMap = new CompactMap<ObjectType, String>();
     Map<ObjectType, String> progressTypesAndFieldsMap = new CompactMap<ObjectType, String>();
+    int weightedAndDraggableFieldsCount = 0;
 
     for (ObjectType t : validTypes) {
         for (ObjectField f : t.getFields()) {
@@ -569,6 +570,9 @@ if (!isValueExternal) {
             }
             if (ui.isCollectionItemWeight()) {
                 weightedTypesAndFieldsMap.put(t, f.getInternalName());
+                if (ui.isCollectionItemWeightDraggable()) {
+                    weightedAndDraggableFieldsCount ++;
+                }
             }
             if (ui.isCollectionItemToggle()) {
                 toggleTypesAndFieldsMap.put(t, f.getInternalName());
@@ -582,7 +586,9 @@ if (!isValueExternal) {
     boolean displayGrid = field.as(ToolUi.class).isDisplayGrid();
 
     // Only display weights if all valid types have a @ToolUi.CollectionItemWeight annotated field
-    boolean displayWeights = weightedTypesAndFieldsMap.size() == validTypes.size();
+    int validTypesSize = validTypes.size();
+    boolean displayWeights = weightedTypesAndFieldsMap.size() == validTypesSize;
+    boolean weightsDraggable = weightedAndDraggableFieldsCount == validTypesSize;
     boolean displayAlternateListUi = displayWeights || toggleTypesAndFieldsMap.size() > 0 || progressTypesAndFieldsMap.size() > 0;
 
     StringBuilder genericArgumentsString = new StringBuilder();
@@ -607,7 +613,8 @@ if (!isValueExternal) {
 
         if (displayWeights) {
             wp.writeStart("div",
-                    "class", "repeatableForm-itemWeights");
+                    "class", "repeatableForm-itemWeights",
+                    "data-draggable", weightsDraggable);
 
             wp.writeEnd();
         }
@@ -643,6 +650,8 @@ if (!isValueExternal) {
                         // so if that field is changed the front-end knows that the thumbnail should also be updated
                         "data-preview", wp.getPreviewThumbnailUrl(item),
                         "data-preview-field", itemType.getPreviewField(),
+
+                        // Add additional data attributes for customizing embedded item display
                         "data-toggle-field", !StringUtils.isBlank(toggleFieldName) ? toggleFieldName : null,
                         "data-weight-field", !StringUtils.isBlank(weightFieldName) ? weightFieldName : null,
                         "data-progress-field-value", !StringUtils.isBlank(progressFieldName) ? ObjectUtils.to(int.class, ObjectUtils.to(double.class, itemState.get(progressFieldName)) * 100) : null,

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -711,6 +711,14 @@ The HTML within the repeatable element must conform to these standards:
                     self.repositionCollectionItemWeight(oldIndex, newIndex);
 
                 });
+                 
+                var $itemWeightsContainer = self.dom.$list.parent().find('.repeatableForm-itemWeights');
+
+                if ($itemWeightsContainer.data('draggable')) {
+                    self.collectionItemWeightsCalculated = false;
+                } else {
+                    self.collectionItemWeightsCalculated = true;
+                }
               
                 self.initCollectionItemWeightResetButton();
           
@@ -803,7 +811,10 @@ The HTML within the repeatable element must conform to these standards:
                     $itemWeightContainer.children().eq(itemIndex - 1).after($itemWeight);
                 }
 
-                $itemWeight.prepend(self.createCollectionItemWeightHandle($item));
+                // Avoid creating handles if draggable is false
+                if (!self.collectionItemWeightsCalculated) {
+                    $itemWeight.prepend(self.createCollectionItemWeightHandle($item));
+                }
 
                 var itemWeightDoubleValue = $itemWeight.attr('data-weight');
                 
@@ -887,6 +898,11 @@ The HTML within the repeatable element must conform to these standards:
 
             initCollectionItemWeightResetButton: function () {
                 var self = this;
+
+                if (self.collectionItemWeightsCalculated) {
+                    return;
+                }
+
                 self.dom.$list.parent().prepend(
                   $('<a>', {
                       'class': 'repeatableForm-weightResetButton',

--- a/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.repeatable.js
@@ -713,12 +713,7 @@ The HTML within the repeatable element must conform to these standards:
                 });
                  
                 var $itemWeightsContainer = self.dom.$list.parent().find('.repeatableForm-itemWeights');
-
-                if ($itemWeightsContainer.data('draggable')) {
-                    self.collectionItemWeightsCalculated = false;
-                } else {
-                    self.collectionItemWeightsCalculated = true;
-                }
+                self.collectionItemWeightsCalculated = $itemWeightsContainer.data('calculated');
               
                 self.initCollectionItemWeightResetButton();
           


### PR DESCRIPTION
New flag to indicate whether or not the weights should be editable via default drag UI. By default, calculated is false, which would allow drag to resize.