### PR TITLE
RTE track changes undo history bugfix (BSP-2574)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4078,14 +4078,14 @@ define([
                             // Currently the entire content that is pasted will be marked as inserted text,
                             // but it could have deleted text within it.
                             // We need to remove that deleted text *after* the new content is pasted in.
-                            editor.replaceRange(changeObj.text, changeObj.from, undefined, '+brightspotTrackInsert');
+                            editor.replaceRange(changeObj.text, changeObj.from, undefined, 'brightspotTrackInsert');
                             
                         }
                     }
                     
                     break;
 
-                case '+brightspotTrackInsert':
+                case 'brightspotTrackInsert':
 
                     // Some text was pasted in and already marked as new,
                     // but we must remove any regions within that were previously marked deleted
@@ -5616,9 +5616,10 @@ define([
             // Check for brightspot events
             if (origin.indexOf('brightspot') !== -1) {
                 switch (origin) {
-                    // Let brightspotPaste and brightspotCut operations be added to the history
+                    // Let certain operations be added to the history
                     case 'brightspotPaste':
                     case 'brightspotCut':
+                    case 'brightspotTrackInsert':
                     break;
                     
                     default:

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -5594,7 +5594,7 @@ define([
          */
         historyHandleCodeMirrorEvent: function(beforeChange) {
             
-            var change, marks, marksAndMore, self;
+            var change, marks, marksAndMore, origin, self;
 
             self = this;
             
@@ -5602,11 +5602,29 @@ define([
             if (self.historyIsExecuting()) {
                 return;
             }
-                
-            // Ignore changes where we set the origin containing "brightspot",
-            // because in those instances we will add directly to the history
-            if (beforeChange.origin && beforeChange.origin.indexOf('brightspot') !== -1 || beforeChange.origin === 'paste') {
-                return;
+
+            // Check where this change came from
+            origin = beforeChange.origin || '';
+
+            // Since we handle the "paste" event within our own clipboard handler,
+            // ignore the codemirror paste event. Instead that will come through
+            // in a separate brightspotPaste event.
+            if (origin == 'paste') {
+                return false;
+            }
+
+            // Check for brightspot events
+            if (origin.indexOf('brightspot') !== -1) {
+                switch (origin) {
+                    // Let brightspotPaste and brightspotCut operations be added to the history
+                    case 'brightspotPaste':
+                    case 'brightspotCut':
+                    break;
+                    
+                    default:
+                    // Prevent other brightspot changes from being added to the history
+                    return;
+                }
             }
                 
             // Save a list of the marks that are defined in this range.


### PR DESCRIPTION
This pull requests fixes a couple issues in the rich text editor when "track changes" is turned on:

Activate track changes, select a range of text, then type some text, then undo

Activate track changes, copy a range of text, then select a range of text and paste over it, then undo

