### PR TITLE
BSP-2489 Localizes "Recent Drafts" message heading

### DIFF
--- a/db/src/main/resources/com/psddev/cms/tool/page/content/ObjectMessageDefault_en.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/ObjectMessageDefault_en.properties
@@ -1,5 +1,6 @@
 action.returnToDashboard=Return to Dashboard
 
+message.recentDraftsHeading=Recent Drafts:
 message.published=Published {date}.
 message.saved=Saved {date}.
 message.transition=Transitioned to {state} at {date}.

--- a/db/src/main/resources/com/psddev/cms/tool/page/content/ObjectMessageDefault_es.properties
+++ b/db/src/main/resources/com/psddev/cms/tool/page/content/ObjectMessageDefault_es.properties
@@ -1,3 +1,6 @@
+action.returnToDashboard=Volver al tablero
+
+message.recentDraftsHeading=Borradores Recientes:
 message.published=Publicado {date}
 message.saved=Guardado {date}
 message.transition=Transladado a  {state} a las {date}

--- a/tool-ui/src/main/webapp/WEB-INF/objectMessage.jsp
+++ b/tool-ui/src/main/webapp/WEB-INF/objectMessage.jsp
@@ -50,7 +50,9 @@ if (wp.getOverlaidDraft(object) == null) {
     if (!contentUpdates.isEmpty()) {
         wp.writeStart("div", "class", "message message-info");
         wp.writeStart("p");
-        wp.writeHtml("Recent Drafts:");
+        wp.writeHtml(wp.localize(
+                "com.psddev.cms.tool.page.content.ObjectMessage",
+                "message.recentDraftsHeading"));
         wp.writeEnd();
 
         wp.writeStart("ul");


### PR DESCRIPTION
Localizes the heading of the following message:

![image](https://cloud.githubusercontent.com/assets/1299507/25760561/58bca936-31a5-11e7-8780-6ee7a46ed610.png)


Implementations wishing to override this will need to do the following:

1. Create ObjectMessageOverride_en.properties
2. Add entry for `message.recentDraftsHeading`