### PR TITLE
BSP-2909: Updates a few SearchResultAction label to not refer to collection as they are just manipulating items instead of the collection itself. Also updates SaveSelectionSearchResultAction label to be more specific to its usage (renaming/creating).

### DIFF
--- a/db/src/main/resources/com/psddev/cms/tool/page/BulkArchiveDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/BulkArchiveDefault_en.properties
@@ -1,8 +1,8 @@
 action.archiveAll=Bulk Archive All
-action.archiveSelected=Bulk Archive Collection
+action.archiveSelected=Bulk Archive
 action.confirm=Confirm bulk {name}
 action.restoreAll=Bulk Restore All
-action.restoreSelected=Bulk Restore Collection
+action.restoreSelected=Bulk Restore
 
 message.archived=Successfully archived {count} {count, plural, one{item}other{items}}.
 message.confirm=Click below to confirm bulk {action} of {count} {count, plural, one{item}other{items}}.

--- a/db/src/main/resources/com/psddev/cms/tool/page/BulkArchiveDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/BulkArchiveDefault_es.properties
@@ -1,8 +1,8 @@
 action.archiveAll=Archivar Todo el Conjunto
-action.archiveSelected=Archivar la Colección por Lote
+action.archiveSelected=Archivar por Lote
 action.confirm=Confirmar Conjunto {name}
 action.restoreAll=Restaurar Todo por Lote
-action.restoreSelected=Restaurar la Colección por Lote
+action.restoreSelected=Restaurar por Lote
 
 message.archived=Archivar elementos con éxito {count}
 message.confirm=Hacer clic abajo para confirmar conjunto {action} de {count} {count, plural, one{elemento}other{elementos}}.

--- a/db/src/main/resources/com/psddev/cms/tool/page/ExportContentDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/ExportContentDefault_en.properties
@@ -1,2 +1,2 @@
 action.exportAll=Export All
-action.exportSelected=Export Collection
+action.exportSelected=Export

--- a/db/src/main/resources/com/psddev/cms/tool/page/ExportContentDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/ExportContentDefault_es.properties
@@ -1,2 +1,2 @@
 action.exportAll=Exportar Todo
-action.exportSelected=Exportar la Colección
+action.exportSelected=Exportar

--- a/db/src/main/resources/com/psddev/cms/tool/page/SearchResultActionsDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/SearchResultActionsDefault_en.properties
@@ -4,4 +4,4 @@ message.moreItemsSelected=+ {size} more {size, plural, one{item}other{items}} se
 option.newSelection=New Collection
 
 subtitle.all=Actions
-subtitle.selection=Collection Actions
+subtitle.selection=Actions

--- a/db/src/main/resources/com/psddev/cms/tool/page/SearchResultActionsDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/SearchResultActionsDefault_es.properties
@@ -4,4 +4,4 @@ message.moreItemsSelected=+ {size} Más {size, plural, one{Elemento Seleccionado
 option.newSelection=Colección Nueva
 
 subtitle.all=Acciones
-subtitle.selection=Colección Acciones
+subtitle.selection=Acciones

--- a/db/src/main/resources/com/psddev/cms/tool/search/BulkEditSearchResultActionDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/search/BulkEditSearchResultActionDefault_en.properties
@@ -1,2 +1,2 @@
 action.editAll=Bulk Edit All
-action.editSelected=Bulk Edit Collection
+action.editSelected=Bulk Edit

--- a/db/src/main/resources/com/psddev/cms/tool/search/BulkEditSearchResultActionDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/search/BulkEditSearchResultActionDefault_es.properties
@@ -1,2 +1,2 @@
 action.editAll=Agrupar Todas las Ediciones
-action.editSelected=Editar la Colección por Lote
+action.editSelected=Editar por Lote

--- a/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_en.properties
@@ -1,2 +1,2 @@
-action.editSelection=Edit Collection
-action.saveSelection=Save Collection
+action.editSelection=Rename Collection
+action.saveSelection=Create New Collection

--- a/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_en.properties
@@ -1,2 +1,2 @@
 action.editSelection=Rename Collection
-action.saveSelection=Create New Collection
+action.saveSelection=New Collection

--- a/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_es.properties
@@ -1,2 +1,3 @@
-action.editSelection=Editar Colección
-action.saveSelection=Guardar Colección
+action.editSelection=Renombrar Colección
+action.saveSelection=Crear Nueva Colección
+

--- a/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/search/SaveSelectionSearchResultActionDefault_es.properties
@@ -1,3 +1,2 @@
 action.editSelection=Renombrar Colección
-action.saveSelection=Crear Nueva Colección
-
+action.saveSelection=Nueva Colección


### PR DESCRIPTION
Also updates SaveSelectionSearchResultAction label to be more specific to its usage (renaming/creating).