### PR TITLE
Adds JavaScript cache for viewers data to prevent unnecessary RTC calls from being made. BSP-2481

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -250,7 +250,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
                     var contentId = $container.attr('data-rtc-content-id');
 
                     if (contentId) {
-                        var contentData = VIEWERS_CACHE.fetch(contentId);
+                        var contentData = efu_cache.fetch(contentId);
                         var i;
 
                         if (typeof contentData === 'object' && contentData instanceof Array) {

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -1,4 +1,4 @@
-define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_utils, rtc, color_utils) {
+define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateCache' ], function ($, bsp_utils, rtc, color_utils, efu_cache) {
 
     var colorsByUuid = { };
 
@@ -104,6 +104,8 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils' ], function ($, bsp_u
         if ($containers.length === 0) {
             return;
         }
+
+        efu_cache.put(data);
         
         var userId = data.userId;
         var fieldNamesByObjectId = data.fieldNamesByObjectId;

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -243,6 +243,11 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
         },
 
         afterInsert: function (containers) {
+
+            // restores viewer data on the specified containers,
+            // fetching from cache if available, otherwise making
+            // an rtc.restore call for the data
+
             var contentIds = [ ];
 
             $(containers).each(function () {
@@ -252,12 +257,29 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
                     var contentId = $container.attr('data-rtc-content-id');
 
                     if (contentId) {
-                        contentIds.push(contentId);
+
+                        var contentData = VIEWERS_CACHE.fetch(contentId);
+                        var i;
+                        if (typeof contentData === 'object' && contentData instanceof Array) {
+
+                            for (i = 0; i < contentData.length; i += 1) {
+
+                                updateContainer($container, contentData[i]);
+                            }
+
+                        } else {
+
+                            efu_cache.putEmpty(contentId);
+                            contentIds.push(contentId);
+                        }
                     }
                 }
             });
 
             if (contentIds.length > 0) {
+
+                efu_cache.clearUnused();
+
                 rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
                     contentId: contentIds
                 });

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -175,6 +175,8 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
         })
     });
 
