### PR TITLE
	Adds JavaScript cache for viewers data to prevent unnecessary RTC calls from being made. BSP-2481

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -5,15 +5,14 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         pendingRestore = null,
         VIEWERS_CACHE = (function() {
 
-            var shortViewerDataCache = { },
-                longViewerDataCache = { },
+            var viewerDataCache = { },
                 hitCount = 0,
                 missCount = 0,
                 fetchCount = 0,
                 putCount = 0,
 
                 debugViewersCache = function() {
-                    return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
+                    return true || window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
                 },
 
                 report = function(force) {
@@ -31,8 +30,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                         "putCount: ", putCount,
                         ", fetchCount: ", fetchCount,
                         ", ratio: ", ratio + "%",
-                        ", short_sz: ", Object.keys(shortViewerDataCache).length,
-                        "long_sz: ", Object.keys(longViewerDataCache).length
+                        "size: ", Object.keys(viewerDataCache).length
                     );
                 },
 
@@ -70,68 +68,31 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                     report();
                 },
 
-                // fetches data from cache, combining short-term
-                // cache into long-term cache for the requested contentId
-                // as applicable, then returning the updated or existing
-                // long-term cache value
+                // fetches data from cache
                 fetchData = function(contentId) {
 
                     fetchCount += 1;
 
-                    var i,
-                        shortCacheData = shortViewerDataCache[contentId],
-                        longCacheData = longViewerDataCache[contentId],
-                        result;
-
-                    if (shortCacheData === undefined) {
-
-                        // no short cache,
-                        // return long cache data
-                        result = longCacheData;
-
-                    } else if (longCacheData === undefined) {
-
-                        // copy short cache data to long cache,
-                        // delete short cache data
-                        longViewerDataCache[contentId] = shortCacheData;
-                        delete shortViewerDataCache[contentId];
-                        result = longViewerDataCache[contentId];
-
-                    } else {
-
-                        // merge short cache data to long cache,
-                        // delete short cache data
-
-                        for (i = 0; i < shortCacheData.length; i += 1) {
-
-                            cacheData(longViewerDataCache, shortCacheData[i]);
-                        }
-
-                        delete shortViewerDataCache[contentId];
-
-                        result = longViewerDataCache[contentId];
-                    }
-
                     report();
 
-                    return result;
+                    return viewerDataCache[contentId];
                 },
 
                 containsKey = function(key) {
-                    return shortViewerDataCache[key] || longViewerDataCache[key];
+                    return viewerDataCache[key];
                 };
 
             return {
 
                 putEmpty: function(key) {
 
-                    if (!shortViewerDataCache[key]) {
+                    if (!viewerDataCache[key]) {
 
                         if (debugViewersCache()) {
                             console.log("%cSEED", "color: green", key);
                         }
 
-                        shortViewerDataCache[key] = [ ];
+                        viewerDataCache[key] = [ ];
                     }
                 },
 
@@ -149,7 +110,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                                 console.log("PUT", data.contentId);
                             }
 
-                            cacheData(shortViewerDataCache, data);
+                            cacheData(viewerDataCache, data);
                         } else {
 
                             if (debugViewersCache()) {
@@ -200,8 +161,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                         }
                     });
 
