### PR TITLE
Moves call to ExternalContent#getResponse into beforeCommit.

### DIFF
--- a/db/src/main/java/com/psddev/cms/db/ExternalContent.java
+++ b/db/src/main/java/com/psddev/cms/db/ExternalContent.java
@@ -184,8 +184,8 @@ public class ExternalContent extends Content implements Renderer {
     }
 
     @Override
-    protected void beforeSave() {
-        super.beforeSave();
+    protected void beforeCommit() {
+        super.beforeCommit();
         getResponse();
     }
 


### PR DESCRIPTION
Prevents gratuitous external API calls by ContentState servlet when editing content.