### PR TITLE
BSP-2917 Fixes documentation build issues in Permissions/Roles section

### DIFF
--- a/docs/editorial-guide/index.rst
+++ b/docs/editorial-guide/index.rst
@@ -29,3 +29,4 @@
     looking-glass/all
     releases/index
     license/index
+

--- a/docs/editorial-guide/roles-and-permissions/all.rst
+++ b/docs/editorial-guide/roles-and-permissions/all.rst
@@ -1,7 +1,3 @@
-.. |emDash| raw:: html
-
-   &#8212;
-
 Roles, Users, and Permissions
 =============================
 

--- a/docs/editorial-guide/roles-and-permissions/roles.rst
+++ b/docs/editorial-guide/roles-and-permissions/roles.rst
@@ -1,7 +1,9 @@
+.. _creating_new_roles:
+
 Creating New Roles
 ------------------
 
-Each role has an associated list of permissions to access certain features within Brightspot. For example, administrators typically have access to all sites, tabs, areas, and widgets. Contributors and editors typically have access only to those sites, areas, and controls associated with the content they provide. (For more information about permissions, see `Understanding Permissions and Controls`_.)
+Each role has an associated list of permissions to access certain features within Brightspot. For example, administrators typically have access to all sites, tabs, areas, and widgets. Contributors and editors typically have access only to those sites, areas, and controls associated with the content they provide. (For more information about permissions, see :ref:`understanding_permissions_and_controls`.)
 
 **To create a role:**
 
@@ -31,7 +33,7 @@ Users and Roles Widgets
 +----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |Name                              |Name of role.                                                                                                                                                                                             |
 +----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|Permissions                       |Role's permissions associated with a variety of controls. Select all, none, or some for each feature. For an explanation of these controls, see `Understanding Permissions and Controls`_.                |
+|Permissions                       |Role's permissions associated with a variety of controls. Select all, none, or some for each feature. For an explanation of these controls, see :ref:`understanding_permissions_and_controls`.            |
 +----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |**Dashboard tab**                                                                                                                                                                                                                            |
 +----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/editorial-guide/roles-and-permissions/roles.rst
+++ b/docs/editorial-guide/roles-and-permissions/roles.rst
@@ -1,5 +1,3 @@
-.. include:: ../substitutions.rst
-
 Creating New Roles
 ------------------
 

--- a/docs/editorial-guide/roles-and-permissions/roles.rst
+++ b/docs/editorial-guide/roles-and-permissions/roles.rst
@@ -1,3 +1,5 @@
+.. include:: ../substitutions.rst
+
 Creating New Roles
 ------------------
 

--- a/docs/editorial-guide/roles-and-permissions/understanding_permissions.rst
+++ b/docs/editorial-guide/roles-and-permissions/understanding_permissions.rst
@@ -1,5 +1,3 @@
-.. include:: ../substitutions.rst
-
 Understanding Permissions and Controls
 --------------------------------------
 

--- a/docs/editorial-guide/roles-and-permissions/understanding_permissions.rst
+++ b/docs/editorial-guide/roles-and-permissions/understanding_permissions.rst
@@ -1,3 +1,5 @@
+.. _understanding_permissions_and_controls:
+
 Understanding Permissions and Controls
 --------------------------------------
 

--- a/docs/editorial-guide/roles-and-permissions/understanding_permissions.rst
+++ b/docs/editorial-guide/roles-and-permissions/understanding_permissions.rst
@@ -1,3 +1,5 @@
+.. include:: ../substitutions.rst
+
 Understanding Permissions and Controls
 --------------------------------------
 

--- a/docs/editorial-guide/roles-and-permissions/users.rst
+++ b/docs/editorial-guide/roles-and-permissions/users.rst
@@ -1,3 +1,5 @@
+.. include:: ../substitutions.rst
+
 Creating New Users
 ------------------
 

--- a/docs/editorial-guide/roles-and-permissions/users.rst
+++ b/docs/editorial-guide/roles-and-permissions/users.rst
@@ -1,5 +1,3 @@
-.. include:: ../substitutions.rst
-
 Creating New Users
 ------------------
 

--- a/docs/editorial-guide/roles-and-permissions/users.rst
+++ b/docs/editorial-guide/roles-and-permissions/users.rst
@@ -3,7 +3,7 @@ Creating New Users
 
 **To create a user:**
 
-#. From the system menu, select **Admin > Users & Roles**. The Users and Roles widgets appear on the left side of the page (`example <users_roles_widgets_>`_).
+#. From the system menu, select **Admin > Users & Roles**. The Users and Roles widgets appear on the left side of the page (:ref:`example <users_roles_widgets>`).
 
 #. In the Users widget, click **New Tool User**. The New Tool User widget appears.
 
@@ -22,7 +22,7 @@ Creating New Users
 +====================================+================================================================================================================================================================================================================================================+
 |**Main tab**                                                                                                                                                                                                                                                                         |
 +------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|Role                                |User's role. If blank, user has access to all features. For an explanation of roles, see `Creating New Roles`_.                                                                                                                                 |
+|Role                                |User's role. If blank, user has access to all features. For an explanation of roles, see :ref:`creating_new_roles`.                                                                                                                             |
 +------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |Name                                |Name that appears on content created or edited by the user.                                                                                                                                                                                     |
 +------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -110,7 +110,7 @@ Editing Users
 
 **To edit a user:**
 
-#. From the system menu, select **Admin > Users & Roles**. The Users and Roles widgets appear on the left side of the page (`example <users_roles_widgets_>`_).
+#. From the system menu, select **Admin > Users & Roles**. The Users and Roles widgets appear on the left side of the page (:ref:`example <users_roles_widgets>`).
 
 #. In the Users widget, click in the **Search** field, and start typing the user's name. Brightspot lists matching users.
 

--- a/docs/editorial-guide/substitutions.rst
+++ b/docs/editorial-guide/substitutions.rst
@@ -1,2 +1,0 @@
-.. |emdash|   unicode:: U+2014 .. EM DASH
-

--- a/docs/editorial-guide/substitutions.rst
+++ b/docs/editorial-guide/substitutions.rst
@@ -1,0 +1,2 @@
+.. |emdash|   unicode:: U+2014 .. EM DASH
+


### PR DESCRIPTION
Removed substitution directive from all.rst, placing it into top-level /substitutions.trs file. (This pull request is a merge that skips an intermediate pull request that I inadvertently closed.)