### PR TITLE
RTE allow copy when RTE is read-only (BSP-1769)

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -872,7 +872,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.rte.init(self.$editor);
 
             // Set to read only mode if necessary
-            self.rte.readOnlySet( self.$el.closest('.inputContainer-readOnly').length );
+            self.rte.readOnlySet( self.$el.closest('.inputContainer-readOnly, .objectInputs-readOnly').length );
             
             // Override the rich text editor to tell it how enhancements should be imported from HTML
             self.rte.enhancementFromHTML = function($content, line) {

--- a/tool-ui/src/main/webapp/style/v3/form.less
+++ b/tool-ui/src/main/webapp/style/v3/form.less
@@ -277,7 +277,8 @@
   .repeatableForm-previewable > ol > li,
   .carousel-tile,
   .carousel-nav,
-  .carousel-target-nav {
+  .carousel-target-nav,
+  .rte2-codemirror {
     pointer-events: auto;
   }
 


### PR DESCRIPTION
Currently when the RTE is part of a readonly object, the mouse pointer events are disabled to prevent the user from interacting with the RTE. However, this prevents users from being about to copy content out of the RTE. This commit puts the RTE into read-only mode but still lets the user copy content.