### PR TITLE
RTE bugfix for track changes and undo history (BSP-2491, BSP-2042, BSP-1503)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1645,10 +1645,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 }
             }
 
-            // Certain styles like comments look strange when there are two
-            // adjacent marks, so combine adjacent marks if possible.
-            rte.inlineCombineAdjacentMarks();
-            
             // Update the toolbar so it makes the buttons active or inactive
             // based on the cursor position or selection
             self.toolbarUpdate();

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2033,6 +2033,7 @@ define([
                 var i;
                 var mark;
                 var markNext;
+                var hasAttributes;
 
                 i = 0;
 
@@ -2042,6 +2043,7 @@ define([
                 } else if (self.classes[className].initialBody) {
                     // Do not combine any classname that has initialBody (for example, a "discretionary hyphen")
                     // because we don't want to combine them
+
                 } else {
                     // Combine spans if necessary
                     while (spans[i]) {
@@ -2053,8 +2055,12 @@ define([
                             break;
                         }
                         
+                        // Check if either mark has attributes, in which case we should not combine
+                        hasAttributes = Boolean((mark.marker && !$.isEmptyObject(mark.marker.attributes)) ||
+                            (markNext.marker && !$.isEmptyObject(markNext.marker.attributes)));
+
                         // Check if the marks overlap
-                        if (markNext.from <= mark.to) {
+                        if ((markNext.from <= mark.to) && !hasAttributes) {
                             
                             // Extend the first mark
                             mark.to = markNext.to;

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -2019,13 +2019,7 @@ define([
                 if (!self.classes[className]) {
                     return;
                 }
-     
-                // Skip any classname that has an onClick since we dont' want to mess with those.
-                // For example, links.
-                if (self.classes[className].onClick) {
-                    return;
-                }
-                
+                     
                 if (!spansByClassName[className]) {
                     spansByClassName[className] = [];
                 }
@@ -2041,35 +2035,45 @@ define([
                 var markNext;
 
                 i = 0;
-                while (spans[i]) {
 
-                    mark = spans[i];
-                    markNext = spans[i + 1];
-                    
-                    if (!markNext) {
-                        break;
-                    }
-
-                    // Check if the marks overlap
-                    if (markNext.from <= mark.to) {
+                if (self.classes[className].onClick) {
+                    // Do not combine any classname that has an onClick since we dont' want to mess with those.
+                    // For example, links.
+                } else if (self.classes[className].initialBody) {
+                    // Do not combine any classname that has initialBody (for example, a "discretionary hyphen")
+                    // because we don't want to combine them
+                } else {
+                    // Combine spans if necessary
+                    while (spans[i]) {
                         
-                        // Extend the first mark
-                        mark.to = markNext.to;
+                        mark = spans[i];
+                        markNext = spans[i + 1];
                         
-                        // Remove the next mark
-                        spans.splice(i + 1, 1);
+                        if (!markNext) {
+                            break;
+                        }
                         
-                        // Do not increment the counter in this case because
-                        // we need to recheck the first mark against the following
-                        // mark because it might overlap that one too
+                        // Check if the marks overlap
+                        if (markNext.from <= mark.to) {
+                            
+                            // Extend the first mark
+                            mark.to = markNext.to;
+                            
+                            // Remove the next mark
+                            spans.splice(i + 1, 1);
+                            
+                            // Do not increment the counter in this case because
+                            // we need to recheck the first mark against the following
+                            // mark because it might overlap that one too
+                            continue;
+                        }
                         
-                    } else {
-                        // No overlap so continue to the next mark
+                        // Continue to the next mark
                         i++;
                     }
                 }
                 
-                // Add these marks to the list of marks we will return
+                // Add these spans to the list of marks we will return
                 Array.prototype.push.apply(spansAdjusted, spans);
             });
             


### PR DESCRIPTION
When track changes was turned on, the undo history was not working as expected. This fix required changes to the inlineCleanup() function, which combined CodeMirror marks if they were adjacent to each other, so that the HTML output would be cleaner.

Rather than modify the actual CodeMirror marks, the logic was changed so the HTML output routine now detects adjacent marks on-the-fly, so the CodeMirror marks would not be modified and the undo history would not be changed.

Also fixes a problem where styles with initialBody content were being combined, so for example if you inserted two "discretionary hyphen" styles, it would combine them and the HTML would output only a single element for the two marks. Instead those marks are not combined when they are adjacent to each other, and the HTML output contains two elements.

Also fixes a problem where styles with attributes were being combined. Instead marks are checked for attributes, and if they have attributes they will not be combined when they are adjacent to each other.