### PR TITLE
BSP-3004 - Calls saveImmediately on ExternalContentCache record.

### DIFF
--- a/db/src/main/java/com/psddev/cms/rte/ExternalContentCache.java
+++ b/db/src/main/java/com/psddev/cms/rte/ExternalContentCache.java
@@ -137,7 +137,7 @@ public class ExternalContentCache extends Record {
         cache.getState().setId(id);
         cache.created = now;
         cache.response = response;
-        cache.save();
+        cache.saveImmediately();
 
         return response;
     }


### PR DESCRIPTION
Calls saveImmediately on the cache record to ensure it gets saved even when called inside a transaction.

Prevents issue where ExternalContent API calls invoked by ContentStateServlet are rolled back preventing the cache record from getting saved and potentially spamming the API.