### PR TITLE
BSP-2936 Fixes various publishing issues from content edit popup

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -151,6 +151,16 @@ public class ToolPageContext extends WebPageContext {
     public static final String VARIATION_ID_PARAMETER = "variationId";
     public static final String RETURN_URL_PARAMETER = "returnUrl";
 
+    private static final String WORKFLOW_ACTION_PARAMETER = "action-workflow";
+    private static final String NEW_DRAFT_ACTION_PARAMETER = "action-newDraft";
+    private static final String DRAFT_ACTION_PARAMETER = "action-draft";
+    private static final String MERGE_ACTION_PARAMETER = "action-merge";
+    private static final String PUBLISH_ACTION_PARAMETER = "action-publish";
+    private static final String DELETE_ACTION_PARAMETER = "action-delete";
+    private static final String RESTORE_ACTION_PARAMETER = "action-restore";
+    private static final String SAVE_ACTION_PARAMETER = "action-save";
+    private static final String UNSCHEDULE_ACTION_PARAMETER = "action-unschedule";
+
     private static final String ATTRIBUTE_PREFIX = ToolPageContext.class.getName() + ".";
     private static final String ERRORS_ATTRIBUTE = ATTRIBUTE_PREFIX + "errors";
     private static final String FORM_FIELDS_DISABLED_ATTRIBUTE = ATTRIBUTE_PREFIX + "formFieldsDisabled";
@@ -3349,7 +3359,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean tryDelete(Object object) {
         if (!isFormPost()
-                || param(String.class, "action-delete") == null) {
+                || param(String.class, DELETE_ACTION_PARAMETER) == null) {
             return false;
         }
 
@@ -3413,7 +3423,7 @@ public class ToolPageContext extends WebPageContext {
 
     public boolean tryUnschedule(Object object) {
         if (!isFormPost()
-                || param(String.class, "action-unschedule") == null) {
+                || param(String.class, UNSCHEDULE_ACTION_PARAMETER) == null) {
             return false;
         }
 
@@ -3526,7 +3536,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean tryDraft(Object object) {
         if (!isFormPost()
-                || (param(String.class, "action-draft") == null
+                || (param(String.class, DRAFT_ACTION_PARAMETER) == null
                 && param(String.class, "action-draftAndReturn") == null)) {
             return false;
         }
@@ -3616,7 +3626,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean tryNewDraft(Object object) {
         if (!isFormPost()
-                || (param(String.class, "action-newDraft") == null
+                || (param(String.class, NEW_DRAFT_ACTION_PARAMETER) == null
                 && param(String.class, "action-newDraftAndReturn") == null)) {
             return false;
         }
@@ -3686,7 +3696,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean tryPublish(Object object) {
         if (!isFormPost()
-                || param(String.class, "action-publish") == null) {
+                || param(String.class, PUBLISH_ACTION_PARAMETER) == null) {
             return false;
         }
 
@@ -3919,7 +3929,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean tryRestore(Object object) {
         if (!isFormPost()
-                || param(String.class, "action-restore") == null) {
+                || param(String.class, RESTORE_ACTION_PARAMETER) == null) {
             return false;
         }
 
@@ -3955,7 +3965,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean trySave(Object object) {
         if (!isFormPost()
-                || param(String.class, "action-save") == null) {
+                || param(String.class, SAVE_ACTION_PARAMETER) == null) {
             return false;
         }
 
@@ -4037,7 +4047,7 @@ public class ToolPageContext extends WebPageContext {
             return false;
         }
 
-        String action = param(String.class, "action-merge");
+        String action = param(String.class, MERGE_ACTION_PARAMETER);
 
         if (ObjectUtils.isBlank(action)) {
             return false;
@@ -4096,7 +4106,7 @@ public class ToolPageContext extends WebPageContext {
             return false;
         }
 
-        String action = param(String.class, "action-workflow");
+        String action = param(String.class, WORKFLOW_ACTION_PARAMETER);
 
         if (ObjectUtils.isBlank(action)) {
             return false;

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -151,15 +151,15 @@ public class ToolPageContext extends WebPageContext {
     public static final String VARIATION_ID_PARAMETER = "variationId";
     public static final String RETURN_URL_PARAMETER = "returnUrl";
 
-    private static final String WORKFLOW_ACTION_PARAMETER = "action-workflow";
-    private static final String NEW_DRAFT_ACTION_PARAMETER = "action-newDraft";
-    private static final String DRAFT_ACTION_PARAMETER = "action-draft";
-    private static final String MERGE_ACTION_PARAMETER = "action-merge";
-    private static final String PUBLISH_ACTION_PARAMETER = "action-publish";
-    private static final String DELETE_ACTION_PARAMETER = "action-delete";
-    private static final String RESTORE_ACTION_PARAMETER = "action-restore";
-    private static final String SAVE_ACTION_PARAMETER = "action-save";
-    private static final String UNSCHEDULE_ACTION_PARAMETER = "action-unschedule";
+    public static final String WORKFLOW_ACTION_PARAMETER = "action-workflow";
+    public static final String NEW_DRAFT_ACTION_PARAMETER = "action-newDraft";
+    public static final String DRAFT_ACTION_PARAMETER = "action-draft";
+    public static final String MERGE_ACTION_PARAMETER = "action-merge";
+    public static final String PUBLISH_ACTION_PARAMETER = "action-publish";
+    public static final String DELETE_ACTION_PARAMETER = "action-delete";
+    public static final String RESTORE_ACTION_PARAMETER = "action-restore";
+    public static final String SAVE_ACTION_PARAMETER = "action-save";
+    public static final String UNSCHEDULE_ACTION_PARAMETER = "action-unschedule";
 
     private static final String ATTRIBUTE_PREFIX = ToolPageContext.class.getName() + ".";
     private static final String ERRORS_ATTRIBUTE = ATTRIBUTE_PREFIX + "errors";

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -157,6 +157,7 @@ public class ToolPageContext extends WebPageContext {
     public static final String MERGE_ACTION_PARAMETER = "action-merge";
     public static final String PUBLISH_ACTION_PARAMETER = "action-publish";
     public static final String DELETE_ACTION_PARAMETER = "action-delete";
+    public static final String TRASH_ACTION_PARAMETER = "action-trash";
     public static final String RESTORE_ACTION_PARAMETER = "action-restore";
     public static final String SAVE_ACTION_PARAMETER = "action-save";
     public static final String UNSCHEDULE_ACTION_PARAMETER = "action-unschedule";
@@ -4017,7 +4018,7 @@ public class ToolPageContext extends WebPageContext {
      */
     public boolean tryTrash(Object object) {
         if (!isFormPost()
-                || param(String.class, "action-trash") == null) {
+                || param(String.class, TRASH_ACTION_PARAMETER) == null) {
             return false;
         }
 

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -395,6 +395,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                     <a class="icon icon-action-edit widgetControlsEditInFull" target="_blank" href="<%= wp.url("",
                                                                                                         ToolPageContext.DELETE_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.DRAFT_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.NEW_DRAFT_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.PUBLISH_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.RESTORE_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.SAVE_ACTION_PARAMETER, null,

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -302,6 +302,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
             enctype="multipart/form-data"
             action="<%= wp.objectUrl("", selected,
                     ToolPageContext.DELETE_ACTION_PARAMETER, null,
+                    ToolPageContext.TRASH_ACTION_PARAMETER, null,
                     ToolPageContext.DRAFT_ACTION_PARAMETER, null,
                     ToolPageContext.NEW_DRAFT_ACTION_PARAMETER, null,
                     ToolPageContext.PUBLISH_ACTION_PARAMETER, null,
@@ -394,6 +395,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                 <div class="widgetControls">
                     <a class="icon icon-action-edit widgetControlsEditInFull" target="_blank" href="<%= wp.url("",
                                                                                                         ToolPageContext.DELETE_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.TRASH_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.DRAFT_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.NEW_DRAFT_ACTION_PARAMETER, null,
                                                                                                         ToolPageContext.PUBLISH_ACTION_PARAMETER, null,

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -301,12 +301,16 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
             method="post"
             enctype="multipart/form-data"
             action="<%= wp.objectUrl("", selected,
-                    "action-delete", null,
-                    "action-draft", null,
-                    "action-publish", null,
-                    "action-restore", null,
-                    "action-save", null,
-                    "action-trash", null,
+                    ToolPageContext.DELETE_ACTION_PARAMETER, null,
+                    ToolPageContext.DRAFT_ACTION_PARAMETER, null,
+                    ToolPageContext.PUBLISH_ACTION_PARAMETER, null,
+                    ToolPageContext.RESTORE_ACTION_PARAMETER, null,
+                    ToolPageContext.SAVE_ACTION_PARAMETER, null,
+                    ToolPageContext.DRAFT_ACTION_PARAMETER, null,
+                    ToolPageContext.MERGE_ACTION_PARAMETER, null,
+                    ToolPageContext.RESTORE_ACTION_PARAMETER, null,
+                    ToolPageContext.WORKFLOW_ACTION_PARAMETER, null,
+                    ToolPageContext.UNSCHEDULE_ACTION_PARAMETER, null,
                     "published", null) %>"
             autocomplete="off"
             <% if (!wp.getCmsTool().isDisableFieldLocking()) { %>

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -391,7 +391,17 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
                 %></h1>
 
                 <div class="widgetControls">
-                    <a class="icon icon-action-edit widgetControlsEditInFull" target="_blank" href="<%= wp.url("") %>">
+                    <a class="icon icon-action-edit widgetControlsEditInFull" target="_blank" href="<%= wp.url("",
+                                                                                                        ToolPageContext.DELETE_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.DRAFT_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.PUBLISH_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.RESTORE_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.SAVE_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.DRAFT_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.MERGE_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.RESTORE_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.WORKFLOW_ACTION_PARAMETER, null,
+                                                                                                        ToolPageContext.UNSCHEDULE_ACTION_PARAMETER, null) %>">
                         <%= wp.h(wp.localize("com.psddev.cms.tool.page.content.Edit", "action.editFull"))%>
                     </a>
                     <% if (wp.getCmsTool().isEnableAbTesting()) { %>

--- a/tool-ui/src/main/webapp/content/edit.jsp
+++ b/tool-ui/src/main/webapp/content/edit.jsp
@@ -303,6 +303,7 @@ wp.writeHeader(editingState.getType() != null ? editingState.getType().getLabel(
             action="<%= wp.objectUrl("", selected,
                     ToolPageContext.DELETE_ACTION_PARAMETER, null,
                     ToolPageContext.DRAFT_ACTION_PARAMETER, null,
+                    ToolPageContext.NEW_DRAFT_ACTION_PARAMETER, null,
                     ToolPageContext.PUBLISH_ACTION_PARAMETER, null,
                     ToolPageContext.RESTORE_ACTION_PARAMETER, null,
                     ToolPageContext.SAVE_ACTION_PARAMETER, null,


### PR DESCRIPTION
Most of the issues stem from action-* parameters persisting to the form action between form posts. This ensures that the parameters are stripped, and a clean /content/edit url is created for the form action.

This also performs the same "cleaning" of urls for the "Edit in Full" link in the popup.