### PR TITLE
BSP-2374 - Allows ViewRenderer to specify Content-Type. Prevents HTML in JSON responses.

### DIFF
--- a/db/etc/clirr-ignored.xml
+++ b/db/etc/clirr-ignored.xml
@@ -63,6 +63,12 @@
     </difference>
 
     <difference>
+        <className>com/psddev/cms/view/ViewRenderer</className>
+        <differenceType>7012</differenceType>
+        <method>java.lang.String getContentType()</method>
+    </difference>
+
+    <difference>
         <className>com/psddev/cms/db/ToolUi$CollectionItemWeight</className>
         <differenceType>7012</differenceType>
         <method>boolean calculated()</method>

--- a/db/src/main/java/com/psddev/cms/db/PageFilter.java
+++ b/db/src/main/java/com/psddev/cms/db/PageFilter.java
@@ -1244,15 +1244,16 @@ public class PageFilter extends AbstractFilter {
                 jsonViewRenderer.setDisallowMixedOutput(true);
 
                 renderer = jsonViewRenderer;
-
-                response.setContentType("application/json");
-
             } else {
                 renderer = ViewRenderer.createRenderer(viewModel);
             }
 
             // 6. Render the ViewModel
             if (renderer != null) {
+                String contentType = renderer.getContentType();
+                if (contentType != null) {
+                    response.setContentType(contentType);
+                }
 
                 try {
                     ViewOutput result = renderer.render(viewModel, getViewTemplateLoader(request));

--- a/db/src/main/java/com/psddev/cms/view/JsonViewRenderer.java
+++ b/db/src/main/java/com/psddev/cms/view/JsonViewRenderer.java
@@ -67,6 +67,11 @@ public class JsonViewRenderer implements ViewRenderer {
         this.disallowMixedOutput = disallowMixedOutput;
     }
 
+    @Override
+    public String getContentType() {
+        return "application/json";
+    }
+
     @Deprecated
     @Override
     public ViewOutput render(Object view) {

--- a/db/src/main/java/com/psddev/cms/view/ViewRenderer.java
+++ b/db/src/main/java/com/psddev/cms/view/ViewRenderer.java
@@ -43,6 +43,15 @@ public interface ViewRenderer {
     }
 
     /**
+     * Gets the content type produced by this view renderer.
+     *
+     * @return the content type.
+     */
+    default String getContentType() {
+        return "text/html";
+    }
+
+    /**
      * Creates an appropriate ViewRenderer based on the specified view.
      *
      * @param view the view from which to create a view renderer.
@@ -120,6 +129,11 @@ public interface ViewRenderer {
                 // wrap the view renderer so that it always converts the view to a ViewMap
                 // before delegating to the actual renderer if it's not already a map.
                 return new ViewRenderer() {
+
+                    @Override
+                    public String getContentType() {
+                        return renderer.getContentType();
+                    }
 
                     @Deprecated
                     @Override


### PR DESCRIPTION
Allows ViewRenderer to specify Content-Type and changes PageFilter to set it on the response before renderering the view to prevent brightspot.object HTML comments being emitted in output.