### PR TITLE
BSP-2767 prevents default values from overwriting hidden state values on copy

### DIFF
--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -200,7 +200,6 @@ if (wp.isFormPost() && copy != null && editingState.isNew()) {
         copyState.as(Site.ObjectModification.class).setOwner(site);
     }
 
-    copyState.putAll(editingState.getRawValues());
     copyState.setId(editingState.getId());
     copyState.setStatus(editingState.getStatus());
     state = copyState;


### PR DESCRIPTION
Removes unnecessary editingState overlay from copyState to prevent unintentional overlay of hidden values with default values.  The true update of the copyState with editingState values is performed by update using form parameters in ToolPageContext#try* methods.