### PR TITLE
BSP-2862 Reduces performance degradation of side-by-side diff height equalization JS by about 95.1%.

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/content/diff.js
+++ b/tool-ui/src/main/webapp/script/v3/content/diff.js
@@ -51,9 +51,10 @@ define([ 'jquery', 'bsp-utils', 'diff', 'v3/RecalculateDimensions' ], function($
       });
 
       var equalizeHeights = $.throttle(100, function() {
+        var $contentDiffRightContainers = $container.find('.contentDiffRight .inputContainer');
         $container.find('.contentDiffLeft .inputContainer').not('.contentDiffSame').each(function() {
           var $leftInput = $(this);
-          var $rightInput = $container.find('.contentDiffRight .inputContainer[data-name="' + $leftInput.attr('data-name') + '"]');
+          var $rightInput = $contentDiffRightContainers.filter('[data-name="' + $leftInput.attr('data-name') + '"]');
           var $bothInputs = $leftInput.add($rightInput);
 
           $bothInputs.css('height', '');

--- a/tool-ui/src/main/webapp/script/v3/content/diff.js
+++ b/tool-ui/src/main/webapp/script/v3/content/diff.js
@@ -51,7 +51,7 @@ define([ 'jquery', 'bsp-utils', 'diff', 'v3/RecalculateDimensions' ], function($
       });
 
       var equalizeHeights = $.throttle(100, function() {
-        $container.find('.contentDiffLeft .inputContainer').each(function() {
+        $container.find('.contentDiffLeft .inputContainer').not('.contentDiffSame').each(function() {
           var $leftInput = $(this);
           var $rightInput = $container.find('.contentDiffRight .inputContainer[data-name="' + $leftInput.attr('data-name') + '"]');
           var $bothInputs = $leftInput.add($rightInput);


### PR DESCRIPTION
Before:
<img width="1383" alt="screen shot 2016-12-20 at 12 16 12 pm" src="https://cloud.githubusercontent.com/assets/400882/21434646/a9c01e10-c843-11e6-964c-74d8dcdcdf4a.png">

After Exclusion of `.contentDiffSame` elements:
![screen shot 2016-12-22 at 12 29 11 pm](https://cloud.githubusercontent.com/assets/400882/21434658/bb34ed06-c843-11e6-94f0-77956876a293.png)

After caching of `.contentDiffRight .inputContainer` elements:
![screen shot 2016-12-22 at 12 59 47 pm](https://cloud.githubusercontent.com/assets/400882/21435268/e42e0078-c846-11e6-994d-70595720d76d.png)

Total execution time of `equalizeHeights` method reduced from 300ms to 14.7ms.