-                    shortViewerDataCache = { };
-                    longViewerDataCache = cleanCache;
+                    viewerDataCache = cleanCache;
                 }
             };
         })();

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -1,6 +1,8 @@
 define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_utils, rtc, color_utils) {
 
-    var colorsByUuid = { };
+    var colorsByUuid = {},
+        shortViewerDataCache = { },
+        longViewerDataCache = { };
 
     function backgroundColor(uuid) {
 
@@ -11,8 +13,225 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         return colorsByUuid[uuid];
     }
 
+    // restores viewer data on the specified containers,
+    // fetching from cache if available, otherwise making
+    // an rtc.restore call for the data
+    function restoreData($containers) {
+
+        var contentIds = [ ];
+
+        $($containers).each(function () {
+            var container = this,
+                $container = $(container),
+                contentId,
+                contentData,
+                i;
+
+            if (!$container.is('form')) {
+                contentId = $container.attr('data-rtc-content-id');
+
+                if (contentId) {
+
+                    contentData = fetchData(contentId);
+                    if (typeof contentData === 'object' && contentData instanceof Array) {
+
+                        console.log("CACHE RESTORE", contentData);
+
+                        for (i = 0; i < contentData.length; i += 1) {
+
+                            updateContainer(container, contentData[i]);
+                        }
+
+                    } else {
+
+                        shortViewerDataCache[contentId] = [ ];
+                        contentIds.push(contentId);
+                    }
+                }
+            }
+        });
+
+        if (contentIds.length > 0) {
+
+            console.log("RTC RESTORE ", contentIds);
+            rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
+                contentId: contentIds
+            });
+        }
+    }
+
+    // caches the specified viewer data in the specified cache object,
+    // keyed by contentId then userId.
+    function cacheData(cache, data) {
+
+        console.log("CACHE", data);
+
+        var contentId = data.contentId,
+            userId = data.userId,
+            contentData,
+            userDataIndex = undefined,
+            i;
+
+        contentData = cache[contentId];
+
+        if (contentData === undefined) {
+            contentData = [ ];
+            cache[contentId] = contentData;
+        }
+
+        for (i = 0; i < contentData.length; i += 1) {
+            if (contentData[i].userId === userId) {
+                userDataIndex = i;
+            }
+        }
+
+        if (userDataIndex !== undefined && userDataIndex >= 0) {
+            contentData.splice(userDataIndex, 1, data);
+        } else {
+            contentData.push(data);
+        }
+    }
+
+    // fetches data from cache, combining short-term
+    // cache into long-term cache for the requested contentId
+    // as applicable, then returning the updated or existing
+    // long-term cache value
+    function fetchData(contentId) {
+
+        var i,
+            shortCacheData = shortViewerDataCache[contentId],
+            longCacheData = longViewerDataCache[contentId];
+
+        if (shortCacheData === undefined) {
+
+            // no short cache,
+            // return long cache data
+            return longCacheData;
+
+        } else if (longCacheData === undefined) {
+
+            // copy short cache data to long cache,
+            // delete short cache data
+            longViewerDataCache[contentId] = shortCacheData;
+            delete shortViewerDataCache[contentId];
+            return longViewerDataCache[contentId];
+        }
+
+        // merge short cache data to long cache,
+        // delete short cache data
+
+        for (i = 0; i < shortCacheData.length; i += 1) {
+
+            cacheData(longViewerDataCache, shortCacheData[i]);
+        }
+
+        delete shortViewerDataCache[contentId];
+
+        return longViewerDataCache[contentId];
+    }
+
+    // pushes the observed data into short-term cache,
+    // to be used by fetchData
+    function observeData(data) {
+
+        console.log("OBSERVE", data);
+        cacheData(shortViewerDataCache, data);
+    }
+
+    // shared-use function for updating a container element either from cached data
+    // stored in dataByContentId or from an EditFieldUpdateBroadcast RTC event
+    function updateContainer(containerElement, data) {
+
+        var $container = $(containerElement),
+            userId = data.userId,
+            closed = data.closed,
+            userAvatarHtml = data.userAvatarHtml,
+            fieldNamesByObjectId = data.fieldNamesByObjectId,
+            $viewersContainer = $container.find('[data-rtc-edit-field-update-viewers]'),
+            $viewers = $viewersContainer.find('> .EditFieldUpdateViewers'),
+            $some,
+            $none;
+
+        if ($viewersContainer.length > 0) {
+
+            if ($viewers.length === 0) {
+                $none = $('<div/>', {
+                    'class': 'EditFieldUpdateViewers-none',
+                    html: $viewersContainer.html()
+                });
+
+                $some = $('<div/>', {
+                    'class': 'EditFieldUpdateViewers-some'
+                });
+
+                $viewers = $('<div/>', {
+                    'class': 'EditFieldUpdateViewers',
+                    html: [
+                        $none,
+                        $some
+                    ]
+                });
+
+                $viewers.append($none);
+                $viewers.append($some);
+                $viewersContainer.html($viewers);
+
+            } else {
+                $some = $viewers.find('> .EditFieldUpdateViewers-some');
+            }
+
+            var $viewer = $some.find('> .EditFieldUpdateViewers-viewer[data-user-id="' + userId + '"]');
+
+            if ($viewer.length > 0) {
+                if (closed) {
+                    $viewer.remove();
+                }
+
+            } else if (!closed) {
+                $viewer = $('<div/>', {
+                    'class': 'EditFieldUpdateViewers-viewer',
+                    'data-user-id': userId,
+                    html: userAvatarHtml
+                });
+
+                $viewer.find('.ToolUserAvatar').css({
+                    'background-color': backgroundColor(userId)
+                });
+
+                $some.append($viewer);
+            }
+
+            function checkFieldNames(id) {
+                var fieldNames = fieldNamesByObjectId[id];
+                return fieldNames && fieldNames.length > 0;
+            }
+
+            if (fieldNamesByObjectId && Object.keys(fieldNamesByObjectId).filter(checkFieldNames).length > 0) {
+                $viewer.attr('data-editing', true);
+
+            } else {
+                $viewer.removeAttr('data-editing');
+            }
+
+            if ($some.find('> .EditFieldUpdateViewers-viewer').length > 0) {
+                $viewers.attr('data-some', true);
+
+            } else {
+                $viewers.removeAttr('data-some');
+            }
+        }
+    }
+
     rtc.receive('com.psddev.cms.tool.page.content.EditFieldUpdateBroadcast', function(data) {
+
         var contentId = data.contentId;
+
+        if (!contentId) {
+            return;
+        }
+
+        observeData(data);
+
         var $containers = $('[data-rtc-content-id="' + contentId + '"]');
         
         if ($containers.length === 0) {
@@ -24,83 +243,12 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
 
         $containers.each(function() {
 
+            updateContainer(this, data);
+
             var $container = $(this);
 
-            var $viewersContainer = $container.find('[data-rtc-edit-field-update-viewers]');
-
-            if ($viewersContainer.length > 0) {
-                var userAvatarHtml = data.userAvatarHtml;
-                var closed = data.closed;
-                var $viewers = $viewersContainer.find('> .EditFieldUpdateViewers');
-                var $some;
-
-                if ($viewers.length === 0) {
-                    var $none = $('<div/>', {
-                        'class': 'EditFieldUpdateViewers-none',
-                        html: $viewersContainer.html()
-                    });
-
-                    $some = $('<div/>', {
-                        'class': 'EditFieldUpdateViewers-some'
-                    });
-
-                    $viewers = $('<div/>', {
-                        'class': 'EditFieldUpdateViewers',
-                        html: [
-                            $none,
-                            $some
-                        ]
-                    });
-
-                    $viewers.append($none);
-                    $viewers.append($some);
-                    $viewersContainer.html($viewers);
-
-                } else {
-                    $some = $viewers.find('> .EditFieldUpdateViewers-some');
-                }
-
-                var $viewer = $some.find('> .EditFieldUpdateViewers-viewer[data-user-id="' + userId + '"]');
-
-                if ($viewer.length > 0) {
-                    if (closed) {
-                        $viewer.remove();
-                    }
-
-                } else if (!closed) {
-                    $viewer = $('<div/>', {
-                        'class': 'EditFieldUpdateViewers-viewer',
-                        'data-user-id': userId,
-                        html: userAvatarHtml
-                    });
-
-                    $viewer.find('.ToolUserAvatar').css({
-                        'background-color': backgroundColor(userId)
-                    });
-
-                    $some.append($viewer);
-                }
-
-                function checkFieldNames(id) {
-                    var fieldNames = fieldNamesByObjectId[id];
-                    return fieldNames && fieldNames.length > 0;
-                }
-
-                if (fieldNamesByObjectId && Object.keys(fieldNamesByObjectId).filter(checkFieldNames).length > 0) {
-                    $viewer.attr('data-editing', true);
-
-                } else {
-                    $viewer.removeAttr('data-editing');
-                }
-
-                if ($some.find('> .EditFieldUpdateViewers-viewer').length > 0) {
-                    $viewers.attr('data-some', true);
-
-                } else {
-                    $viewers.removeAttr('data-some');
-                }
-            }
-
+            // logic below is scoped to containers within a form - the Edit page.
+            // this excludes containers that appear in search results.
             if (!$container.is('form')) {
                 return;
             }
@@ -170,6 +318,8 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         insert: function (container) {
             var $container = $(container);
 
+            // logic below is scoped to containers within a form - the Edit page.
+            // this excludes containers that appear in search results.
             if (!$container.is('form')) {
                 return;
             }
@@ -228,25 +378,8 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         },
 
         afterInsert: function (containers) {
-            var contentIds = [ ];
 
-            $(containers).each(function () {
-                var $container = $(this);
-
-                if (!$container.is('form')) {
-                    var contentId = $container.attr('data-rtc-content-id');
-
-                    if (contentId) {
-                        contentIds.push(contentId);
-                    }
-                }
-            });
-
-            if (contentIds.length > 0) {
-                rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
-                    contentId: contentIds
-                });
-            }
+            restoreData(containers);
         }
     });
 });

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -148,11 +148,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
     // to be used by fetchData
     function observeData(data) {
 
-        var contentId = data.contentId;
-
-        if (contentId && $('[data-rtc-content-id="' + contentId + '"]').size() > 0) {
-            cacheData(shortViewerDataCache, data);
-        }
+        cacheData(shortViewerDataCache, data);
     }
 
     // shared-use function for updating a container element either from cached data

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -35,8 +35,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                     contentData = fetchData(contentId);
                     if (typeof contentData === 'object' && contentData instanceof Array) {
 
-                        console.log("CACHE RESTORE", contentData);
-
                         for (i = 0; i < contentData.length; i += 1) {
 
                             updateContainer(container, contentData[i]);
@@ -53,7 +51,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
 
         if (contentIds.length > 0) {
 
-            console.log("RTC RESTORE ", contentIds);
             rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
                 contentId: contentIds
             });
@@ -63,8 +60,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
     // caches the specified viewer data in the specified cache object,
     // keyed by contentId then userId.
     function cacheData(cache, data) {
-
-        console.log("CACHE", data);
 
         var contentId = data.contentId,
             userId = data.userId,
@@ -134,7 +129,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
     // to be used by fetchData
     function observeData(data) {
 
-        console.log("OBSERVE", data);
         cacheData(shortViewerDataCache, data);
     }
 

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -217,47 +217,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         return colorsByUuid[uuid];
     }
 
-    function restoreByContentId(contentId) {
-
-        if (contentId) {
-
-            if (contentId instanceof Array) {
-
-                var i, id;
-
-                for (i = 0; i < contentId.length; i += 1) {
-
-                    id = contentId[i];
-                    if (id && pendingRestoreIds.indexOf(id) === -1) {
-                        pendingRestoreIds.push(id);
-                    }
-                }
-
-            } else if (pendingRestoreIds.indexOf(contentId) === -1) {
-
-                pendingRestoreIds.push(contentId);
-            }
-
-            if (pendingRestore) {
-                window.clearTimeout(pendingRestore);
-            }
-
-            if (pendingRestoreIds.length > 0) {
-
-                pendingRestore = window.setTimeout(function() {
-
-                    VIEWERS_CACHE.clearUnused();
-
-                    rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
-                        contentId: pendingRestoreIds
-                    });
-
-                    pendingRestoreIds = [ ];
-                }, 250);
-            }
-        }
-    }
-
     // shared-use function for updating a container element either from cached data
     // stored in dataByContentId or from an EditFieldUpdateBroadcast RTC event
     function updateContainer(containerElement, data) {
@@ -507,7 +466,9 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
             // fetching from cache if available, otherwise making
             // an rtc.restore call for the data
 
-            var contentIds = [ ];
+            var contentIds = [ ],
+                i,
+                id;
 
             $(containers).each(function () {
                 var container = this,
@@ -538,7 +499,34 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                 }
             });
 
