### PR TITLE
RTE fix lists and nested lists (BSP-2575)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -7567,11 +7567,22 @@ define([
                             
                             // Create new line if this is a block element and we are not on the first line
                             if (matchStyleObj && val.length) {
+                                
+                                // Special case for lists (and nested lists)
                                 if (matchStyleObj.elementContainer) {
-                                    // Special case to handle nested lists: create a new line if needed
+                                    
+                                    // Create a new line for the first list item but not if list item
+                                    // is nested within another.
+                                    // Note this is not ideal because we get away from the "elementContainer"
+                                    // model, and are assuming we're dealing with LI elements.
+                                    if ($(next).is(':first-child') && $(next).parents('li').length === 0) {
+                                        val += '\n';
+                                    }
+                                    
                                     if (!val.match(/\n$/)) {
                                         val += '\n';
                                     }
+                                    
                                 } else if (matchStyleObj.line && !insideAnotherBlock) {
                                     // If this is a block element add a new line
                                     // But not if there are multiple blocks defined on the same line,

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -7565,9 +7565,18 @@ define([
                             // Determine if the element maps to one of our defined styles
                             matchStyleObj = self.getStyleForElement(next);
                             
-                            // Create new line if this is a block element (and we are not already inside another block)
-                            if (val.length && matchStyleObj && matchStyleObj.line && !insideAnotherBlock) {
-                                val += '\n';
+                            // Create new line if this is a block element and we are not on the first line
+                            if (matchStyleObj && val.length) {
+                                if (matchStyleObj.elementContainer) {
+                                    // Special case to handle nested lists: create a new line if needed
+                                    if (!val.match(/\n$/)) {
+                                        val += '\n';
+                                    }
+                                } else if (matchStyleObj.line && !insideAnotherBlock) {
+                                    // If this is a block element add a new line
+                                    // But not if there are multiple blocks defined on the same line,
+                                    val += '\n';
+                                }
                             }
                         }
 
@@ -7744,9 +7753,11 @@ define([
                                 });
                             }
                         }
-                        // Add a new line for certain elements
-                        // Add a new line for custom elements
-                        if (self.newLineRegExp.test(elementName) || (matchStyleObj && matchStyleObj.line)) {
+                        
+                        // Add a new line for certain elements (like <br>)
+                        if (self.newLineRegExp.test(elementName)) {
+                            val += '\n';
+                        } else if (matchStyleObj && matchStyleObj.line) {
                             
                             // Special cases:
                             // If we are already inside another block do not add a newline.


### PR DESCRIPTION
Lists were getting blank lines in between when the HTML was imported, then when the HTML was exported it saw set as multiple lists. Also nested lists were not importing correctly at all.

The problems seem to have been introduced by the following recent changes:

https://github.com/perfectsense/brightspot-cms/pull/973
RTE change behavior of BR before block element (BSP-2038)
Seems to cause extra line break between lists)

https://github.com/perfectsense/brightspot-cms/pull/1009
RTE allow multiple block styles per line (BSP-2410) 
Seems to mess up nested lists
