### PR TITLE
RTE link show url in dropdown (BSP-1912)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -3737,6 +3737,16 @@ define([
                     text: label
                 }).appendTo($div);
 
+                // Check if this is a link with an href attribute
+                if (mark.attributes && mark.attributes.href) {
+                    $('<a/>', {
+                        'class': 'rte2-dropdown-href',
+                        text: mark.attributes.href,
+                        href: mark.attributes.href,
+                        target: '_blank'
+                    }).appendTo($div);
+                }
+                
                 // Popup edit defaults to true, but if set to false do not include edit link
                 if (styleObj.popup !== false && styleObj.onClick) {
                     $('<a/>', {

--- a/tool-ui/src/main/webapp/style/v3/rte2.less
+++ b/tool-ui/src/main/webapp/style/v3/rte2.less
@@ -889,10 +889,7 @@ li.CodeMirror-hint-active {
   }
 
   .rte2-dropdown-label,
-  .rte2-dropdown-edit,
-  .rte2-dropdown-move-up,
-  .rte2-dropdown-move-down,
-  .rte2-dropdown-clear {
+  a {
     display: table-cell;
   }
 
@@ -904,22 +901,25 @@ li.CodeMirror-hint-active {
     }
   }
 
-  .rte2-dropdown-edit,
-  .rte2-dropdown-move-up,
-  .rte2-dropdown-move-down {
+  a:not(:last-of-type) {
     border-right: 1px solid @color-separator;
     margin-right: 5px;
     padding-right: 5px;
   }
 
-  .rte2-dropdown-move-up,
-  .rte2-dropdown-move-down {
+  a:not(:first-of-type) {
     padding-left: 5px;
   }
 
   .rte2-dropdown-clear {
     color: @color-remove;
-    padding-left: 5px;
+  }
+  
+  .rte2-dropdown-href {
+    max-width: 400px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
In the rich text editor, when the cursor is over a link (or any mark that has an href attribute) then in the dropdown that appears, show the link URL and let user click it to visit the url in a new browser window. If the URL is too long truncate the display with ellipsis.

![link](https://cloud.githubusercontent.com/assets/185461/19198443/3ae9521e-8c8d-11e6-9920-f9d57c77206e.png)
