### PR TITLE
Auto-expand causing RTE performance problems (BSP-2645)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -384,22 +384,33 @@ function() {
 
     // For new rich text editor, special handling for the word count.
     // Note this counts only the text content not the final output which includes extra HTML elements.
-    $doc.on('rteChange', $.throttle(1000, function(event, rte) {
+    var rteWordCountInterval;
 
-        var $input, $container, html, $html, text;
+    function rteWordCount(rte) {
+      var $input, $container, html, $html, text;
 
-        $input = rte.$el;
-        $container = $input.closest('.rte2-wrapper').find('> .rte2-toolbar');
+      $input = rte.$el;
+      $container = $input.closest('.rte2-wrapper').find('> .rte2-toolbar');
 
-        html = rte.toHTML();
-        $html = $(new DOMParser().parseFromString(html, "text/html").body);
-        $html.find('del,.rte-comment').remove();
-        $html.find('br,p,div,ul,ol,li').after('\n');
-        text = $html.text();
+      html = rte.toHTML();
+      $html = $(new DOMParser().parseFromString(html, "text/html").body);
+      $html.find('del,.rte-comment').remove();
+      $html.find('br,p,div,ul,ol,li').after('\n');
+      text = $html.text();
+      console.log('word count', text.length);
 
-        updateWordCount($container, $input, text);
+      updateWordCount($container, $input, text);
+    }
 
-    }));
+    $doc.on('rteChange', function (event, rte) {
+      if (rteWordCountInterval) {
+        clearInterval(rteWordCountInterval);
+      }
+
+      rteWordCountInterval = setTimeout(function () {
+        rteWordCount(rte);
+      }, 1000);
+    });
 
   })();
 

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -397,7 +397,6 @@ function() {
       $html.find('del,.rte-comment').remove();
       $html.find('br,p,div,ul,ol,li').after('\n');
       text = $html.text();
-      console.log('word count', text.length);
 
       updateWordCount($container, $input, text);
     }

--- a/tool-ui/src/main/webapp/script/v3/plugin/auto-expand.js
+++ b/tool-ui/src/main/webapp/script/v3/plugin/auto-expand.js
@@ -113,7 +113,7 @@
 
         'expand': function(inputs) {
             var plugin = this;
-            var $inputs = $(inputs);
+            var $inputs = $(inputs).filter(':visible');
             var shadows = [ ];
 
             $inputs.each(function() {


### PR DESCRIPTION
Change the auto-expand plugin so it does not attempt to resize hidden textareas, because this was causing performance problems when the Rich Text Editor had a large amount of content.