### PR TITLE
RTE after link edit focus on editor with no append (BSP-2428)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -190,7 +190,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                                 mark.clear();
                                 self.rte.triggerChange();
                             }
-                        });
+                        }).always(function(){
+                            // After editing the link, put the cursor at the end of the link text
+                            // and make sure typing doesn't expand the link.
+                            self.linkAfterEdit();                            
+                        })
                         
                     }, 100);
 
@@ -2051,6 +2055,37 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.linkDeferred = deferred;
 
             return deferred.promise();
+        },
+
+
+        /**
+         * Code to run after the edit popup was completed or canceled.
+         */
+        linkAfterEdit: function(){
+            
+            var range;
+            var self;
+            self = this;
+            
+            self.rte.focus();
+            
+            // After editing the mark, the range of text will be selected.
+            // Instead we want to put the cursor at the end of the range.
+            range = self.rte.getRange();
+            if (range.from.ch !== range.to.ch) {
+                
+                range.from = range.to;
+                self.rte.setSelection(range);
+
+                // Now clear the styles at the cursor point so new characters typed will not expand the link.
+                // However, if user moves the cursor then returns to the end of the link, then characters typed
+                // will be added to the link.
+                self.rte.removeStyles();
+                
+                // Make sure the toolbar updates so the link button is not highlighted, so user knows typing
+                // will not expand the link.
+                self.toolbarUpdate();
+            }
         },
 
 


### PR DESCRIPTION
Feature request for the RTE after editing a link the focus should return to the editor. Also the cursor should be placed after the link, and immediately typing more text should not expand the link. Note that if you move the cursor, then return it after the link, then typing will expand the link (this is standard behavior for marked regions, such as bold, etc.)