### PR TITLE
RTE add table sizer interface (BSP-1991)

### DIFF
--- a/tool-ui/src/main/webapp/style/v3/element.less
+++ b/tool-ui/src/main/webapp/style/v3/element.less
@@ -564,7 +564,7 @@ table.links.table-striped {
   @-message-padding: 10px;
   @-message-paddingLeft: @-message-padding + @lineHeight-default + 5px;
 
-  .background-flat(@color-heading);
+  .background-flat(@color-separator);
   .icon;
   .icon-info-sign;
   .message-icon();

--- a/tool-ui/src/main/webapp/style/v3/tableEditor.less
+++ b/tool-ui/src/main/webapp/style/v3/tableEditor.less
@@ -3,6 +3,12 @@
   position:relative;
   z-index: 3;
 
+}
+
+// Table goes inside here, and if it is too wide it should be scrollable
+.bspTableEditTableWrapper {
+  overflow:auto;
+
   table {
     
     width:100%;
@@ -41,9 +47,22 @@
   }
 }
 
-// Table goes inside here, and if it is too wide it should be scrollable
-.bspTableEditTableWrapper {
-  overflow:auto;
+.bspTableEditSizer {
+  table {
+    border-collapse: separate;
+    border-spacing: 4px;
+    width: auto;
+  }
+  td, th {
+    width:20px;
+    height:20px;
+    border:1px solid @color-border;
+    padding: 0;
+    background-color: #fff;
+  }
+  .active {
+    background-color: mix(@color-focus, white, 50%);;
+  }
 }
 
 // Context menu will be positioned using javascript

--- a/tool-ui/src/main/webapp/style/v3/tableEditor.less
+++ b/tool-ui/src/main/webapp/style/v3/tableEditor.less
@@ -50,10 +50,12 @@
 .bspTableEditSizer {
   table {
     border-collapse: separate;
-    border-spacing: 4px;
+    border-spacing: 5px;
+    margin: -5px -5px 0 -5px;
     width: auto;
   }
   td, th {
+    cursor: pointer;
     width:20px;
     height:20px;
     border:1px solid @color-border;
@@ -61,8 +63,14 @@
     background-color: #fff;
   }
   .active {
-    background-color: mix(@color-focus, white, 50%);;
+    background-color: @color-focus;
+    border-color: @color-focus;
   }
+}
+.bspTableEditSizerMessage {
+  .message;
+  .message-info;
+  margin-bottom: 10px;
 }
 
 // Context menu will be positioned using javascript


### PR DESCRIPTION
Give user ability to easily select the number of rows and columns when creating a new table.

Usage: click "Table" toolbar button to insert table. The table enhancement block appears in the editor, with a grid that represents possible numbers of columns and rows. Move the mouse over various cells to highlight the number of rows and columns - in addition the description shows the numerical columns and rows that will be created. Click the cell to initialize the table to that size.

![article](https://cloud.githubusercontent.com/assets/185461/18966730/55f5b694-8650-11e6-99a5-d5d9f0405b2d.png)