-            restoreByContentId(contentIds);
+            if (contentIds.length > 0) {
+
+                for (i = 0; i < contentId.length; i += 1) {
+
+                    id = contentId[i];
+                    if (id && pendingRestoreIds.indexOf(id) === -1) {
+                        pendingRestoreIds.push(id);
+                    }
+                }
+
+                if (pendingRestore) {
+                    window.clearTimeout(pendingRestore);
+                }
+
+                if (pendingRestoreIds.length > 0) {
+
+                    pendingRestore = window.setTimeout(function() {
+
+                        VIEWERS_CACHE.clearUnused();
+
+                        rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
+                            contentId: pendingRestoreIds
+                        });
+
+                        pendingRestoreIds = [ ];
+                    }, 250);
+                }
+            }
         }
     });
 });

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -129,7 +129,11 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
     // to be used by fetchData
     function observeData(data) {
 
-        cacheData(shortViewerDataCache, data);
+        var contentId = data.contentId;
+
+        if (contentId && $('[data-rtc-content-id="' + contentId + '"]').size() > 0) {
+            cacheData(shortViewerDataCache, data);
+        }
     }
 
     // shared-use function for updating a container element either from cached data

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -13,6 +13,23 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         return colorsByUuid[uuid];
     }
 
+    function cleanUnusedDataFromCache() {
+
+        var cleanCache = { };
+
+        $('[data-rtc-content-id]').each(function() {
+            var contentId = $(this).attr('data-rtc-content-id'),
+                cachedData = fetchData(contentId);
+
+            if (cachedData) {
+                cleanCache[contentId] = cachedData;
+            }
+        });
+
+        shortViewerDataCache = { };
+        longViewerDataCache = cleanCache;
+    }
+
     // restores viewer data on the specified containers,
     // fetching from cache if available, otherwise making
     // an rtc.restore call for the data
