### PR TITLE
RTE improve context checking with keymap styles (BSP-1940)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -844,6 +844,109 @@ define([
         },
         
         
+        /**
+         * Determines if a particular style is allowed to be applied based on the context rules.
+         *
+         * @param  {String} styleKey
+         * The style key that you want to check.
+         * @param  {Object} range
+         * The range to check. If undefined will call getRange().
+         * @param  {Array} context
+         * The context as returned by getContext(). If undefined, will call getContext().
+         * 
+         * @return {Boolean}
+         */
+        checkContext: function(styleKey, range, context) {
+            
+            var rangeCollapsed;
+            var self;
+            var styles;
+            var styleObj;
+            var validContextInner;
+            var validContextOuter;
+            
+            self = this;
+            context = context || self.getContext(range);
+            range = range || self.getRange();
+            rangeCollapsed = range.from.line === range.to.line && range.from.ch === range.to.ch;
+            
+            // Get all the styles defined on the current range
+            // Note ALL characters in the range must have the style or it won't be returned
+            styles = $.extend({}, self.inlineGetStyles(range), self.blockGetStyles(range));
+           
+            styleObj = self.styles[styleKey] || {};
+            
+            if (styleObj.context) {
+                
+                // Loop through all the current contexts.
+                // Note there can be multiple contexts because multiple characters can be
+                // selected in the range, and each character might be in a different context.
+                // For example, if the character R represents the selected range:
+                // aaa<B>RRR</B>RRR<I>RRR</I>aaa
+                // Then the context would be B, I, and null.
+                //
+                // We must check each context that is selected, to determine if
+                // the style is allowed in that context.
+                //
+                // If the style fails for any one of the contexts, then it
+                // should be invalid, and we should prevent the user from applying the style
+                // across the range.
+                
+                // Loop through all the contexts for the selected range
+                validContextInner = true;
+                $.each(context, function(contextElement) {
+                    if (contextElement === '') {
+                        contextElement = null;
+                    }
+                    
+                    // If a different root context was specified, then use that as the root element
+                    // For example, if the rte is meant to edit the content inside a '<mycontent>' element,
+                    // then contextRoot would be 'mycontent', and only those elements allowed in that element
+                    // would be allowed.
+                    if (self.contextRoot && contextElement === null) {
+                        contextElement = self.contextRoot;
+                    }
+                    
+                    // Is this contextElement listed among the context allowed by the current style?
+                    if ($.inArray(contextElement, styleObj.context) === -1) {
+                        
+                        // Special case - if this style can be toggled, then it should be considered valid
+                        // if the entire range contains this style
+                        if (contextElement === styleObj.element && styleObj.toggle && styles[styleKey]) {
+                            return; // continue looping
+                        }
+                        
+                        validContextInner = false;
+                        return false; // stop looping
+                    }
+                });
+                
+                validContextOuter = false;
+                
+                if (!rangeCollapsed) {
+                    validContextOuter = true;
+                    
+                    $.each(context, function (contextElement, contextOptions) {
+                        if (contextOptions.context && $.inArray(styleObj.element, contextOptions.context) === -1) {
+                            validContextOuter = false;
+                            return false; // stop looping
+                        }
+                    });
+                }
+                
+                // Set a class on the toolbar button to indicate we are out of context.
+                // That class will be used to style the button, but also
+                // to prevent clicking on the button.
+                return Boolean(validContextInner || validContextOuter);
+                
+            } else {
+                
+                // No context specified for this style
+                return true;
+            }
+        },
+        
+        
         //==================================================
         // INLINE STYLES
         // The following format functions deal with inline styles.

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -6647,8 +6647,16 @@ define([
                     
                     $.each(keys, function(i, keyName) {
                         keymap[keyName] = function (cm) {
-                            var $button = self.$el.closest('.rte2-wrapper').find('> .rte2-toolbar [data-rte-style="' + styleKey + '"]').eq(0);
-
+                            var allowed;
+                            var $button;
+                            
+                            // Check the context to see if this style is allowed
+                            allowed = self.checkContext(styleKey);
+                            if (!allowed) {
+                                return false;
+                            }
+                            
+                            $button = self.$el.closest('.rte2-wrapper').find('> .rte2-toolbar [data-rte-style="' + styleKey + '"]').eq(0);
                             if ($button.length > 0) {
                                 $button.click();
                                 return false;


### PR DESCRIPTION
Re-write the context checking for RTE styles, so context can be checked when using a keyboard shortcut (in addition to checking context when using the toolbar buttons).
