### PR TITLE
BSP-2980 add drag and drop to StorageItems fields

### DIFF
--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -414,6 +414,35 @@ function() {
 
   })();
 
+  // Add function to calculate z-index
+  $.fn.zIndex = function (zIndex) {
+    if (zIndex !== undefined) {
+      return this.css("zIndex", zIndex);
+    }
+
+    if (this.length) {
+      var elem = $(this[ 0 ]), position, value;
+      while (elem.length && elem[ 0 ] !== document) {
+        // Ignore z-index if position is set to a value where z-index is ignored by the browser
+        // This makes behavior of this function consistent across browsers
+        // WebKit always returns auto if the element is positioned
+        position = elem.css("position");
+        if (position === "absolute" || position === "relative" || position === "fixed") {
+          // IE returns 0 when zIndex is not specified
+          // other browsers return a string
+          // we ignore the case of nested elements with an explicit value of 0
+          // <div style="z-index: -10;"><div style="z-index: 0;"></div></div>
+          value = parseInt(elem.css("zIndex"), 10);
+          if (!isNaN(value) && value !== 0) {
+            return value;
+          }
+        }
+        elem = elem.parent();
+      }
+    }
+    return 0;
+  };
+
   // Handle file uploads from drag-and-drop.
   (function() {
     var docEntered;
@@ -478,6 +507,13 @@ function() {
             $fileSelectorInput,
             $fileSelectorLabel;
 
+        // Only add drag and drop if the element is visible.
+        // For example, an element might be hidden in another tab,
+        // so we do not want drag and drop region for that element.
+        if (!$(this).is(':visible')) {
+          return;
+        }
+
         // Check if this is a FileSelector widget, such as used to upload a single new file
         if ($(this).is('.fileSelector')) {
           $fileSelector = $(this);
@@ -492,7 +528,11 @@ function() {
         overlayCss = $.extend($container.offset(), {
           'height': $container.outerHeight(),
           'position': 'absolute',
-          'width': $container.outerWidth()
+          'width': $container.outerWidth(),
+           // Calculate the z-index for the element and use the same value for the drag-and-drop overlay.
+           // This should ensure that things like popups will show the drag and drop overlay,
+           // and still be on top of other drag-and-drop overlays that are in a lower stacking context.
+          'z-index': $(this).zIndex() || 'auto'
         });
 
         $dropZone = $('<div/>', {

--- a/tool-ui/src/main/webapp/script/v3.js
+++ b/tool-ui/src/main/webapp/script/v3.js
@@ -537,7 +537,7 @@ function() {
             $fileSelectorLabel.trigger('dropDown-update');
 
             // Copy attributes from the original file input to the replacement file input
-            $.each([ 'class', 'id', 'name', 'style', 'data-bsp-uploader', 'data-input-name', 'data-type-id' ], function(index, name) {
+            $.each([ 'class', 'id', 'name', 'style', 'data-input-name', 'data-type-id' ], function(index, name) {
 
               var val;
 
@@ -551,6 +551,11 @@ function() {
 
               $fileInput.attr(name, val);
             });
+
+            // Determine if the front-end uploader should be used
+            if ($fileSelectorInput.attr('data-bsp-uploader') !== undefined) {
+              $fileInput.attr('data-bsp-uploader', '');
+            }
 
             // Replace the original file input with the new one
             $fileSelectorInput.replaceWith($fileInput);


### PR DESCRIPTION
For StorageItem fields (which give the user option to upload a file) add a drag-and-drop region so user can drop files on the field. Dragging a file into the window shows a droppable regions, and if user drops the file, the StorageItem will change to "New File" and use the dropped file in the file input. The file input also has the bsp-uploader plugin, so after dropping the file it should be automatically uploaded.

Example usage: create a new image object then drag a file onto the File field.

Note the drag and drop code is also used in other areas such as upload links, so things such as bulk upload and galleries should be re-verified as part of testing.

Note the file is uploaded automatically only if the following setting is enabled: Settings > CMS > UI > Enable Front End Uploader