+    var invalidateTimeout;
+
     bsp_utils.onDomInsert(document, '[data-rtc-content-id]', {
         insert: function (container) {
             var $container = $(container);
@@ -267,7 +269,17 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
             });
 
             if (contentIds.length > 0) {
-                efu_cache.clearUnused();
+                if (invalidateTimeout) {
+                    clearTimeout(invalidateTimeout);
+                }
+
+                invalidateTimeout = setTimeout(function () {
+                    invalidateTimeout = null;
+
+                    efu_cache.invalidate($('[data-rtc-content-id]').map(function () {
+                        return $(this).attr('data-rtc-content-id');
+                    }).get());
+                }, 5000);
 
                 rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {
                     contentId: contentIds

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -250,7 +250,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
                     var contentId = $container.attr('data-rtc-content-id');
 
                     if (contentId) {
-                        var contentData = efu_cache.fetch(contentId);
+                        var contentData = efu_cache.get(contentId);
                         var i;
 
                         if (typeof contentData === 'object' && contentData instanceof Array) {
@@ -259,7 +259,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
                             }
 
                         } else {
-                            efu_cache.putEmpty(contentId);
+                            efu_cache.init(contentId);
                             contentIds.push(contentId);
                         }
                     }

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdate.js
@@ -13,17 +13,12 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
 
     // shared-use function for updating a container element either from cached data
     // stored in dataByContentId or from an EditFieldUpdateBroadcast RTC event
-    function updateContainer(container, data) {
-
+    function updateContainer($container, data) {
         var userId = data.userId;
         var fieldNamesByObjectId = data.fieldNamesByObjectId;
-
-        var $container = $(container);
-
         var $viewersContainer = $container.find('[data-rtc-edit-field-update-viewers]');
 
         if ($viewersContainer.length > 0) {
-
             var userAvatarHtml = data.userAvatarHtml;
             var closed = data.closed;
             var $viewers = $viewersContainer.find('> .EditFieldUpdateViewers');
@@ -100,21 +95,20 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
     rtc.receive('com.psddev.cms.tool.page.content.EditFieldUpdateBroadcast', function(data) {
         var contentId = data.contentId;
         var $containers = $('[data-rtc-content-id="' + contentId + '"]');
-        
+
         if ($containers.length === 0) {
             return;
         }
 
         efu_cache.put(data);
-        
+
         var userId = data.userId;
         var fieldNamesByObjectId = data.fieldNamesByObjectId;
 
         $containers.each(function() {
-
-            updateContainer(this, data);
-
             var $container = $(this);
+
+            updateContainer($container, data);
 
             if (!$container.is('form')) {
                 return;
@@ -247,7 +241,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
             // restores viewer data on the specified containers,
             // fetching from cache if available, otherwise making
             // an rtc.restore call for the data
-
             var contentIds = [ ];
 
             $(containers).each(function () {
@@ -257,18 +250,15 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
                     var contentId = $container.attr('data-rtc-content-id');
 
                     if (contentId) {
-
                         var contentData = VIEWERS_CACHE.fetch(contentId);
                         var i;
+
                         if (typeof contentData === 'object' && contentData instanceof Array) {
-
                             for (i = 0; i < contentData.length; i += 1) {
-
                                 updateContainer($container, contentData[i]);
                             }
 
                         } else {
-
                             efu_cache.putEmpty(contentId);
                             contentIds.push(contentId);
                         }
@@ -277,7 +267,6 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc', 'v3/color-utils', 'v3/EditFieldUpdateC
             });
 
             if (contentIds.length > 0) {
-
                 efu_cache.clearUnused();
 
                 rtc.restore('com.psddev.cms.tool.page.content.EditFieldUpdateState', {

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -1,176 +1,168 @@
 define(['jquery'], function($) {
+    var viewerDataCache = { },
+        hitCount = 0,
+        missCount = 0,
+        fetchCount = 0,
+        putCount = 0,
+        cleanCallCount = 0,
 
-    var VIEWERS_CACHE = (function() {
+        debugViewersCache = function() {
+            return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
+        },
 
-        var viewerDataCache = { },
-            hitCount = 0,
-            missCount = 0,
-            fetchCount = 0,
-            putCount = 0,
-            cleanCallCount = 0,
+        report = function() {
 
-            debugViewersCache = function() {
-                return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
-            },
+            if (!debugViewersCache()) {
+                return;
+            }
 
-            report = function() {
+            var total = hitCount + missCount,
+                ratio = (total === 0 && hitCount === 0) ? 0.0 : (total === 0 ? 1.0 : (hitCount === 0 ? 0.0 : hitCount / total));
 
-                if (!debugViewersCache()) {
-                    return;
+            ratio *= 100;
+
+            console.log(
+                "putCount: ", putCount,
+                ", fetchCount: ", fetchCount,
+                ", ratio: ", ratio + "%",
+                "size: ", Object.keys(viewerDataCache).length
+            );
+        },
+
+    // caches the specified viewer data in the specified cache object,
+    // keyed by contentId then userId.
+        cacheData = function(cache, data) {
+
+            putCount += 1;
+
+            var contentId = data.contentId,
+                userId = data.userId,
+                contentData,
+                userDataIndex = undefined,
+                i;
+
+            contentData = cache[contentId];
+
+            if (contentData === undefined) {
+                contentData = [ ];
+                cache[contentId] = contentData;
+            }
+
+            for (i = 0; i < contentData.length; i += 1) {
+                if (contentData[i].userId === userId) {
+                    userDataIndex = i;
                 }
+            }
 
-                var total = hitCount + missCount,
-                    ratio = (total === 0 && hitCount === 0) ? 0.0 : (total === 0 ? 1.0 : (hitCount === 0 ? 0.0 : hitCount / total));
+            if (userDataIndex !== undefined && userDataIndex >= 0) {
+                contentData.splice(userDataIndex, 1, data);
+            } else {
+                contentData.push(data);
+            }
 
-                ratio *= 100;
+            report();
+        },
 
-                console.log(
-                    "putCount: ", putCount,
-                    ", fetchCount: ", fetchCount,
-                    ", ratio: ", ratio + "%",
-                    "size: ", Object.keys(viewerDataCache).length
-                );
-            },
+    // fetches data from cache
+        fetchData = function(contentId) {
 
-        // caches the specified viewer data in the specified cache object,
-        // keyed by contentId then userId.
-            cacheData = function(cache, data) {
+            fetchCount += 1;
 
-                putCount += 1;
+            report();
 
-                var contentId = data.contentId,
-                    userId = data.userId,
-                    contentData,
-                    userDataIndex = undefined,
-                    i;
+            return viewerDataCache[contentId];
+        },
 
-                contentData = cache[contentId];
+        containsKey = function(key) {
+            return viewerDataCache[key];
+        };
 
-                if (contentData === undefined) {
-                    contentData = [ ];
-                    cache[contentId] = contentData;
-                }
+    return {
 
-                for (i = 0; i < contentData.length; i += 1) {
-                    if (contentData[i].userId === userId) {
-                        userDataIndex = i;
-                    }
-                }
+        putEmpty: function(key) {
 
-                if (userDataIndex !== undefined && userDataIndex >= 0) {
-                    contentData.splice(userDataIndex, 1, data);
-                } else {
-                    contentData.push(data);
-                }
-
-                report();
-            },
-
-        // fetches data from cache
-            fetchData = function(contentId) {
-
-                fetchCount += 1;
-
-                report();
-
-                return viewerDataCache[contentId];
-            },
-
-            containsKey = function(key) {
-                return viewerDataCache[key];
-            };
-
-        return {
-
-            putEmpty: function(key) {
-
-                if (!viewerDataCache[key]) {
-
-                    if (debugViewersCache()) {
-                        console.log("%cSEED", "color: green", key);
-                    }
-
-                    viewerDataCache[key] = [ ];
-                }
-            },
-
-            put: function(data) {
-
-                if (data && data.contentId) {
-
-                    // only cache data that's existed or been
-                    // pre-seeded to ensure that data in the
-                    // cache was intentionally placed there
-                    // starting with a restore
-                    if (containsKey(data.contentId)) {
-
-                        if (debugViewersCache()) {
-                            console.log("PUT", data.contentId);
-                        }
-
-                        cacheData(viewerDataCache, data);
-                    } else {
-
-                        if (debugViewersCache()) {
-                            console.log("SKIP", data.contentId);
-                        }
-                    }
-                }
-            },
-
-            fetch: function(contentId) {
-
-                var result = fetchData(contentId);
-
-                if (result) {
-
-                    hitCount += 1;
-                    if (debugViewersCache()) {
-                        console.log("%cCACHE HIT", "color: blue", contentId);
-                    }
-
-                } else {
-
-                    missCount += 1;
-
-                    if (debugViewersCache()) {
-                        console.log("%cCACHE MISS", "color: red", contentId);
-                    }
-                }
-
-                return result;
-            },
-
-            clearUnused: function() {
-
-                cleanCallCount += 1;
-
-                if (!(cleanCallCount % 20 === 0)) {
-                    return;
-                }
+            if (!viewerDataCache[key]) {
 
                 if (debugViewersCache()) {
-                    console.log("CLEAR");
+                    console.log("%cSEED", "color: green", key);
                 }
 
-                // clean out unused cache entries before making call to restore
-                var cleanCache = { };
-
-                $('[data-rtc-content-id]').each(function() {
-                    var contentId = $(this).attr('data-rtc-content-id'),
-                        cachedData = fetchData(contentId);
-
-                    if (cachedData) {
-                        cleanCache[contentId] = cachedData;
-                    }
-                });
-
-                viewerDataCache = cleanCache;
+                viewerDataCache[key] = [ ];
             }
-        };
-    })();
+        },
 
-    window.VIEWERS_CACHE = VIEWERS_CACHE;
+        put: function(data) {
 
-    return VIEWERS_CACHE;
+            if (data && data.contentId) {
+
+                // only cache data that's existed or been
+                // pre-seeded to ensure that data in the
+                // cache was intentionally placed there
+                // starting with a restore
+                if (containsKey(data.contentId)) {
+
+                    if (debugViewersCache()) {
+                        console.log("PUT", data.contentId);
+                    }
+
+                    cacheData(viewerDataCache, data);
+                } else {
+
+                    if (debugViewersCache()) {
+                        console.log("SKIP", data.contentId);
+                    }
+                }
+            }
+        },
+
+        fetch: function(contentId) {
+
+            var result = fetchData(contentId);
+
+            if (result) {
+
+                hitCount += 1;
+                if (debugViewersCache()) {
+                    console.log("%cCACHE HIT", "color: blue", contentId);
+                }
+
+            } else {
+
+                missCount += 1;
+
+                if (debugViewersCache()) {
+                    console.log("%cCACHE MISS", "color: red", contentId);
+                }
+            }
+
+            return result;
+        },
+
+        clearUnused: function() {
+
+            cleanCallCount += 1;
+
+            if (!(cleanCallCount % 20 === 0)) {
+                return;
+            }
+
+            if (debugViewersCache()) {
+                console.log("CLEAR");
+            }
+
+            // clean out unused cache entries before making call to restore
+            var cleanCache = { };
+
+            $('[data-rtc-content-id]').each(function() {
+                var contentId = $(this).attr('data-rtc-content-id'),
+                    cachedData = fetchData(contentId);
+
+                if (cachedData) {
+                    cleanCache[contentId] = cachedData;
+                }
+            });
+
+            viewerDataCache = cleanCache;
+        }
+    };
 });

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -15,7 +15,11 @@ define(['jquery'], function($) {
 
             report = function(force) {
 
-                if (debugViewersCache() && !force && !((putCount + fetchCount) % 15 === 0)) {
+                if (!debugViewersCache()) {
+                    return;
+                }
+
+                if (force !== true && !((putCount + fetchCount) % 15 === 0)) {
                     return;
                 }
 

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -3,10 +3,9 @@ define(['jquery'], function($) {
     var puts = 0;
     var gets = 0;
     var hits = 0;
-    var cleanCallCount = 0;
 
     function log() {
-        if (!window.DEBUG_EDIT_FIELD_UPDATE_CACHE || typeof console === "undefined") {
+        if (!window.DEBUG_EDIT_FIELD_UPDATE_CACHE || typeof console === 'undefined') {
             return;
         }
 
@@ -28,8 +27,9 @@ define(['jquery'], function($) {
     return {
         init: function(key) {
             if (!cache[key]) {
-                log('%cinit', 'color: blue', key);
                 cache[key] = [ ];
+
+                log('%cinit', 'color: blue', key);
             }
         },
 
@@ -49,11 +49,12 @@ define(['jquery'], function($) {
             // cache was intentionally placed there
             // starting with a restore
             if (cache[contentId]) {
-                log('%cput', 'color: blue', contentId);
 
                 // caches the specified viewer data in the specified cache object,
                 // keyed by contentId then userId.
                 puts += 1;
+
+                log('%cput', 'color: blue', contentId);
 
                 var userId = data.userId;
                 var contentData = cache[contentId];
@@ -79,15 +80,15 @@ define(['jquery'], function($) {
                 }
 
             } else {
-                log("%cput (skipped)", 'color: blue', contentId);
+                log('%cput (skipped)', 'color: blue', contentId);
             }
         },
 
         get: function(contentId) {
             gets += 1;
-            var result = cache[contentId];
+            var contentData = cache[contentId];
 
-            if (result) {
+            if (contentData) {
                 hits += 1;
                 log('%cget (hit)', 'color: green', contentId);
 
@@ -95,31 +96,28 @@ define(['jquery'], function($) {
                 log('%cget (miss)', 'color: red', contentId);
             }
 
-            return result;
+            return contentData;
         },
 
-        clearUnused: function() {
-            cleanCallCount += 1;
-
-            if (!(cleanCallCount % 20 === 0)) {
+        invalidate: function (contentIds) {
+            if (contentIds.length < 1) {
                 return;
             }
-
-            log('%cclear', 'color: blue');
 
             // clean out unused cache entries before making call to restore
             var cleanCache = { };
 
-            $('[data-rtc-content-id]').each(function() {
-                var contentId = $(this).attr('data-rtc-content-id');
-                var cachedData = cache[contentId];
+            $.each(contentIds, function (i, contentId) {
+                var contentData = cache[contentId];
 
-                if (cachedData) {
-                    cleanCache[contentId] = cachedData;
+                if (contentData) {
+                    cleanCache[contentId] = contentData;
                 }
             });
 
             cache = cleanCache;
+
+            log('%cinvalidate', 'color: blue', 'keep: ' + contentIds);
         }
     };
 });

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -1,0 +1,176 @@
+define(['jquery'], function($) {
+
+    var VIEWERS_CACHE = (function() {
+
+        var viewerDataCache = { },
+            hitCount = 0,
+            missCount = 0,
+            fetchCount = 0,
+            putCount = 0,
+            cleanCallCount = 0,
+
+            debugViewersCache = function() {
+                return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
+            },
+
+            report = function(force) {
+
+                if (debugViewersCache() && !force && !((putCount + fetchCount) % 15 === 0)) {
+                    return;
+                }
+
+                var total = hitCount + missCount,
+                    ratio = (total === 0 && hitCount === 0) ? 0.0 : (total === 0 ? 1.0 : (hitCount === 0 ? 0.0 : hitCount / total));
+
+                ratio *= 100;
+
+                console.log(
+                    "putCount: ", putCount,
+                    ", fetchCount: ", fetchCount,
+                    ", ratio: ", ratio + "%",
+                    "size: ", Object.keys(viewerDataCache).length
+                );
+            },
+
+        // caches the specified viewer data in the specified cache object,
+        // keyed by contentId then userId.
+            cacheData = function(cache, data) {
+
+                putCount += 1;
+
+                var contentId = data.contentId,
+                    userId = data.userId,
+                    contentData,
+                    userDataIndex = undefined,
+                    i;
+
+                contentData = cache[contentId];
+
+                if (contentData === undefined) {
+                    contentData = [ ];
+                    cache[contentId] = contentData;
+                }
+
+                for (i = 0; i < contentData.length; i += 1) {
+                    if (contentData[i].userId === userId) {
+                        userDataIndex = i;
+                    }
+                }
+
+                if (userDataIndex !== undefined && userDataIndex >= 0) {
+                    contentData.splice(userDataIndex, 1, data);
+                } else {
+                    contentData.push(data);
+                }
+
+                report();
+            },
+
+        // fetches data from cache
+            fetchData = function(contentId) {
+
+                fetchCount += 1;
+
+                report();
+
+                return viewerDataCache[contentId];
+            },
+
+            containsKey = function(key) {
+                return viewerDataCache[key];
+            };
+
+        return {
+
+            putEmpty: function(key) {
+
+                if (!viewerDataCache[key]) {
+
+                    if (debugViewersCache()) {
+                        console.log("%cSEED", "color: green", key);
+                    }
+
+                    viewerDataCache[key] = [ ];
+                }
+            },
+
+            put: function(data) {
+
+                if (data && data.contentId) {
+
+                    // only cache data that's existed or been
+                    // pre-seeded to ensure that data in the
+                    // cache was intentionally placed there
+                    // starting with a restore
+                    if (containsKey(data.contentId)) {
+
+                        if (debugViewersCache()) {
+                            console.log("PUT", data.contentId);
+                        }
+
+                        cacheData(viewerDataCache, data);
+                    } else {
+
+                        if (debugViewersCache()) {
+                            console.log("SKIP", data.contentId);
+                        }
+                    }
+                }
+            },
+
+            fetch: function(contentId) {
+
+                var result = fetchData(contentId);
+
+                if (result) {
+
+                    hitCount += 1;
+                    if (debugViewersCache()) {
+                        console.log("%cCACHE HIT", "color: blue", contentId);
+                    }
+
+                } else {
+
+                    missCount += 1;
+
+                    if (debugViewersCache()) {
+                        console.log("%cCACHE MISS", "color: red", contentId);
+                    }
+                }
+
+                return result;
+            },
+
+            clearUnused: function() {
+
+                cleanCallCount += 1;
+
+                if (!(cleanCallCount % 20 === 0)) {
+                    return;
+                }
+
+                if (debugViewersCache()) {
+                    console.log("CLEAR");
+                }
+
+                // clean out unused cache entries before making call to restore
+                var cleanCache = { };
+
+                $('[data-rtc-content-id]').each(function() {
+                    var contentId = $(this).attr('data-rtc-content-id'),
+                        cachedData = fetchData(contentId);
+
+                    if (cachedData) {
+                        cleanCache[contentId] = cachedData;
+                    }
+                });
+
+                viewerDataCache = cleanCache;
+            }
+        };
+    })();
+
+    window.VIEWERS_CACHE = VIEWERS_CACHE;
+
+    return VIEWERS_CACHE;
+});

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -28,40 +28,6 @@ define(['jquery'], function($) {
         );
     }
 
-    // caches the specified viewer data in the specified cache object,
-    // keyed by contentId then userId.
-    function cacheData(cache, data) {
-
-        putCount += 1;
-
-        var contentId = data.contentId,
-            userId = data.userId,
-            contentData,
-            userDataIndex = undefined,
-            i;
-
-        contentData = cache[contentId];
-
-        if (contentData === undefined) {
-            contentData = [ ];
-            cache[contentId] = contentData;
-        }
-
-        for (i = 0; i < contentData.length; i += 1) {
-            if (contentData[i].userId === userId) {
-                userDataIndex = i;
-            }
-        }
-
-        if (userDataIndex !== undefined && userDataIndex >= 0) {
-            contentData.splice(userDataIndex, 1, data);
-        } else {
-            contentData.push(data);
-        }
-
-        report();
-    }
-
     // fetches data from cache
     function fetchData(contentId) {
 
@@ -70,10 +36,6 @@ define(['jquery'], function($) {
         report();
 
         return viewerDataCache[contentId];
-    }
-
-    function containsKey(key) {
-        return viewerDataCache[key];
     }
 
     return {
@@ -98,13 +60,43 @@ define(['jquery'], function($) {
                 // pre-seeded to ensure that data in the
                 // cache was intentionally placed there
                 // starting with a restore
-                if (containsKey(data.contentId)) {
+                if (viewerDataCache[data.contentId]) {
 
                     if (debugViewersCache()) {
                         console.log("PUT", data.contentId);
                     }
 
-                    cacheData(viewerDataCache, data);
+                    // caches the specified viewer data in the specified cache object,
+                    // keyed by contentId then userId.
+                    putCount += 1;
+
+                    var contentId = data.contentId,
+                            userId = data.userId,
+                            contentData,
+                            userDataIndex = undefined,
+                            i;
+
+                    contentData = viewerDataCache[contentId];
+
+                    if (contentData === undefined) {
+                        contentData = [ ];
+                        viewerDataCache[contentId] = contentData;
+                    }
+
+                    for (i = 0; i < contentData.length; i += 1) {
+                        if (contentData[i].userId === userId) {
+                            userDataIndex = i;
+                        }
+                    }
+
+                    if (userDataIndex !== undefined && userDataIndex >= 0) {
+                        contentData.splice(userDataIndex, 1, data);
+                    } else {
+                        contentData.push(data);
+                    }
+
+                    report();
+
                 } else {
 
                     if (debugViewersCache()) {

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -13,13 +13,9 @@ define(['jquery'], function($) {
                 return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
             },
 
-            report = function(force) {
+            report = function() {
 
                 if (!debugViewersCache()) {
-                    return;
-                }
-
-                if (force !== true && !((putCount + fetchCount) % 15 === 0)) {
                     return;
                 }
 

--- a/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
+++ b/tool-ui/src/main/webapp/script/v3/EditFieldUpdateCache.js
@@ -1,81 +1,80 @@
 define(['jquery'], function($) {
-    var viewerDataCache = { },
-        hitCount = 0,
-        missCount = 0,
-        fetchCount = 0,
-        putCount = 0,
-        cleanCallCount = 0,
+    var viewerDataCache = { };
+    var hitCount = 0;
+    var missCount = 0;
+    var fetchCount = 0;
+    var putCount = 0;
+    var cleanCallCount = 0;
 
-        debugViewersCache = function() {
-            return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
-        },
+    function debugViewersCache() {
+        return window.LOG_VIEWERS_REPORTS && typeof console !== "undefined";
+    }
 
-        report = function() {
+    function report() {
+        if (!debugViewersCache()) {
+            return;
+        }
 
-            if (!debugViewersCache()) {
-                return;
-            }
+        var total = hitCount + missCount,
+            ratio = (total === 0 && hitCount === 0) ? 0.0 : (total === 0 ? 1.0 : (hitCount === 0 ? 0.0 : hitCount / total));
 
-            var total = hitCount + missCount,
-                ratio = (total === 0 && hitCount === 0) ? 0.0 : (total === 0 ? 1.0 : (hitCount === 0 ? 0.0 : hitCount / total));
+        ratio *= 100;
 
-            ratio *= 100;
-
-            console.log(
-                "putCount: ", putCount,
-                ", fetchCount: ", fetchCount,
-                ", ratio: ", ratio + "%",
-                "size: ", Object.keys(viewerDataCache).length
-            );
-        },
+        console.log(
+            "putCount: ", putCount,
+            ", fetchCount: ", fetchCount,
+            ", ratio: ", ratio + "%",
+            "size: ", Object.keys(viewerDataCache).length
+        );
+    }
 
     // caches the specified viewer data in the specified cache object,
     // keyed by contentId then userId.
-        cacheData = function(cache, data) {
+    function cacheData(cache, data) {
 
-            putCount += 1;
+        putCount += 1;
 
-            var contentId = data.contentId,
-                userId = data.userId,
-                contentData,
-                userDataIndex = undefined,
-                i;
+        var contentId = data.contentId,
+            userId = data.userId,
+            contentData,
+            userDataIndex = undefined,
+            i;
 
-            contentData = cache[contentId];
+        contentData = cache[contentId];
 
-            if (contentData === undefined) {
-                contentData = [ ];
-                cache[contentId] = contentData;
+        if (contentData === undefined) {
+            contentData = [ ];
+            cache[contentId] = contentData;
+        }
+
+        for (i = 0; i < contentData.length; i += 1) {
+            if (contentData[i].userId === userId) {
+                userDataIndex = i;
             }
+        }
 
-            for (i = 0; i < contentData.length; i += 1) {
-                if (contentData[i].userId === userId) {
-                    userDataIndex = i;
-                }
-            }
+        if (userDataIndex !== undefined && userDataIndex >= 0) {
+            contentData.splice(userDataIndex, 1, data);
+        } else {
+            contentData.push(data);
+        }
 
-            if (userDataIndex !== undefined && userDataIndex >= 0) {
-                contentData.splice(userDataIndex, 1, data);
-            } else {
-                contentData.push(data);
-            }
-
-            report();
-        },
+        report();
+    }
 
     // fetches data from cache
-        fetchData = function(contentId) {
+    function fetchData(contentId) {
 
-            fetchCount += 1;
+        fetchCount += 1;
 
-            report();
+        report();
 
-            return viewerDataCache[contentId];
-        },
+        return viewerDataCache[contentId];
+    }
 
-        containsKey = function(key) {
-            return viewerDataCache[key];
-        };
+    function containsKey(key) {
+        return viewerDataCache[key];
+    }
 
     return {
 


### PR DESCRIPTION
PR #1069  adds a cache of `rtc.restore` triggered and subsequent broadcast data for `com.psddev.cms.tool.page.content.EditFieldUpdateState`.

The purpose of caching `EditFieldUpdateState` data is to reduce the number of burst-restores issued to the master database when many Viewers containers exist on the page at the same time.  In particular, custom dashboard widget refresh triggered by ongoing CMS publish operations cause large bursts of `rtc.restore` calls, resulting in a large distributed query volume directed against the master database.

The caching plan put in place by this pull request allows caching of broadcast data only once the cache has been primed to receive data for a specific content ID, effectively ignoring irrelevant broadcast data for which no `[data-rtc-content-id]` containers exist on the current page.  This also ensures that `rtc.restore` requests are made at least once each time a new container ID is observed.

Periodically, prior to a `rtc.restore` call, the cache is scrubbed of entries with no corresponding `[data-rtc-content-id]` element on the page.

Preliminary testing indicates that high hit ratios are likely from the many-viewer dashboard:

<img width="978" alt="screen shot 2016-10-28 at 1 03 35 am" src="https://cloud.githubusercontent.com/assets/400882/19795539/62765624-9caa-11e6-894c-3e52e3621f00.png">

Where the hit ratio is effectively the reduction factor of `rtc.restore`-initiated queries against the master database.

The largest change to existing code is the re-organization of the broadcast reception callback into an `updateContainer` callback that is invoked with both in response to broadcast data and fetch from cache.
