### PR TITLE
BSP-2954: Updates edit tab of image storage item to not display resizes button …

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/file/ImageFileType.java
+++ b/db/src/main/java/com/psddev/cms/tool/file/ImageFileType.java
@@ -179,15 +179,17 @@ public class ImageFileType implements FileContentType {
                             page.writeEnd();
                         page.writeEnd();
 
-                        page.writeStart("li");
-                            page.writeStart("a",
-                                    "class", "icon icon-crop",
-                                    "data-frame-post", "",
-                                    "href", page.h(page.url("/contentImages", "data", ObjectUtils.toJson(fieldValue))),
-                                    "target", "contentImages");
-                                page.writeHtml(page.localize(ImageFileType.class, "action.viewResized"));
+                        if (!StandardImageSize.findAll().isEmpty()) {
+                            page.writeStart("li");
+                                page.writeStart("a",
+                                        "class", "icon icon-crop",
+                                        "data-frame-post", "",
+                                        "href", page.h(page.url("/contentImages", "data", ObjectUtils.toJson(fieldValue))),
+                                        "target", "contentImages");
+                                    page.writeHtml(page.localize(ImageFileType.class, "action.viewResized"));
+                                page.writeEnd();
                             page.writeEnd();
-                        page.writeEnd();
+                        }
                     page.writeEnd();
                 page.writeEnd();
 


### PR DESCRIPTION
…if there are none available.