### PR TITLE
BSP-1439 adds capability to combine raw Hunspell spell checker dictionary with custom SpellCheckerDictionary implementations.

### DIFF
--- a/db/src/main/java/com/psddev/cms/nlp/SpellCheckerDictionary.java
+++ b/db/src/main/java/com/psddev/cms/nlp/SpellCheckerDictionary.java
@@ -1,0 +1,109 @@
+package com.psddev.cms.nlp;
+
+import com.google.common.base.Preconditions;
+import com.psddev.dari.db.Modification;
+import com.psddev.dari.db.Query;
+import com.psddev.dari.db.Recordable;
+import com.psddev.dari.util.StringUtils;
+import com.psddev.dari.util.UuidFormatException;
+import com.psddev.dari.util.UuidUtils;
+
+import java.util.Date;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Additional dictionary for {@link SpellChecker SpellCheckers}.
+ */
+public interface SpellCheckerDictionary extends Recordable {
+
+    String LOCALE_EXTENSION_PREFIX = "bsp-";
+
+    Locale getBaseLocale();
+
+    Set<String> getAllWords();
+
+    default Date getLastUpdated() {
+        return null;
+    }
+
+    /**
+     * Returns a SpellCheckerDictionary for a {@link Locale} when the
+     * Locale's {@link Locale#PRIVATE_USE_EXTENSION} represents a Brightspot
+     * SpellCheckerDictionary object.
+     *
+     * @param locale
+     *        Can't be {@code null}.
+     *
+     * @return {@code null} if the provided Locale's extension does not
+     *         contain a scoped {@link java.util.UUID} of a SpellCheckerDictionary
+     *         object.
+     */
+    static SpellCheckerDictionary forLocale(Locale locale) {
+
+        Preconditions.checkNotNull(locale);
+
+        String extension = locale.getExtension('x');
+
+        if (StringUtils.isBlank(extension)) {
+            return null;
+        }
+
+        if (!extension.startsWith(LOCALE_EXTENSION_PREFIX)) {
+            return null;
+        }
+
+        extension = extension.substring(4).replaceAll("\\-", "");
+
+        if (StringUtils.isBlank(extension)) {
+            return null;
+        }
+
+        try {
+            return Query.findById(SpellCheckerDictionary.class, UuidUtils.fromString(extension));
+        } catch (UuidFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Provides a method to acquire a {@link Locale} representing the
+     * SpellCheckerDictionary.
+     */
+    class LocaleModification extends Modification<SpellCheckerDictionary> {
+
+        /**
+         * Returns a {@link Locale} based on {@link SpellCheckerDictionary#getBaseLocale()}
+         * or {@link Locale#getDefault()} with the {@link Locale#PRIVATE_USE_EXTENSION}
+         * containing the {@link com.psddev.dari.db.State#id id} of the modified
+         * object.
+         *
+         * @return Never {@code null}.
+         */
+        public Locale getDictionaryLocale() {
+
+            SpellCheckerDictionary spellCheckerDictionary = getOriginalObject();
+
+            Locale baseLocale = spellCheckerDictionary.getBaseLocale();
+
+            if (baseLocale == null) {
+                baseLocale = Locale.getDefault();
+            }
+
+            StringBuilder extBuilder = new StringBuilder(getState().getId().toString().replaceAll("\\-", ""));
+
+            for (int i = 30; i > 1; i -= 2) {
+                extBuilder.insert(i, '-');
+            }
+
+            String extension = extBuilder.toString();
+
+            // add private-use extension of the form bsp-00-00-01-58-70-3f-db-31-a5-7a-77-ff-0b-4f-00-00
+            return new Locale.Builder()
+                .setLocale(baseLocale)
+                .clearExtensions()
+                .setExtension('x', LOCALE_EXTENSION_PREFIX + extension)
+                .build();
+        }
+    }
+}

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/AbstractHunspellDictionary.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/AbstractHunspellDictionary.java
@@ -1,0 +1,98 @@
+package com.psddev.cms.hunspell;
+
+import com.google.common.base.Preconditions;
+import com.psddev.dari.db.Modification;
+import com.psddev.dari.db.Query;
+import com.psddev.dari.db.Record;
+import com.psddev.dari.util.ObjectUtils;
+import com.psddev.dari.util.StringUtils;
+import com.psddev.dari.util.UuidFormatException;
+import com.psddev.dari.util.UuidUtils;
+
+import java.util.Locale;
+
+public abstract class AbstractHunspellDictionary extends Record implements HunspellDictionary {
+
+
+    /**
+     * Returns a SpellCheckerDictionary for a {@link Locale} when the
+     * Locale's {@link Locale#PRIVATE_USE_EXTENSION} represents a Brightspot
+     * SpellCheckerDictionary object.
+     *
+     * @param name
+     *        Can't be {@code null}.
+     *
+     * @return {@code null} if the provided Locale's extension does not
+     *         contain a scoped {@link java.util.UUID} of a SpellCheckerDictionary
+     *         object.
+     */
+    static HunspellDictionary forName(String name) {
+
+        Preconditions.checkArgument(!ObjectUtils.isBlank(name));
+
+        Locale locale = Locale.forLanguageTag(name);
+
+        String extension = locale.getExtension('x');
+
+        if (StringUtils.isBlank(extension)) {
+            return null;
+        }
+
+        if (!extension.startsWith(LOCALE_EXTENSION_PREFIX)) {
+            return null;
+        }
+
+        extension = extension.substring(4).replaceAll("\\-", "");
+
+        if (StringUtils.isBlank(extension)) {
+            return null;
+        }
+
+        try {
+            return Query.findById(HunspellDictionary.class, UuidUtils.fromString(extension));
+        } catch (UuidFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Provides a method to acquire a {@link Locale} representing the
+     * SpellCheckerDictionary.
+     */
+    class LocaleModification extends Modification<AbstractHunspellDictionary> {
+
+        /**
+         * Returns a {@link Locale} based on {@link HunspellDictionary#getBaseLocale()}
+         * or {@link Locale#getDefault()} with the {@link Locale#PRIVATE_USE_EXTENSION}
+         * containing the {@link com.psddev.dari.db.State#id id} of the modified
+         * object.
+         *
+         * @return Never {@code null}.
+         */
+        public Locale getDictionaryLocale() {
+
+            HunspellDictionary hunspellDictionary = getOriginalObject();
+
+            Locale baseLocale = hunspellDictionary.getBaseLocale();
+
+            if (baseLocale == null) {
+                baseLocale = Locale.getDefault();
+            }
+
+            StringBuilder extBuilder = new StringBuilder(getState().getId().toString().replaceAll("\\-", ""));
+
+            for (int i = 30; i > 1; i -= 2) {
+                extBuilder.insert(i, '-');
+            }
+
+            String extension = extBuilder.toString();
+
+            // add private-use extension of the form bsp-00-00-01-58-70-3f-db-31-a5-7a-77-ff-0b-4f-00-00
+            return new Locale.Builder()
+                .setLocale(baseLocale)
+                .clearExtensions()
+                .setExtension('x', LOCALE_EXTENSION_PREFIX + extension)
+                .build();
+        }
+    }
+}

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
@@ -1,13 +1,5 @@
 package com.psddev.cms.hunspell;
 
-import com.google.common.base.Preconditions;
-import com.psddev.dari.db.Modification;
-import com.psddev.dari.db.Query;
-import com.psddev.dari.util.ObjectUtils;
-import com.psddev.dari.util.StringUtils;
-import com.psddev.dari.util.UuidFormatException;
-import com.psddev.dari.util.UuidUtils;
-
 import java.util.Locale;
 import java.util.Set;
 
@@ -20,87 +12,7 @@ public interface HunspellDictionary {
 
     Locale getBaseLocale();
 
+    boolean isSupported(Locale locale);
+
     Set<String> getAllWords();
-
-    /**
-     * Returns a SpellCheckerDictionary for a {@link Locale} when the
-     * Locale's {@link Locale#PRIVATE_USE_EXTENSION} represents a Brightspot
-     * SpellCheckerDictionary object.
-     *
-     * @param name
-     *        Can't be {@code null}.
-     *
-     * @return {@code null} if the provided Locale's extension does not
-     *         contain a scoped {@link java.util.UUID} of a SpellCheckerDictionary
-     *         object.
-     */
-    static HunspellDictionary forName(String name) {
-
-        Preconditions.checkArgument(!ObjectUtils.isBlank(name));
-
-        Locale locale = Locale.forLanguageTag(name);
-
-        String extension = locale.getExtension('x');
-
-        if (StringUtils.isBlank(extension)) {
-            return null;
-        }
-
-        if (!extension.startsWith(LOCALE_EXTENSION_PREFIX)) {
-            return null;
-        }
-
-        extension = extension.substring(4).replaceAll("\\-", "");
-
-        if (StringUtils.isBlank(extension)) {
-            return null;
-        }
-
-        try {
-            return Query.findById(HunspellDictionary.class, UuidUtils.fromString(extension));
-        } catch (UuidFormatException e) {
-            return null;
-        }
-    }
-
-    /**
-     * Provides a method to acquire a {@link Locale} representing the
-     * SpellCheckerDictionary.
-     */
-    class LocaleModification extends Modification<HunspellDictionary> {
-
-        /**
-         * Returns a {@link Locale} based on {@link HunspellDictionary#getBaseLocale()}
-         * or {@link Locale#getDefault()} with the {@link Locale#PRIVATE_USE_EXTENSION}
-         * containing the {@link com.psddev.dari.db.State#id id} of the modified
-         * object.
-         *
-         * @return Never {@code null}.
-         */
-        public Locale getDictionaryLocale() {
-
-            HunspellDictionary hunspellDictionary = getOriginalObject();
-
-            Locale baseLocale = hunspellDictionary.getBaseLocale();
-
-            if (baseLocale == null) {
-                baseLocale = Locale.getDefault();
-            }
-
-            StringBuilder extBuilder = new StringBuilder(getState().getId().toString().replaceAll("\\-", ""));
-
-            for (int i = 30; i > 1; i -= 2) {
-                extBuilder.insert(i, '-');
-            }
-
-            String extension = extBuilder.toString();
-
-            // add private-use extension of the form bsp-00-00-01-58-70-3f-db-31-a5-7a-77-ff-0b-4f-00-00
-            return new Locale.Builder()
-                .setLocale(baseLocale)
-                .clearExtensions()
-                .setExtension('x', LOCALE_EXTENSION_PREFIX + extension)
-                .build();
-        }
-    }
 }

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.psddev.cms.nlp.SpellChecker;
 import com.psddev.dari.db.Modification;
 import com.psddev.dari.db.Query;
+import com.psddev.dari.util.ObjectUtils;
 import com.psddev.dari.util.StringUtils;
 import com.psddev.dari.util.UuidFormatException;
 import com.psddev.dari.util.UuidUtils;
@@ -32,16 +33,18 @@ public interface HunspellDictionary {
      * Locale's {@link Locale#PRIVATE_USE_EXTENSION} represents a Brightspot
      * SpellCheckerDictionary object.
      *
-     * @param locale
+     * @param name
      *        Can't be {@code null}.
      *
      * @return {@code null} if the provided Locale's extension does not
      *         contain a scoped {@link java.util.UUID} of a SpellCheckerDictionary
      *         object.
      */
-    static HunspellDictionary forLocale(Locale locale) {
+    static HunspellDictionary forName(String name) {
 
-        Preconditions.checkNotNull(locale);
+        Preconditions.checkArgument(!ObjectUtils.isBlank(name));
+
+        Locale locale = Locale.forLanguageTag(name);
 
         String extension = locale.getExtension('x');
 

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
@@ -1,9 +1,9 @@
-package com.psddev.cms.nlp;
+package com.psddev.cms.hunspell;
 
 import com.google.common.base.Preconditions;
+import com.psddev.cms.nlp.SpellChecker;
 import com.psddev.dari.db.Modification;
 import com.psddev.dari.db.Query;
-import com.psddev.dari.db.Recordable;
 import com.psddev.dari.util.StringUtils;
 import com.psddev.dari.util.UuidFormatException;
 import com.psddev.dari.util.UuidUtils;
@@ -15,7 +15,7 @@ import java.util.Set;
 /**
  * Additional dictionary for {@link SpellChecker SpellCheckers}.
  */
-public interface SpellCheckerDictionary extends Recordable {
+public interface HunspellDictionary {
 
     String LOCALE_EXTENSION_PREFIX = "bsp-";
 
@@ -39,7 +39,7 @@ public interface SpellCheckerDictionary extends Recordable {
      *         contain a scoped {@link java.util.UUID} of a SpellCheckerDictionary
      *         object.
      */
-    static SpellCheckerDictionary forLocale(Locale locale) {
+    static HunspellDictionary forLocale(Locale locale) {
 
         Preconditions.checkNotNull(locale);
 
@@ -60,7 +60,7 @@ public interface SpellCheckerDictionary extends Recordable {
         }
 
         try {
-            return Query.findById(SpellCheckerDictionary.class, UuidUtils.fromString(extension));
+            return Query.findById(HunspellDictionary.class, UuidUtils.fromString(extension));
         } catch (UuidFormatException e) {
             return null;
         }
@@ -70,10 +70,10 @@ public interface SpellCheckerDictionary extends Recordable {
      * Provides a method to acquire a {@link Locale} representing the
      * SpellCheckerDictionary.
      */
-    class LocaleModification extends Modification<SpellCheckerDictionary> {
+    class LocaleModification extends Modification<HunspellDictionary> {
 
         /**
-         * Returns a {@link Locale} based on {@link SpellCheckerDictionary#getBaseLocale()}
+         * Returns a {@link Locale} based on {@link HunspellDictionary#getBaseLocale()}
          * or {@link Locale#getDefault()} with the {@link Locale#PRIVATE_USE_EXTENSION}
          * containing the {@link com.psddev.dari.db.State#id id} of the modified
          * object.
@@ -82,9 +82,9 @@ public interface SpellCheckerDictionary extends Recordable {
          */
         public Locale getDictionaryLocale() {
 
-            SpellCheckerDictionary spellCheckerDictionary = getOriginalObject();
+            HunspellDictionary hunspellDictionary = getOriginalObject();
 
-            Locale baseLocale = spellCheckerDictionary.getBaseLocale();
+            Locale baseLocale = hunspellDictionary.getBaseLocale();
 
             if (baseLocale == null) {
                 baseLocale = Locale.getDefault();

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
@@ -8,12 +8,11 @@ import com.psddev.dari.util.StringUtils;
 import com.psddev.dari.util.UuidFormatException;
 import com.psddev.dari.util.UuidUtils;
 
-import java.util.Date;
 import java.util.Locale;
 import java.util.Set;
 
 /**
- * Additional dictionary for {@link SpellChecker SpellCheckers}.
+ * Additional dictionary for {@link HunspellSpellChecker HunspellSpellCheckers}.
  */
 public interface HunspellDictionary {
 
@@ -22,10 +21,6 @@ public interface HunspellDictionary {
     Locale getBaseLocale();
 
     Set<String> getAllWords();
-
-    default Date getLastUpdated() {
-        return null;
-    }
 
     /**
      * Returns a SpellCheckerDictionary for a {@link Locale} when the

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellDictionary.java
@@ -1,7 +1,6 @@
 package com.psddev.cms.hunspell;
 
 import com.google.common.base.Preconditions;
-import com.psddev.cms.nlp.SpellChecker;
 import com.psddev.dari.db.Modification;
 import com.psddev.dari.db.Query;
 import com.psddev.dari.util.ObjectUtils;

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
@@ -72,11 +72,9 @@ public class HunspellSpellChecker implements SpellChecker {
                         if (affixInput != null) {
                             try (InputStream dictionaryInput = getClass().getResourceAsStream("/" + name + DICTIONARY_FILE_SUFFIX)) {
                                 if (dictionaryInput != null) {
-
                                     HunspellDictionary dictionary = HunspellDictionary.forName(name);
 
                                     String tmpdir = System.getProperty("java.io.tmpdir");
-
                                     Path affixPath = Paths.get(tmpdir, name + AFFIX_FILE_SUFFIX);
                                     Path dictionaryPath = Paths.get(tmpdir, name + DICTIONARY_FILE_SUFFIX);
 

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
@@ -8,7 +8,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.psddev.cms.nlp.SpellChecker;
-import com.psddev.cms.nlp.SpellCheckerDictionary;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
@@ -84,19 +83,12 @@ public class HunspellSpellChecker implements SpellChecker {
                             try (InputStream dictionaryInput = getClass().getResourceAsStream("/" + name + DICTIONARY_FILE_SUFFIX)) {
                                 if (dictionaryInput != null) {
 
-                                    SpellCheckerDictionary dictionary = SpellCheckerDictionary.forLocale(locale);
-
-                                    String prefixPath = name;
-
-                                    if (dictionary != null) {
-
-                                        prefixPath = prefixPath + "_" + dictionary.getState().getId().toString().replaceAll("\\-", "");
-                                    }
+                                    HunspellDictionary dictionary = HunspellDictionary.forLocale(locale);
 
                                     String tmpdir = System.getProperty("java.io.tmpdir");
 
-                                    Path affixPath = Paths.get(tmpdir, prefixPath + AFFIX_FILE_SUFFIX);
-                                    Path dictionaryPath = Paths.get(tmpdir, prefixPath + DICTIONARY_FILE_SUFFIX);
+                                    Path affixPath = Paths.get(tmpdir, name + AFFIX_FILE_SUFFIX);
+                                    Path dictionaryPath = Paths.get(tmpdir, name + DICTIONARY_FILE_SUFFIX);
 
                                     Files.copy(affixInput, affixPath, StandardCopyOption.REPLACE_EXISTING);
                                     Files.copy(dictionaryInput, dictionaryPath, StandardCopyOption.REPLACE_EXISTING);
@@ -123,9 +115,9 @@ public class HunspellSpellChecker implements SpellChecker {
     private Hunspell findHunspell(Locale locale) {
 
         if (lastAccessed.containsKey(locale)) {
-            SpellCheckerDictionary spellCheckerDictionary = SpellCheckerDictionary.forLocale(locale);
-            if (spellCheckerDictionary != null) {
-                Date lastUpdated = spellCheckerDictionary.getLastUpdated();
+            HunspellDictionary hunspellDictionary = HunspellDictionary.forLocale(locale);
+            if (hunspellDictionary != null) {
+                Date lastUpdated = hunspellDictionary.getLastUpdated();
                 if (lastUpdated != null && lastUpdated.after(lastAccessed.get(locale))) {
                     hunspells.invalidate(locale);
                 }

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
@@ -67,7 +67,6 @@ public class HunspellSpellChecker implements SpellChecker {
                 @Override
                 @ParametersAreNonnullByDefault
                 public Optional<Hunspell> load(String name) throws IOException {
-
                     try (InputStream affixInput = getClass().getResourceAsStream("/" + name + AFFIX_FILE_SUFFIX)) {
                         if (affixInput != null) {
                             try (InputStream dictionaryInput = getClass().getResourceAsStream("/" + name + DICTIONARY_FILE_SUFFIX)) {

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
@@ -71,6 +71,7 @@ public class HunspellSpellChecker implements SpellChecker {
                         if (affixInput != null) {
                             try (InputStream dictionaryInput = getClass().getResourceAsStream("/" + name + DICTIONARY_FILE_SUFFIX)) {
                                 if (dictionaryInput != null) {
+                                    // Doesn't work - needs a way to acquire the dictionary
                                     HunspellDictionary dictionary = HunspellDictionary.forName(name);
 
                                     String tmpdir = System.getProperty("java.io.tmpdir");

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
@@ -49,56 +49,56 @@ public class HunspellSpellChecker implements SpellChecker {
     public static final String DICTIONARY_FILE_SUFFIX = ".dic";
 
     private final LoadingCache<String, Optional<Hunspell>> hunspells = CacheBuilder
-        .newBuilder()
-        .removalListener(new RemovalListener<String, Optional<Hunspell>>() {
+            .newBuilder()
+            .removalListener(new RemovalListener<String, Optional<Hunspell>>() {
 
-            @Override
-            @ParametersAreNonnullByDefault
-            public void onRemoval(RemovalNotification<String, Optional<Hunspell>> removalNotification) {
-                Optional<Hunspell> hunspellOptional = removalNotification.getValue();
+                @Override
+                @ParametersAreNonnullByDefault
+                public void onRemoval(RemovalNotification<String, Optional<Hunspell>> removalNotification) {
+                    Optional<Hunspell> hunspellOptional = removalNotification.getValue();
 
-                if (hunspellOptional != null) {
-                    hunspellOptional.ifPresent(Hunspell::close);
+                    if (hunspellOptional != null) {
+                        hunspellOptional.ifPresent(Hunspell::close);
+                    }
                 }
-            }
-        })
-        .build(new CacheLoader<String, Optional<Hunspell>>() {
+            })
+            .build(new CacheLoader<String, Optional<Hunspell>>() {
 
-            @Override
-            @ParametersAreNonnullByDefault
-            public Optional<Hunspell> load(String name) throws IOException {
+                @Override
+                @ParametersAreNonnullByDefault
+                public Optional<Hunspell> load(String name) throws IOException {
 
-                try (InputStream affixInput = getClass().getResourceAsStream("/" + name + AFFIX_FILE_SUFFIX)) {
-                    if (affixInput != null) {
-                        try (InputStream dictionaryInput = getClass().getResourceAsStream("/" + name + DICTIONARY_FILE_SUFFIX)) {
-                            if (dictionaryInput != null) {
+                    try (InputStream affixInput = getClass().getResourceAsStream("/" + name + AFFIX_FILE_SUFFIX)) {
+                        if (affixInput != null) {
+                            try (InputStream dictionaryInput = getClass().getResourceAsStream("/" + name + DICTIONARY_FILE_SUFFIX)) {
+                                if (dictionaryInput != null) {
 
-                                HunspellDictionary dictionary = HunspellDictionary.forName(name);
+                                    HunspellDictionary dictionary = HunspellDictionary.forName(name);
 
-                                String tmpdir = System.getProperty("java.io.tmpdir");
+                                    String tmpdir = System.getProperty("java.io.tmpdir");
 
-                                Path affixPath = Paths.get(tmpdir, name + AFFIX_FILE_SUFFIX);
-                                Path dictionaryPath = Paths.get(tmpdir, name + DICTIONARY_FILE_SUFFIX);
+                                    Path affixPath = Paths.get(tmpdir, name + AFFIX_FILE_SUFFIX);
+                                    Path dictionaryPath = Paths.get(tmpdir, name + DICTIONARY_FILE_SUFFIX);
 
-                                Files.copy(affixInput, affixPath, StandardCopyOption.REPLACE_EXISTING);
-                                Files.copy(dictionaryInput, dictionaryPath, StandardCopyOption.REPLACE_EXISTING);
+                                    Files.copy(affixInput, affixPath, StandardCopyOption.REPLACE_EXISTING);
+                                    Files.copy(dictionaryInput, dictionaryPath, StandardCopyOption.REPLACE_EXISTING);
 
-                                Hunspell hunspell = new Hunspell(dictionaryPath.toString(), affixPath.toString());
+                                    Hunspell hunspell = new Hunspell(dictionaryPath.toString(), affixPath.toString());
 
-                                if (dictionary != null) {
-                                    for (String word : dictionary.getAllWords()) {
-                                        hunspell.add(word);
+                                    if (dictionary != null) {
+                                        for (String word : dictionary.getAllWords()) {
+                                            hunspell.add(word);
+                                        }
                                     }
-                                }
 
-                                return Optional.of(hunspell);
+                                    return Optional.of(hunspell);
+                                }
                             }
                         }
                     }
-                }
 
-                return Optional.empty();
-            }
+                    return Optional.empty();
+                }
         });
 
     private Hunspell findHunspell(Locale locale) {

--- a/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
+++ b/hunspell/src/main/java/com/psddev/cms/hunspell/HunspellSpellChecker.java
@@ -99,15 +99,15 @@ public class HunspellSpellChecker implements SpellChecker {
 
                     return Optional.empty();
                 }
-        });
+            });
 
     private Hunspell findHunspell(Locale locale) {
         return SpellChecker.createDictionaryNames("HunspellDictionary", locale)
-            .stream()
-            .map(l -> hunspells.getUnchecked(l).orElse(null))
-            .filter(h -> h != null)
-            .findFirst()
-            .orElse(null);
+                .stream()
+                .map(l -> hunspells.getUnchecked(l).orElse(null))
+                .filter(h -> h != null)
+                .findFirst()
+                .orElse(null);
     }
 
     @Override


### PR DESCRIPTION
Provides the `SpellCheckerDictionary` interface for implementing managed add-on dictionaries and integrates the "bsp-"-scoped private-use extended Locale into HunspellSpellChecker.

Requirements for a SpellCheckerDictionary are that it provide a base `Locale`, a `Set<String> words`, and a `Date lastUpdated` timestamp.  A simple implementation can be:

```
public class MySpellCheckerDictionary extends Record implements SpellCheckerDictionary {

    private Set<String> words;
    
    private Locale locale;

    @Override
    public Set<String> getAllWords() {

        if (words == null) {
            words = new HashSet<>();
        }
        return words;
    }

    @Override
    public Locale getBaseLocale() {
        return locale;
    }

    @Override
    public Date getLastUpdated() {
        return as(Content.ObjectModification.class).getUpdateDate();
    }
}
```

Use the `SpellChecker` containing the custom `SpellCheckerDictionary` like:

```
MySpellCheckerDictionary dictionary = Query.findById(MySpellCheckerDictionary.class, dictionaryId);

Locale dictionaryLocale = dictionary.as(SpellCheckerDictionary.LocaleModification.class).getDictionaryLocale();

SpellChecker.getInstance(dictionaryLocale).suggest(dictionaryLocale, "appel");
// returns "apple" and other suggestions when dictionary contains no works,
// returns no suggestions is dictionary contains "appel"
```
