### PR TITLE
RTE add ability to CSS style for toolbar submenu (BSP-2022)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1298,7 +1298,6 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 var styleName = rtElement.styleName;
                 var submenuName = rtElement.submenu;
                 var $submenu;
-                var submenuClass;
                 var toolbarButton;
 
                 toolbarButton = {
@@ -1324,16 +1323,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     if (!$submenu) {
                         
                         // The submenu does not exist so create it now and save the value
-                        
-                        // Calculate a safe classname to use for the submenu.
-                        // Since the submenu name could be something like "My Enhancements",
-                        // substitute a dash character for any non-alphanumeric characters
-                        // to end up with class "rte2-toolbar-submenu-My-Enhancements"
-                        submenuClass = 'rte2-toolbar-submenu-' + submenuName.replace(/\W+/g, '-');
-                        
                         $submenu = submenus[submenuName] = self.toolbarAddSubmenu({
                             text: submenuName,
-                            className:submenuClass
+                            // Save the submenu name in a data attribute so it can be used to style the submenu
+                            attr: {'data-rte-toolbar-submenu': submenuName}
                         }, $toolbar);
                     }
 
@@ -1352,8 +1345,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          *
          * @param {Object} item
          * The toolbar item to add.
-         * @param {Object} item.className
          * @param {Object} item.text
+         * @param {Object} [item.className] Class name for the submenu element
+         * @param {Object} [item.attr] Attributes for the submenu element
          *
          * @param {Object} [$addToSubmenu]
          * Optional submenu where the submenu should be added.
@@ -1368,7 +1362,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var $toolbar = $addToSubmenu || self.$toolbar;
             var $submenu;
 
-            $submenu = $('<li class="rte2-toolbar-submenu ' + (item.className || '') + '"><span></span><ul></ul></li>');
+            $submenu = $('<li class="rte2-toolbar-submenu"><span></span><ul></ul></li>');
+            if (item.className) {
+                $submenu.addClass(item.className);
+            }
+            if (item.attr) {
+                $submenu.attr(item.attr);
+            }
             $submenu.find('span').html(item.text);
             $submenu.appendTo($toolbar);
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -1298,6 +1298,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 var styleName = rtElement.styleName;
                 var submenuName = rtElement.submenu;
                 var $submenu;
+                var submenuClass;
                 var toolbarButton;
 
                 toolbarButton = {
@@ -1312,11 +1313,28 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     toolbarButton.action = 'table';
                 }
 
+                // The style defined in RICH_TEXT_ELEMENTS might have a submenu property, Which
+                // is the label of a submenu like "My Enhancements".
+                // Multiple styles can be grouped using this submenu name, so we need to ensure
+                // that we only create the submenu once, then use it for any subsequent styles.
                 if (submenuName) {
                     
+                    // Check to see if the submenu has already been created
                     $submenu = submenus[submenuName];
                     if (!$submenu) {
-                        $submenu = submenus[submenuName] = self.toolbarAddSubmenu({text: submenuName}, $toolbar);
+                        
+                        // The submenu does not exist so create it now and save the value
+                        
+                        // Calculate a safe classname to use for the submenu.
+                        // Since the submenu name could be something like "My Enhancements",
+                        // substitute a dash character for any non-alphanumeric characters
+                        // to end up with class "rte2-toolbar-submenu-My-Enhancements"
+                        submenuClass = 'rte2-toolbar-submenu-' + submenuName.replace(/\W+/g, '-');
+                        
+                        $submenu = submenus[submenuName] = self.toolbarAddSubmenu({
+                            text: submenuName,
+                            className:submenuClass
+                        }, $toolbar);
                     }
 
                     self.toolbarAddButton(toolbarButton, $submenu);


### PR DESCRIPTION
For RTE toolbar submenus that are defined on the backend (via the RICH_TEXT_ELEMENTS javascript variable) it is not possible to style the submenu using CSS. This commit adds a unique classname so the submenu can be styled.

Since the backend specifies the submenu by it's label (such as "My Submenu"), the label is converted into a CSS-compliant class name (rte2-toolbar-submenu-My-Submenu).
