### PR TITLE
BSP-1289 Updates .objectId-edit to reflect if content is editable

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -2426,6 +2426,15 @@ public class ToolPageContext extends WebPageContext {
                 typeIds.setLength(typeIds.length() - 1);
             }
 
+            boolean canEdit = true;
+
+            if (value != null) {
+                ObjectType type = state.getType();
+                canEdit = hasPermission("type/" + type.getId() + "/write")
+                    && !type.as(ToolUi.class).isReadOnly()
+                    && ContentEditable.shouldContentBeEditable(state);
+            }
+
             writeElement("input",
                     "type", "text",
                     "class", "objectId",
@@ -2441,6 +2450,7 @@ public class ToolPageContext extends WebPageContext {
                     "data-suggestions", ui.isEffectivelySuggestions(),
                     "data-typeIds", typeIds,
                     "data-visibility", value != null ? state.getVisibilityLabel() : null,
+                    "data-read-only", !canEdit,
                     "value", value != null ? state.getId() : null,
                     "placeholder", placeholder,
                     attributes);

--- a/tool-ui/src/main/webapp/script/v3/input/object.js
+++ b/tool-ui/src/main/webapp/script/v3/input/object.js
@@ -20,6 +20,7 @@ function($) {
           labelHtml,
           dynamicPlaceholderText,
           dynamicFieldName,
+          isReadOnly,
           placeholder,
           value,
           selectHref,
@@ -175,10 +176,13 @@ function($) {
             '&sg=' + encodeURIComponent($input.attr('data-suggestions') || '')
       });
 
+      var isReadOnly = $input.data('read-only');
+
       $edit = $('<a/>', {
         'class': 'objectId-edit',
+        'data-read-only': isReadOnly,
         'target': target + '-edit',
-        'text': 'Edit'
+        'text': !isReadOnly ? 'Edit' : 'View'
       });
 
       $clear = $('<a/>', {

--- a/tool-ui/src/main/webapp/style/v3/object-id.less
+++ b/tool-ui/src/main/webapp/style/v3/object-id.less
@@ -33,6 +33,10 @@
     text-decoration: line-through;
   }
 
+  &[data-read-only='true'] {
+    .icon-eye-open;
+  }
+
   @media @media-tablet {
     .icon-only;
   }


### PR DESCRIPTION
In the following three scenarios, the `.objectId-edit` link will now display as "View" instead of "Edit":

* ToolUser does not have permission to edit content
* Type is readonly
* Object instance is not editable via `ContentEditable#shouldContentBeEditable`

Edit Link (Not changed):

![image](https://cloud.githubusercontent.com/assets/1299507/21937885/f851149a-d986-11e6-8bca-ff3d08af2425.png)


View Link (New):

![image](https://cloud.githubusercontent.com/assets/1299507/21937940/23adb666-d987-11e6-92bd-6bb0b52bfc59.png)




