### PR TITLE
Speeds up jquery.dropdown.js _create method by approximately 19.63%, reducing DOMContentLoaded duration by 1.65%

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.dropdown.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.dropdown.js
@@ -151,7 +151,7 @@ define([ 'string', 'bsp-utils' ], function (S, bsp_utils) {
       }
 
       $label.bind('dropDown-update', function() {
-        var newLabel = $.map($original.find('option:selected'), function(option) {
+        var newLabel = $.map($original.find('option').filter(':selected'), function(option) {
           return $(option).attr("data-drop-down-html") || $(option).text();
         }).join(', ');
 


### PR DESCRIPTION
Under investigation is the _create function in jquery.tabbed.js, which accounts for just over 7% of DOMContentLoaded duration on an edit page.  Within _create, jquery.dropdown.js _initVisible method accounts for a large portion of CPU usage.

By changing `jQuery.find('option:selected')` to `jQuery.find('option').filter(':selected')` per "Additional Notes" here https://api.jquery.com/selected-selector/, a 13.35% reduction in execution time of dropdown _create is achieved.

jquery.tabbed.js _create Before:

![screen shot 2016-12-22 at 4 19 04 pm](https://cloud.githubusercontent.com/assets/400882/21440947/9f13f296-c863-11e6-8ef0-3a265e68ffa5.png)

jquery.tabbed.js _create After:

![screen shot 2016-12-22 at 4 19 26 pm](https://cloud.githubusercontent.com/assets/400882/21440950/a3b64024-c863-11e6-8200-2d23cc525f90.png)