@@ -48,6 +65,8 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                 }
             }
         });
+
+        cleanUnusedDataFromCache();
 
         if (contentIds.length > 0) {
 

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -219,9 +219,9 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
 
     // shared-use function for updating a container element either from cached data
     // stored in dataByContentId or from an EditFieldUpdateBroadcast RTC event
-    function updateContainer(containerElement, data) {
+    function updateContainer(container, data) {
 
-        var $container = $(containerElement),
+        var $container = $(container),
             userId = data.userId,
             closed = data.closed,
             userAvatarHtml = data.userAvatarHtml,
@@ -471,8 +471,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                 id;
 
             $(containers).each(function () {
-                var container = this,
-                    $container = $(container),
+                var $container = $(this),
                     contentId,
                     contentData,
                     i;
@@ -487,7 +486,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
 
                             for (i = 0; i < contentData.length; i += 1) {
 
-                                updateContainer(container, contentData[i]);
+                                updateContainer($container, contentData[i]);
                             }
 
                         } else {
@@ -501,9 +500,12 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
 
             if (contentIds.length > 0) {
 
-                for (i = 0; i < contentId.length; i += 1) {
+                // push all content IDs onto list of IDs pending restore
+                // to increase the likelihood that multiple observed
+                // mutations are batched into a single rtc.restore request
+                for (i = 0; i < contentIds.length; i += 1) {
 
-                    id = contentId[i];
+                    id = contentIds[i];
                     if (id && pendingRestoreIds.indexOf(id) === -1) {
                         pendingRestoreIds.push(id);
                     }

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -148,7 +148,11 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
     // to be used by fetchData
     function observeData(data) {
 
-        cacheData(shortViewerDataCache, data);
+        var contentId = data.contentId;
+
+        if (contentId && $('[data-rtc-content-id="' + contentId + '"]').size() > 0) {
+            cacheData(shortViewerDataCache, data);
+        }
     }
 
     // shared-use function for updating a container element either from cached data

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -11,7 +11,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
                 cleanCallCount = 0,
 
                 debugViewersCache = function() {
-                    return true || window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
+                    return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
                 },
 
                 report = function(force) {


### PR DESCRIPTION
PR #1066 adds a cache of `rtc.restore` triggered and subsequent broadcast data for `com.psddev.cms.tool.page.content.EditFieldUpdateState`.

The purpose of caching `EditFieldUpdateState` data is to reduce the number of burst-restores issued to the master database when many Viewers containers exist on the page at the same time.  In particular, custom dashboard widget refresh triggered by ongoing CMS publish operations cause large bursts of `rtc.restore` calls, resulting in a large distributed query volume directed against the master database.

The caching plan put in place by this pull request allows caching of broadcast data only once the cache has been primed to receive data for a specific content ID, effectively ignoring irrelevant broadcast data for which no `[data-rtc-content-id]` containers exist on the current page.  This also ensures that `rtc.restore` requests are made at least once each time a new container ID is observed.

Periodically, prior to a `rtc.restore` call, the cache is scrubbed of entries with no corresponding `[data-rtc-content-id]` element on the page.

Preliminary testing indicates that high hit ratios are likely from the many-viewer dashboard:

<img width="978" alt="screen shot 2016-10-28 at 1 03 35 am" src="https://cloud.githubusercontent.com/assets/400882/19795539/62765624-9caa-11e6-894c-3e52e3621f00.png">

Where the hit ratio is effectively the reduction factor of `rtc.restore`-initiated queries against the master database.

The largest change to existing code is the re-organization of the broadcast reception callback into an `updateContainer` callback that is invoked with both in response to broadcast data and fetch from cache.
