### PR TITLE
BSP-2916 pasting URL in RTE should make it a link and open the link dialog

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -89,13 +89,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 elementAttr: {
                     'class': 'rte rte-comment'
                 },
-                
+
                 // Hide this style when viewing in "show final" mode
                 showFinal:false,
-                
+
                 // Don't let this style be removed by the "Clear" toolbar button
                 internal: true,
-                
+
                 // Don't allow tracked changes within this style
                 trackChanges: false,
 
@@ -121,9 +121,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     var label;
 
                     label = '';
-                    
+
                     if (mark.attributes) {
-                        
+
                         user = mark.attributes['data-user-label'];
                         time = mark.attributes['data-time'];
 
@@ -139,7 +139,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                             }
                         }
                     }
-                    
+
                     return label;
                 }
             },
@@ -148,13 +148,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 element: 'a',
                 keymap: ['Ctrl-K', 'Cmd-K'],
                 elementAttrAny: true, // Allow any attributes for this element
-                
+
                 // Do not allow links to span multiple lines
                 singleLine: true,
 
                 // Label to use for the dropdown
                 enhancementName: 'Link',
-                
+
                 onClick: function(event, mark) {
 
                     var self;
@@ -174,7 +174,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     // Using a timeout here because we need to let the click event complete,
                     // otherwise the click outside the popup will close the popup!
                     setTimeout(function() {
-                        
+
                         self.linkEdit(mark.attributes, mark).done(function(attributes){
 
                             if (attributes.remove || attributes.href === '' || attributes.href === 'http://') {
@@ -196,9 +196,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                         }).always(function(){
                             // After editing the link, put the cursor at the end of the link text
                             // and make sure typing doesn't expand the link.
-                            self.linkAfterEdit();                            
+                            self.linkAfterEdit();
                         })
-                        
+
                     }, 100);
 
                 }
@@ -216,7 +216,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 element: 'li',
                 elementContainer: 'ul',
                 clear: ['ol', 'alignLeft', 'alignCenter', 'alignRight']
-            },            
+            },
             alignLeft: {
                 className: 'rte2-style-align-left',
                 line: true,
@@ -273,16 +273,16 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          *    }
          */
         clipboardSanitizeTypes: {
-            
+
             'googledocs': {
                 isType: function(content) {
                     return Boolean($(content).find('[id^=docs-internal-guid]').length);
                 },
                 rules: {
-            
+
                     // Note: Google docs encloses the entire document in a 'b' element so we must exclude that one
                     'b[id^=docs-internal-guid]': '',
-            
+
                     // Google docs styles
                     'span[style*="font-style:italic"]': 'italic',
                     'span[style*="font-weight:700"]': 'bold',
@@ -316,7 +316,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     'td[style*="text-decoration:line-through"]': 'strikethrough',
                 }
             },
-            
+
             'msword': {
                 isType: function(content) {
                     return Boolean($(content).find('[class^=Mso]').length);
@@ -326,10 +326,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     // Since we need to modify the 'p' element,
                     // we'll have to repeat some of the 'p' element
                     // rules here to ensure proper ordering of the rules
-                    
+
                     'p[style*="text-align: right"]': 'alignRight',
                     'p[style*="text-align: center"]': 'alignCenter',
-            
+
                     'p[style*="text-align:right"]': 'alignRight',
                     'p[style*="text-align:center"]': 'alignCenter',
 
@@ -354,14 +354,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                 }
             },
-            
+
             'adobeReader': {
                 // Adobe Reader pastes html that is mostly junk: each word is surrounded by a P element.
                 // The best we can do is put a space between each word and output all words without line breaks.
                 isType: function(content, html) {
                     return Boolean(html && html.indexOf('Cocoa HTML Writer') !== -1);
                 },
-                
+
                 rules: {
                     'p': function($el) {
                         var $replacement;
@@ -389,7 +389,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * {Function} to modify the matching element using a custom function
          */
         clipboardSanitizeRules: {
-            
+
             // Any <b> or '<strong>' element should be treated as bold even if it has extra attributes
             // Example MSWord:  <b style="mso-bidi-font-weight:normal">
             'b': 'bold',
@@ -405,7 +405,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             'p[style*="text-align: right"]': 'alignRight',
             'p[style*="text-align: center"]': 'alignCenter',
-            
+
             'p[style*="text-align:right"]': 'alignRight',
             'p[style*="text-align:center"]': 'alignCenter',
 
@@ -420,7 +420,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             'p': 'linebreak'
         },
 
-        
+
         /**
          * Which buttons are in the toolbar?
          * This is an array of toolbar config objects with the following properties:
@@ -601,7 +601,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          */
         contextRoot: null,
 
-        
+
         /**
          * Initialize the rich text editor.
          *
@@ -655,7 +655,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.trackChangesInit();
             self.placeholderInit();
             self.modeInit();
-            
+
             // Refresh the editor after all the initialization is done.
             // We put it in a timeout to ensure the editor has displayed before doing the refresh.
             setTimeout(function(){
@@ -682,7 +682,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                 // Save the style key as part of the object so we can use it later
                 styleObj.styleKey = styleKey;
-                
+
                 // Modify the onClick function so it is called in the context of our object,
                 // to allow the onclick function access to other RTE functions
                 if (styleObj.onClick) {
@@ -825,7 +825,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Move textarea after the editor
             self.$el.appendTo(self.$container);
-            
+
             // Since the rte will trigger special events on the container,
             // we should catch them and pass them to the textarea
             self.$editor.on('rteFocus', function(){
@@ -833,14 +833,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 return false;
             });
             self.$editor.on('rteBlur', function(){
-                
+
                 // Set a timeout before performing the blur event.
                 // This is to let other code cancel the blur before it occurs
                 // (such as clicking a toolbar button)
                 self.rteBlurTimeout = setTimeout(function(){
                     self.$el.trigger('rteBlur', [self]);
                 }, 200);
-                
+
                 return false;
             });
             self.$editor.on('rteChange', function(){
@@ -849,11 +849,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 if (self.placeholderIsShowing()) {
                     return false;
                 }
-                
+
                 self.$el.trigger('rteChange', [self]);
                 return false;
             });
-            
+
             // Hide the textarea
             self.$el.hide();
 
@@ -873,7 +873,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Set to read only mode if necessary
             self.rte.readOnlySet( self.$el.closest('.inputContainer-readOnly, .objectInputs-readOnly').length );
-            
+
             // Override the rich text editor to tell it how enhancements should be imported from HTML
             self.rte.enhancementFromHTML = function($content, line) {
 
@@ -961,7 +961,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.rte.refresh();
         },
 
-        
+
         /**
          * @returns {Boolean}
          */
@@ -969,14 +969,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             return $('body').hasClass('rte-fullscreen');
         },
 
-        
+
         /*==================================================
          * Mode plain or rich
          *==================================================*/
-        
+
         modeInit: function() {
             var self = this;
-            
+
             self.$container.on('rteModeChange', function(event, mode) {
                 if (mode === 'plain') {
                     self.modeSetPlain();
@@ -986,30 +986,30 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             });
         },
 
-        
+
         modeSetPlain: function() {
             var self = this;
 
             // Mark this as a change
             self.rte.triggerChange();
-            
+
             self.$el.val(self.rte.toHTML());
-            
+
             self.$el.show();
-            
+
             // Trigger a resize event on the window so the textarea will get resized
             $(window).resize();
         },
 
-        
+
         modeSetRich: function() {
             var self = this;
             var rte = self.rte;
             var trackIsOn = rte.trackIsOn();
-            
+
             // Mark this as a change
             self.rte.triggerChange();
-            
+
             self.$el.hide();
 
             // Turn off track changes when converting from plain to rich text
@@ -1017,14 +1017,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             rte.trackSet(false);
 
             rte.fromHTML(self.$el.val());
-            
+
             rte.historyClear();
-            
+
             // Turn track changes back on (if it was on)
             rte.trackSet(trackIsOn);
         },
 
-        
+
         /*==================================================
          * Track Changes
          * Code to save and restor the state of "track changes" for an individual rich text editor.
@@ -1041,13 +1041,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.trackChangesRestore();
         },
 
-        
+
         /**
          * Save the current track changes status.
          * This will normally be saved only when the user submits the form.
          */
         trackChangesSave: function() {
-            
+
             var name;
             var self;
             var state;
@@ -1068,12 +1068,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
-        
+
         /**
          *  Restore the track changes status.
          */
         trackChangesRestore: function() {
-            
+
             var name;
             var self;
 
@@ -1087,28 +1087,28 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
-        
+
         /**
          * Return the sessions storage name that can be used
          * to save the state for this particular input.
          */
         trackChangesGetName: function() {
-            
+
             var name;
             var self;
-            
+
             self = this;
-            
+
             name = self.$el.closest('.inputContainer').attr('data-name') || '';
-            
+
             if (name) {
                 name = 'bsp.rte2.changesTracking.' + name;
             }
-            
+
             return name;
         },
 
-        
+
         /*==================================================
          * TOOLBAR
          *==================================================*/
@@ -1137,7 +1137,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Recursive function for setting up toolbar menu and submenus
             function toolbarProcess(config, $toolbar) {
-                
+
                 var $submenu;
 
                 // Loop through the toolbar config to set up buttons
@@ -1157,7 +1157,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                         // This is a submenu
                         // {submenu:true, text:'', style:'', className:'', submenuItems:[]}
                         $submenu = self.toolbarAddSubmenu(item, $toolbar);
-                        
+
                         toolbarProcess(item.submenu, $submenu);
 
                     } else if (item.custom) {
@@ -1269,7 +1269,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The main toolbar for the RTE.
          */
         toolbarInitRichTextElements: function ($toolbar) {
-            
+
             if (!window.RICH_TEXT_ELEMENTS || RICH_TEXT_ELEMENTS.length === 0) {
                 return;
             }
@@ -1286,7 +1286,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 // For this instance of the RTE, was there a custom list
                 // of elements that should be displayed in the toolbar?
                 if (tags && tags.indexOf(rtElement.tag) < 0) {
-                    
+
                     // Skip this element if it is not listed in the allowed elements
                     return;
                 }
@@ -1297,7 +1297,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 if (rtElement.tag === 'tr' || rtElement.tag === 'td') {
                     return;
                 }
-                
+
                 var styleName = rtElement.styleName;
                 var submenuName = rtElement.submenu;
                 var $submenu;
@@ -1320,11 +1320,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 // Multiple styles can be grouped using this submenu name, so we need to ensure
                 // that we only create the submenu once, then use it for any subsequent styles.
                 if (submenuName) {
-                    
+
                     // Check to see if the submenu has already been created
                     $submenu = submenus[submenuName];
                     if (!$submenu) {
-                        
+
                         // The submenu does not exist so create it now and save the value
                         $submenu = submenus[submenuName] = self.toolbarAddSubmenu({
                             text: submenuName,
@@ -1471,7 +1471,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if ($button.hasClass('outOfContext')) {
                 return;
             }
-            
+
             rte = self.rte;
 
             styleObj = self.rte.styles[item.style] || {};
@@ -1483,7 +1483,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 case 'caseToggleSmart':
                     rte.caseToggleSmart();
                     break;
-                    
+
                 case 'caseToLower':
                     rte.caseToLower();
                     break;
@@ -1516,18 +1516,18 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                     // Before creating a new enhancement via the toolbar, move the cursor to the start of a non-blank line
                     rte.moveToNonBlank();
-                    
+
                     self.enhancementCreate();
                     break;
 
                 case 'table':
                     self.tableCreate();
                     break;
-                    
+
                 case 'fullscreen':
                     self.fullscreenToggle();
                     break;
-                    
+
                 case 'insert':
                     if (item.value) {
                         // Write value to the DOM and read it back again,
@@ -1536,7 +1536,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                         rte.insert(value);
                     }
                     break;
-                    
+
                 case 'marker':
 
                     // Stop the event from propagating, otherwise it will close the enhancement popup
@@ -1706,7 +1706,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // Show them all if 'rich' mode, otherwise hide them.
             // Later we will show certain actions for 'plain' mode.
             self.$toolbar.children('li').toggle(mode === 'rich');
-            
+
             // First make all the buttons inactive,
             // Then we'll decide which need to be active
             $links = self.$toolbar.find('a');
@@ -1737,7 +1737,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 if (!config) {
                     return;
                 }
-                
+
                 // For toolbar actions we need special logic to determine if the button should be "active"
                 // One exception is for inline enhancements, which are treated as a normal style
                 if (config.action && config.action !== 'enhancementInline' && config.action !== 'table') {
@@ -1760,21 +1760,21 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                         break;
 
                     case 'fullscreen':
-                        
+
                         // Make the button active if in fullscreen  mode
                         $link.toggleClass('active', self.fullscreenIsActive());
-                        
+
                         // Always show this button when in rich or plain mode
                         $link.parent().show();
                         break;
-                        
+
                     case 'modeToggle':
                         // Make the button active if in 'plain' mode
                         // And always show the button
                         $link.toggleClass('active', mode === 'plain');
                         $link.parent().show();
                         break;
-                        
+
                     } // switch
 
                 } else {
@@ -1808,7 +1808,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                     // Special case if the toolbar style should only be displayed in certain contexts
                     styleKey = config.style;
-                    
+
                     // Special case for the "Table" button, we will look for a style
                     // definition for the "table" element, to see if it has any
                     // context specified
@@ -1818,7 +1818,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                     // $link.removeClass('outOfContext');
                     inContext = self.rte.checkContext(styleKey, currentRange, context);
-                    
+
                     // Set a class on the toolbar button to indicate we are out of context.
                     // That class will be used to style the button, but also
                     // to prevent clicking on the button.
@@ -2024,18 +2024,18 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * Code to run after the edit popup was completed or canceled.
          */
         linkAfterEdit: function(){
-            
+
             var range;
             var self;
             self = this;
-            
+
             self.rte.focus();
-            
+
             // After editing the mark, the range of text will be selected.
             // Instead we want to put the cursor at the end of the range.
             range = self.rte.getRange();
             if (range.from.ch !== range.to.ch) {
-                
+
                 range.from = range.to;
                 self.rte.setSelection(range);
 
@@ -2043,7 +2043,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 // However, if user moves the cursor then returns to the end of the link, then characters typed
                 // will be added to the link.
                 self.rte.removeStyles();
-                
+
                 // Make sure the toolbar updates so the link button is not highlighted, so user knows typing
                 // will not expand the link.
                 self.toolbarUpdate();
@@ -2073,7 +2073,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             target = $linkDialog.find('.rte2-dialogLinkTarget').val() || '';
             rel = $linkDialog.find('.rte2-dialogLinkRel').val() || '';
             cmsId = $linkDialog.find('.rte2-dialogLinkId').val() || '';
-            
+
             attributes = {};
             attributes.href = href;
 
@@ -2213,7 +2213,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                 // Close the popup - this will also trigger the enhancement display to be updated (see 'close' event below)
                 $target.popup('close');
-                
+
                 // Put focus back on the editor
                 self.focus();
 
@@ -2250,7 +2250,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 // Update the enhancement to show a preview of the content.
                 // This will also remove the enhancement if it is empty.
                 self.enhancementUpdate($enhancement);
-                
+
             });
         },
 
@@ -2303,7 +2303,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 self.enhancementSetCursor(this);
                 self.focus();
             });
-            
+
             // Add the label (preview image and label text)
             $('<div/>', {'class': 'rte2-enhancement-label' }).appendTo($enhancement);
 
@@ -2367,9 +2367,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 self.enhancementRemoveCompletely($enhancement);
                 return;
             }
-            
+
             $content.empty();
-            
+
             if (reference.preview) {
 
                 $('<figure/>', {
@@ -2394,7 +2394,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Modify the Select and Edit buttons in the toolbar
             if (reference.record && reference.record._ref) {
-                
+
                 $select = $enhancement.find('.rte2-enhancement-toolbar-change');
                 $select.text('Change');
 
@@ -2523,7 +2523,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             formAction = self.$el.closest('form').attr('action') || '';
             formId = (/id=([^&]+)/.exec(formAction) || [ ])[1] || '';
             formTypeId = (/typeId=([^&]+)/.exec(formAction) || [ ])[1] || '';
-            
+
             self.enhancementToolbarAddButton({
                 text: 'Select',
                 tooltip: '',
@@ -2708,7 +2708,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self = this;
             $el = self.enhancementGetWrapper(el);
             $el.addClass('toBeRemoved');
-            
+
             // Trigger change event so preview is updated
             self.rte.triggerChange();
         },
@@ -2722,7 +2722,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if (mark) {
                 self.rte.enhancementRemove(mark);
             }
-            
+
             // Trigger change event so preview is updated
             self.rte.triggerChange();
         },
@@ -2734,7 +2734,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self = this;
             $el = self.enhancementGetWrapper(el);
             $el.removeClass('toBeRemoved');
-            
+
             // Trigger change event so preview is updated
             self.rte.triggerChange();
         },
@@ -2770,9 +2770,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if (direction === 1 || direction === -1) {
 
                 $el = self.enhancementGetWrapper(el);
-                
+
                 topOriginal = $el.offset().top;
-                    
+
                 mark = self.rte.enhancementMove(mark, direction);
 
                 topNew = $el.offset().top;
@@ -2791,7 +2791,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
-        
+
         /**
          * Set the editor cursor to the same line that contains the enhancement.
          */
@@ -2801,18 +2801,18 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var self;
 
             self = this;
-            
+
             mark = self.enhancementGetMark(el);
             if (!mark) {
                 return;
             }
 
             line = self.rte.enhancementGetLineNumber(mark);
-            
+
             self.rte.setCursor(line, 0);
         },
 
-        
+
         /**
          * Sets the position for an enhancement.
          *
@@ -3081,7 +3081,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 }
 
                 $sizeLabel.text(sizeDisplayName);
-                
+
             } else {
 
                 // No size is selected so remove label if it exists
@@ -3101,7 +3101,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * jQuery element for the popup.
          */
         enhancementPopupSizesCreate: function(el) {
-            
+
             var $el;
             var $popup;
             var self;
@@ -3109,12 +3109,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             self = this;
             $el = $(el);
-            
+
             sizes = self.enhancementGetSizes();
 
             $popup = $el.data('enhancementSizesPopup');
             if (!$popup) {
-                
+
                 $popup = $('<ul/>', {
                     'class': 'rte2-enhancement-sizes-popup'
                 }).hover(function(event){
@@ -3122,7 +3122,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 }, function(event) {
                     self.enhancementPopupSizesHideDelayed($el);
                 }).css('position', 'absolute').hide().appendTo(document.body);
-                
+
                 $(el).data('enhancementSizesPopup', $popup);
 
                 self.enhancementToolbarAddButton({
@@ -3148,34 +3148,34 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 });
 
             }
-            
+
             return $popup;
         },
 
-        
+
         /**
          * Show the enhancement sizes popup after a short delay.
          * @param {Element} el
          * The image sizes button inside the enhancement element.
          */
         enhancementPopupSizesShowDelayed: function(el) {
-            
+
             var timeout;
             var self;
 
             self = this;
-            
+
             // Cancel any previous attempt to show the popup
             clearTimeout( $(el).data('enhancementPopupSizesHideDelayed') );
-            
+
             timeout = setTimeout(function(){
                 self.enhancementPopupSizesShow(el);
             }, 100);
-            
+
             $(el).data('enhancementPopupSizesShowDelayed', timeout);
         },
 
-        
+
         /**
          * Show the enhancement sizes popup.
          * @param {Element} el
@@ -3199,29 +3199,29 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             $(el).addClass('hovered');
         },
 
-        
+
         /**
          * Hide the enhancement sizes popup after a short delay.
          * @param {Element} el
          * The image sizes button inside the enhancement element.
          */
         enhancementPopupSizesHideDelayed: function(el) {
-            
+
             var timeout;
             var self;
 
             self = this;
-            
+
             // Cancel any previous attempt to show the popup
             clearTimeout( $(el).data('enhancementPopupSizesShowDelayed') );
-            
+
             timeout = setTimeout(function(){
                 self.enhancementPopupSizesHide(el);
             }, 200);
             $(el).data('enhancementPopupSizesHideDelayed', timeout);
         },
 
-        
+
         /**
          * Hide the enhancement sizes popup.
          * @param {Element} el
@@ -3236,7 +3236,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             $(el).removeClass('hovered');
         },
 
-        
+
         /**
          * Get the reference object for the enhancement.
          * @returns {Object}
@@ -3358,7 +3358,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
 
             element = self.enhancementGetElement(el);
-            
+
             if (id) {
 
                 $html = $('<' + element + '/>', {
@@ -3409,7 +3409,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if ($content.is('table')) {
 
                 self.tableCreate($content, line);
-                
+
             } else {
 
                 try {
@@ -3427,7 +3427,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                 // Output html should maintain 'span' or 'button' for the enhancement
                 config.element = $content.is('span') ? 'span' : 'button';
-                
+
                 self.enhancementCreate(config, line);
             }
         },
@@ -3438,7 +3438,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          *==================================================*/
 
         inlineEnhancementInit: function() {
-            
+
             var self;
             self = this;
 
@@ -3451,7 +3451,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
                 // If the style already has an onclick do not change it
                 if (styleObj.onClick) { return; }
-                
+
                 // If this style does not have a popup (no need for the "Edit" button)
                 // and it is a toggle (no need for the "Clear" button)
                 // then do not add an onclick handler (so the dropdown will not appear)
@@ -3463,14 +3463,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             });
         },
 
-        
+
         inlineEnhancementCreate: function(event, style) {
 
             var mark;
             var self;
-            
+
             self = this;
-            
+
             // Create a new mark then call the onclick function on it
             mark = self.rte.setStyle(style);
             if (mark) {
@@ -3502,7 +3502,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if (styleObj.popup === false) {
                 return;
             }
-            
+
             // Stop the click from propagating up to the window
             // because if it did, it would close the popup we will be opening.
             if (event) {
@@ -3519,7 +3519,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             } else {
                 html = self.rte.toHTML(range);
             }
-            
+
             enhancementEditUrl = $.addQueryParameters(
                 window.CONTEXT_PATH + '/content/enhancement.jsp',
                 'typeId', styleObj.enhancementType
@@ -3548,7 +3548,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                         })
                     ]
                 })
-                
+
             }).appendTo(self.$container);
 
             // Set the position of the popup
@@ -3564,21 +3564,21 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // so any popup form can access them
             $divForm.data('rte', self);
             $divForm.data('mark', mark);
-            
+
             // Listen for an 'enhancementUpdate' event that will be triggered on
             // the edit link, so we can tell when the enhancement is updated.
             // The enhancement edit form will trigger this event.
             if (!mark.rteTableMark) {
-                
+
                 // If this mark has rteTableMark=true, that means it is a "fake" CodeMirror mark
-                // that we created for table/tr/td elements. In that case we do not allow the 
+                // that we created for table/tr/td elements. In that case we do not allow the
                 // inline enhancement popup form to modify the html of the table.
-                
+
                 $divForm.on('enhancementUpdate', function(event, html){
                     self.inlineEnhancementReplaceMark(mark, html);
                 });
             }
-            
+
             // Listen for an 'enhancementRead' event that will be triggered on
             // the edit popup, so we can communicate the mark back to the popup form.
             // The enhancement edit form can trigger this event.
@@ -3599,7 +3599,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             // but first wait for the current click to finish so it doesn't interfere
             // with any popups
             setTimeout(function(){
-                
+
                 $divForm.submit();
 
                 // When the popup is closed put focus back on the editor
@@ -3626,7 +3626,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     if (event.target !== event.currentTarget) {
                         return;
                     }
-                    
+
                     self.focus();
                     $div.remove();
                     self.rte.triggerChange();
@@ -3639,7 +3639,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
         },
 
-        
+
         /**
          * Given an existing mark, replace the entire mark with new HTML.
          * Note after calling this function, the original mark is no longer
@@ -3652,12 +3652,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * The HTML to replace the mark.
          */
         inlineEnhancementReplaceMark: function(mark, html) {
-            
+
             var range;
             var self;
 
             self = this;
-            
+
             if (html && $.type(html) === 'string') {
                 range = self.rte.markGetRange(mark);
                 if (range.from) {
@@ -3666,9 +3666,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
         /*
-         * remove link style definition of the "a" element 
+         * remove link style definition of the "a" element
          * with values provided from inline enhancement (RICH_TEXT_ELEMENTS variable)
-         * 
+         *
          * @returns {undefined}
          */
         updateLinkInit: function(){
@@ -3676,7 +3676,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var removeLink;
             var toolKey;
                 self = this;
-                
+
             $.each(self.styles, function(styleKey, styleObj){
                  if (styleObj.element === 'a' && styleKey !== 'link'){
                      if (!styleObj.keymap) {
@@ -3693,11 +3693,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                          toolKey = toolbarKey;
                          return false;
                      }
-                  }); 
+                  });
 
                 delete self.styles.link;
                 if (toolKey !== undefined){
-                   self.toolbarConfig.splice(toolKey, 1);                    
+                   self.toolbarConfig.splice(toolKey, 1);
                 }
 
              }
@@ -3725,17 +3725,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 case 'table':
                     self.tableStyleTable = styleObj;
                     break;
-                    
+
                 case 'tr':
                     self.tableStyleRow = styleObj;
                     break;
-                
+
                 case 'td':
                 case 'th':
                     self.tableStyleCell = styleObj;
                     break;
                 }
-                
+
             });
         },
 
@@ -3757,27 +3757,27 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         /**
-         * 
+         *
          */
         tableCreate: function($content, line) {
-            
+
             var $div;
             var $placeholder;
             var self;
             var tEdit;
-            
+
             self = this;
 
             // Get the line number where the table should be added
             if (line === undefined) {
                 line = self.rte.getRange().from.line;
             }
-            
+
             // Create wrapper element for the table and add the toolbar
             $div = $('<div/>', {
                 'class': 'rte2-table'
             });
-            
+
             if (!self.rte.readOnlyGet() && !self.placeholderIsShowing()) {
                 $div.append( self.tableToolbarCreate() );
             }
@@ -3835,7 +3835,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Save the table editor on the placeholder so we can get to it later
             $placeholder.data('tableEditor', tEdit);
-            
+
             // Add the div to the editor
             self.rte.enhancementAdd($div[0], line, {
                 block:true,
@@ -3854,7 +3854,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             });
         },
 
-        
+
         /**
          * Convert the table to HTML.
          * Checks each table, tr, td, th element to see if it has a fake CodeMirror mark
@@ -3870,7 +3870,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var html;
             var self;
             var $table;
-            
+
             self = this;
             $table = $(table);
 
@@ -3889,7 +3889,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             return html;
         },
 
-        
+
         /**
          * Replace the attributes on an element with a new set of attributes.
          */
@@ -3897,7 +3897,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var $el;
             var original;
             var self;
-            
+
             self = this;
             $el = $(el);
             original = self.rte.getAttributes($el);
@@ -3909,9 +3909,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             });
         },
 
-        
+
         /**
-         * 
+         *
          */
         tableToolbarCreate: function() {
 
@@ -3975,7 +3975,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         /**
-         * 
+         *
          */
         tableMove: function(el, direction) {
 
@@ -3985,7 +3985,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var topNew;
             var topOriginal;
             var topWindow;
-            
+
             self = this;
 
             mark = self.tableGetMark(el);
@@ -3996,9 +3996,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if (direction === 1 || direction === -1) {
 
                 $el = self.tableGetWrapper(el);
-                
+
                 topOriginal = $el.offset().top;
-                    
+
                 mark = self.rte.enhancementMove(mark, direction);
 
                 topNew = $el.offset().top;
@@ -4010,9 +4010,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
-        
+
         /**
-         * 
+         *
          */
         tableRemove: function (el) {
             var $el;
@@ -4023,9 +4023,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.rte.triggerChange();
         },
 
-        
+
         /**
-         * 
+         *
          */
         tableRemoveCompletely: function (el) {
             var mark;
@@ -4039,7 +4039,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         /**
-         * 
+         *
          */
         tableRestore: function (el) {
             var $el;
@@ -4052,7 +4052,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
 
         /**
-         * 
+         *
          */
         tableIsToBeRemoved: function(el) {
             var $el;
@@ -4088,12 +4088,12 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             return self.rte.enhancementGetMark(el);
         },
 
-        
+
         /**
-         * 
+         *
          */
         tableEditInit: function() {
-            
+
             var $controls;
             var self;
 
@@ -4101,19 +4101,19 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Check if editor already exists
             if (self.$tableEditDiv) {
-                
+
                 // Empty the editor
                 self.tableEditRte.rte.empty();
-                
+
                 // Turn off track changes before we add content to the editor
                 self.tableEditRte.rte.trackSet(false);
-            
+
                 return;
             }
-            
+
             // Create popup used to display the editor
             self.$tableEditDiv = $('<div>', {'class':'rte2-table-editor'}).appendTo(document.body);
-            
+
             $('<h1/>', {
                 'class': 'widget-heading',
                 text: 'Edit Table Cell'
@@ -4121,7 +4121,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             self.$tableEditTextarea = $('<textarea>').appendTo(self.$tableEditDiv);
             self.tableEditRte = Object.create(Rte);
-            
+
             self.tableEditRte.init(self.$tableEditTextarea, {
                 contextRoot: 'td',
                 richTextElementTags: self.tableGetRichTextElementTags()
@@ -4138,7 +4138,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     $(this).popup('close');
                 }
             }).appendTo($controls);
-            
+
             self.$tableEditSave = $('<button/>', {
                 'class': 'rte2-table-editor-cancel',
                 text: 'Cancel',
@@ -4154,7 +4154,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.$tableEditDiv.popup('container').attr('name', 'rte2-frame-table-editor');
         },
 
-        
+
         /**
          * Returns a list of elements that should be allowed in a table cell, based on the context rules.
          * This only returns a list if the context rules contain at least one element that has a 'td' context.
@@ -4168,7 +4168,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var tagsArray;
             var self;
             self = this;
-            
+
             // First reverse the context rules so we can perform efficient lookups
             // So for example, we can lookup allowed['td'] and it will show us which styles are allowed inside 'td'
             allowed = {};
@@ -4184,27 +4184,27 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     });
                 }
             })
-                        
+
             // Now see if there are context rules defined for the 'td' element
             if (!allowed.td) {
                 // If there are no context rules for 'td' then return the same element list that
                 // was defined for the main RTE
                 return self.richTextElementTags;
             }
-            
-            // Start with an empty list of elements allowed 
+
+            // Start with an empty list of elements allowed
             tags = {};
-            
+
             // Function to recursively find all the tags allowed within a 'td'
             // plus children tags that should also be allowed
             function processTags(tagsToAdd) {
                 $.each(tagsToAdd, function(tag) {
                     // Check if it's already in the list of tags
                     if (!tags[tag]) {
-                        
+
                         // Add it to the list of tags
                         tags[tag] = true;
-                        
+
                         // Also add the children of this tag
                         if (allowed[tag]) {
                             processTags(allowed[tag]);
@@ -4212,11 +4212,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     }
                 });
             }
-            
+
             // Start the recursive process to find elements allowed in table cells,
             // and children of those elements
             processTags(allowed.td);
-            
+
             // Convert the tags found into an array
             tagsArray = [];
             $.each(tags, function(tag) {
@@ -4224,7 +4224,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             });
             return tagsArray;
         },
-        
+
 
         /**
          * @param jQuery $el
@@ -4236,14 +4236,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var value;
 
             self = this;
-            
+
             // Set up a nested rich text editor in a popup
             // (but only do this once)
             self.tableEditInit();
 
             // Set a flag so we only update the table cell if user clicks the save button
             self.tableEditSave = false;
-            
+
             value = $el.html();
 
             self.$tableEditDiv.popup('source', $el);
@@ -4274,17 +4274,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             });
         },
 
-        
+
         /**
          * Edit the table element attributes.
          * @param {Element|jquery} el
          * The table element to edit.
          */
         tableEditAttrTable: function(el) {
-            
+
             var mark;
             var self;
-            
+
             self = this;
 
             // Make sure there is backend style that is meant for editing the table
@@ -4300,17 +4300,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.inlineEnhancementHandleClick(null, mark);
         },
 
-        
+
         /**
          * Edit the tr element attributes.
          * @param {Element|jquery} el
          * The tr element.
          */
         tableEditAttrRow: function(el) {
-            
+
             var mark;
             var self;
-            
+
             self = this;
 
             // Make sure there is backend style that is meant for editing the table
@@ -4320,22 +4320,22 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             if (!mark) { return; }
 
             mark.className = self.tableStyleRow.className;
-            
+
             // Pop up backend form to edit the table attributes
             self.inlineEnhancementHandleClick(null, mark);
         },
 
-        
+
         /**
          * Edit the td element attributes.
          * @param {Element|jquery} el
          * The td or th element.
          */
         tableEditAttrCell: function(el) {
-            
+
             var mark;
             var self;
-            
+
             self = this;
 
             // Make sure there is backend style that is meant for editing the table
@@ -4366,18 +4366,18 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * For example, to add a className.
          */
         tableMarkCreate: function(el, extraAttributes, markParameters) {
-            
+
             var attributes;
             var mark;
             var self;
-            
+
             self = this;
 
             attributes = self.rte.getAttributes(el);
             if (extraAttributes) {
                 $.extend(attributes, extraAttributes);
             }
-            
+
             mark = {
                 rteTableMark:true,
                 attributes: attributes,
@@ -4408,10 +4408,10 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // Save the mark on the element for future use
             $(el).data('tableMark', mark);
-            
+
             return mark;
         },
-        
+
         /**
          * Update the mark for the table element.
          * @param {Element|jquery} el
@@ -4452,17 +4452,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             return mark;
         },
 
-        
+
         /*==================================================
          * Placeholder
          *==================================================*/
-        
+
         /**
          * Class added to the editor to style the placeholder when it is showing.
          */
         placeholderClass: 'rte2-placeholder-showing',
 
-        
+
         /**
          * Set the placeholder text for when the editor is empty,
          * and periodically check to see if the placeholder text
@@ -4486,9 +4486,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // When RTE gains focus always remove the placeholder if it is active
             self.$el.on('rteFocus', function(){
-                
+
                 self.placeholderRemove();
-                
+
                 // Note if the textarea is an "editable placeholder" then
                 // on focus the editable placeholder code will put content
                 // back into the RTE.
@@ -4496,9 +4496,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             // When RTE loses focus, check if RTE is empty and if so add the placeholder
             self.$el.on('rteBlur', function(){
-                
+
                 self.placeholderRefresh();
-                
+
                 // Note if the textarea is an "editable placeholder" then
                 // on blur the editable placeholder code will possibly examine
                 // the RTE and empty it again, then call placeholderRefresh again.
@@ -4518,11 +4518,11 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             var placeholderIsShowing;
             var self;
             var showPlaceholder;
-            
+
             self = this;
-            
+
             placeholderIsShowing = self.placeholderIsShowing();
-            
+
             // Determine if we should display the placeholder
             if (placeholderIsShowing) {
                 // Placeholder is already showing; however, the placeholder attribute might have
@@ -4544,9 +4544,9 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
-        
+
         /**
-         * Determine if the placeholder is currently showing (based on the placeholderActive flag). 
+         * Determine if the placeholder is currently showing (based on the placeholderActive flag).
          * @returns {Boolean}
          */
         placeholderIsShowing: function() {
@@ -4555,17 +4555,17 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             return Boolean( self.placeholderActive );
         },
 
-        
+
         /**
          * Replaces the content of the editor with the content in the textarea placeholder attribute (if any).
          * Also sets the placeholderActive flag.
          * If the placeholder attribute from the textarea is empty, then it removes the placeholder.
          */
         placeholderShow: function() {
-            
+
             var placeholder;
             var self;
-            
+
             self = this;
 
             // Get the placeholder content from the textarea
@@ -4577,7 +4577,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 self.placeholderRemove();
                 return;
             }
-      
+
             // Set placeholder active to true to other code like toHTML()
             // and events like rteChange can modify their behavior
             self.placeholderActive = true;
@@ -4590,7 +4590,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self.fromHTML(placeholder);
         },
 
-        
+
         /**
          * If the placeholder content is currently active, removes it from the editor and clears the editor content.
          */
@@ -4604,7 +4604,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }
         },
 
-        
+
         /*==================================================
          * Preview
          * To support brightspot cms preview functionality,
@@ -4612,7 +4612,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * Triggering an "input" event will update the preview.
          *==================================================*/
 
-        
+
         /**
          * Initialize an event listener so whenever the rich text editor changes,
          * we update the textarea with the latest content, and trigger an
@@ -4621,7 +4621,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
          * This is throttled agressively to prevent performance problems.
          */
         previewInit: function() {
-            
+
             var self;
             self = this;
 
@@ -4630,25 +4630,25 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             }));
         },
 
-        
+
         /**
          * Update the textarea with the latest content from the rich text editor,
          * plus trigger an "input" event so the preview will be updated, and
          * a "change" event so the change indicator can be updated.
          */
         previewUpdate: function() {
-            
+
             var html;
             var self;
             var val;
-            
+
             self = this;
 
             // Do not update if we are in read only mode
             if (self.rte.readOnlyGet()) {
                 return;
             }
-            
+
             // Do not update if the content in the editor has not been changed
             if (!self.changed) {
                 return;
@@ -4657,13 +4657,13 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             html = self.toHTML();
 
             val = self.$el.val();
-            
+
             if (html !== val) {
                 self.$el.val(html).trigger('input').trigger('change');
             }
         },
 
-        
+
         /*==================================================
          * Misc
          *==================================================*/
@@ -4721,14 +4721,14 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
             self = this;
             clearTimeout(self.rteBlurTimeout);
         },
-        
-        
+
+
         refresh: function() {
             var self;
             self = this;
             self.rte.refresh();
         },
-        
+
         setCursor: function(line, ch) {
             var self;
             self.rte.setCursor(line, ch);
@@ -4812,7 +4812,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
 
             rte = Object.create(Rte);
             rte.init(input, options);
-            
+
             function updatePreview() {
                 rte.rte.blockEachLineMark(function (name, mark) {
                     var className = mark.className;
@@ -4825,7 +4825,7 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                     if (!styleObj || !styleObj.previewable) {
                         return;
                     }
-                    
+
                     if (mark.rtePreviewKey !== newPreviewKey) {
                         mark.rtePreviewKey = newPreviewKey;
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtext2.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtext2.js
@@ -4761,7 +4761,8 @@ define(['jquery', 'v3/input/richtextCodeMirror', 'v3/input/tableEditor', 'v3/plu
                 keymap: rtElement.keymap,
                 clear: rtElement.clear,
                 toggle: rtElement.toggle,
-                previewable: Boolean(rtElement.previewable)
+                previewable: Boolean(rtElement.previewable),
+                urlPatterns: rtElement.urlPatterns
             };
         });
     }

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4701,6 +4701,7 @@ define([
                     // and CodeMirror handles the paste operation.
 
                     value = self.htmlEncode(valueText).replace(/[\n\r]/g, '<br/>');
+                    value = self.detectUrls(value);
                 }
             }
 

--- a/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
+++ b/tool-ui/src/main/webapp/script/v3/input/richtextCodeMirror.js
@@ -4809,6 +4809,9 @@ define([
             // valid HTML.
             html = self.limitHTML($el[0]);
 
+            // Detect any URLs in the html and turn them into links
+            html = self.detectUrls(html);
+
             return html;
         },
 
@@ -7572,6 +7575,7 @@ define([
             var enhancements;
             var el;
             var history;
+            var markToOpen;
             var self;
             var val;
 
@@ -8006,9 +8010,19 @@ define([
             $.each(annotations, function(i, annotation) {
 
                 var annotationRange;
+                var mark;
+                var openMark;
                 var styleObj;
 
                 styleObj = annotation.styleObj;
+
+                // Check if this mark was a pasted in link, so the mark should be edited after it is added
+                if (annotation.attributes && annotation.attributes['data-rte2-open']) {
+                    // Remove the attribute so it doesn't appear in the final output
+                    delete annotation.attributes['data-rte2-open'];
+                    // Set a flag so we know to open the mark after it is created.
+                    openMark = true;
+                }
 
                 // Adjust the position of the annotation based on the range where we're inserting the text
                 if (range.from.line !== 0 || range.from.ch !== 0) {
@@ -8054,7 +8068,14 @@ define([
                         }
 
                     } else {
-                        self.inlineSetStyle(styleObj, annotation, {addToHistory:false, triggerChange:false, attributes:annotation.attributes});
+
+                        mark = self.inlineSetStyle(styleObj, annotation, {addToHistory:false, triggerChange:false, attributes:annotation.attributes});
+
+                        // If this mark was a pasted-in link that should be opened save the mark.
+                        // But only open the first mark that is found.
+                        if (openMark && !markToOpen) {
+                            markToOpen = mark;
+                        }
                     }
                 } else if (annotation.indent) {
                     // Special case for extra lines within a list item,
@@ -8072,6 +8093,12 @@ define([
 
             editor.setHistory(history);
             self.triggerChange();
+
+            // If user pasted in a url and it was converted to a link,
+            // open the edit form for that link.
+            if (markToOpen) {
+                self.onClickDoMark(null, markToOpen);
+            }
 
         }, // fromHTML()
 
@@ -8181,6 +8208,95 @@ define([
             } // if (matchArray)
 
             return matchStyleObj;
+        },
+
+
+        /**
+         * Detect any URLs in pasted content and change them into links.
+         * @param  {String} html
+         * @return {String}
+         */
+        detectUrls: function(html) {
+
+            var el;
+            var expression;
+            var match;
+            var node;
+            var nodeLink;
+            var re;
+            var self;
+            var text;
+            var walker;
+            var $wrapper;
+
+            self = this;
+
+            // Convert HTML into a DOM element so we can parse it using the browser node functions
+            el = self.htmlParse(html);
+
+            expression = 'https?://(www\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)';
+            re = new RegExp(expression);
+
+            // Loop through all the text nodes
+            walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+            while(walker.nextNode()) {
+
+                node = walker.currentNode;
+                text = node.nodeValue;
+
+                // Make sure this text node is not already within another link?
+                if ($(node).closest('a').length) {
+                    continue;
+                }
+
+                // Check to see if the text contains a URL.
+                // Note the text might contain multiple separate URLs so we need to find them all.
+                while ((match = re.exec(text)) !== null) {
+
+                    // Split the text node if the url is not at the start
+                    // For example: "This is a http://example.com link"
+                    // We end up with "http://example.com link"
+                    if (match.index > 0) {
+
+                        nodeLink = node.splitText(match.index);
+
+                        // Move the tree walker to the next node (which was just created) to avoid processing multiple times
+                        walker.nextNode();
+                        node = walker.currentNode;
+
+                    } else {
+                        nodeLink = node;
+                    }
+
+                    // Split the text node if the url is not at the end
+                    // For example: "http://example.com link"
+                    // We end up with "http://example.com"
+                    if (match[0].length + match.index < text.length) {
+
+                        nodeLink.splitText(match[0].length);
+
+                        // Move the tree walker to the next node (which was just created) to avoid processing multiple times
+                        walker.nextNode();
+                        node = walker.currentNode;
+
+                        // Since we modified the text by splitting the text nodes and so forth,
+                        // update the text so we won't find the same URL twice
+                        text = walker.currentNode.nodeValue;
+                    }
+
+                    // Wrap the text node in a link element
+                    // Also add the data-rte2-open attribute to the element, which will be stripped off later,
+                    // and causes the editor to open the edit form for this element.
+                    $wrapper = $('<a/>', {
+                        href: match[0],
+                        'data-rte2-open': true
+                    });
+
+                    $(nodeLink).wrap( $wrapper );
+                }
+            }
+
+            return $(el).html();
         },
 
 


### PR DESCRIPTION
For text or HTML that is pasted into the RTE (from outside sources), parse the text to locate any text that looks like a URL. If found, turn the text into a link, and also open the link popup for the link. Note if multiple links are found, then only the popup for the first link will be opened.

This also adds support for a urlPatterns parameter for richtext elements that are defined on the backend. The urlPatterns must be an array of strings, each string is a regular expression to match a URL in the pasted text. For example, you could specify a regular expression to match only Instagram links, and that URL would be wrapped by the custom richtext element instead of a link (A) element.

Note: at time of creation, this pull request consists of the front-end code to support pasting and urlPatterns. Additional work will need to be done to add urlPattern support on the back-end.