### PR TITLE
BSP - 3224 Prevents widget refresh when interactions with widget are detected

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/dashboard.js
+++ b/tool-ui/src/main/webapp/script/v3/dashboard.js
@@ -6,7 +6,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
         var widgetUrl = $widget.attr('data-dashboard-widget-url');
 
 
-        // prevent widget refresh under the followign scenarios:
+        // Prevent widget refresh under the following scenarios:
         // 1. User is hovering over the widget
         // 2. User has a dropdown open for the current widget
         // 3. User has activated the page thumbnail preview icon (only relevant for search result widgets)

--- a/tool-ui/src/main/webapp/script/v3/dashboard.js
+++ b/tool-ui/src/main/webapp/script/v3/dashboard.js
@@ -5,9 +5,16 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
         var $widget = $(this);
         var widgetUrl = $widget.attr('data-dashboard-widget-url');
 
+
+        // prevent widget refresh under the followign scenarios:
+        // 1. User is hovering over the widget
+        // 2. User has a dropdown open for the current widget
+        // 3. User has activated the page thumbnail preview icon (only relevant for search result widgets)
         if (widgetUrl
             && !$widget.is(':hover')
-            && $widget.find('.dropDown-list-open').size() === 0) {
+            && $widget.find('.dropDown-list-open').size() === 0
+            && $('body').find('.pageThumbnails_toggle').size() === 0) {
+
           $.ajax({
             'cache': false,
             'type': 'get',

--- a/tool-ui/src/main/webapp/script/v3/dashboard.js
+++ b/tool-ui/src/main/webapp/script/v3/dashboard.js
@@ -5,7 +5,9 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
         var $widget = $(this);
         var widgetUrl = $widget.attr('data-dashboard-widget-url');
 
-        if (widgetUrl && !$widget.is(':hover')) {
+        if (widgetUrl
+            && !$widget.is(':hover')
+            && $widget.find('.dropDown-list-open').size() === 0) {
           $.ajax({
             'cache': false,
             'type': 'get',

--- a/tool-ui/src/main/webapp/script/v3/dashboard.js
+++ b/tool-ui/src/main/webapp/script/v3/dashboard.js
@@ -5,13 +5,14 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
         var $widget = $(this);
         var widgetUrl = $widget.attr('data-dashboard-widget-url');
 
-
         // Prevent widget refresh under the following scenarios:
         // 1. User is hovering over the widget
         // 2. User has a dropdown open for the current widget
         // 3. User has activated the page thumbnail preview icon (only relevant for search result widgets)
+        // 4. User has triggered a click or a change event on the widget form
         if (widgetUrl
             && !$widget.is(':hover')
+            && $widget.data('refresh-disabled') !== true
             && $widget.find('.dropDown-list-open').size() === 0
             && $('body').children('.pageThumbnails_toggle').size() === 0) {
 
@@ -31,4 +32,16 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
       });
     }, 2000);
   }));
+
+  // Disables automatic refresh on click or change event
+  $(document).on('change click', '[data-dashboard-widget-url] form, [data-dashboard-widget-url] a', function() {
+    var $widget = $(this).closest('[data-dashboard-widget-url]');
+
+    // prevent disabling refresh on first form load
+    if (!$widget.hasClass('loading') && !$widget.hasClass('loaded')) {
+      return false;
+    }
+
+    $(this).closest('[data-dashboard-widget-url]').data('refresh-disabled', true);
+  });
 });

--- a/tool-ui/src/main/webapp/script/v3/dashboard.js
+++ b/tool-ui/src/main/webapp/script/v3/dashboard.js
@@ -13,7 +13,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
         if (widgetUrl
             && !$widget.is(':hover')
             && $widget.find('.dropDown-list-open').size() === 0
-            && $('body').find('.pageThumbnails_toggle').size() === 0) {
+            && $('body').children('.pageThumbnails_toggle').size() === 0) {
 
           $.ajax({
             'cache': false,

--- a/tool-ui/src/main/webapp/script/v3/dashboard.js
+++ b/tool-ui/src/main/webapp/script/v3/dashboard.js
@@ -5,7 +5,7 @@ define([ 'jquery', 'bsp-utils', 'v3/rtc' ], function($, bsp_utils, rtc) {
         var $widget = $(this);
         var widgetUrl = $widget.attr('data-dashboard-widget-url');
 
-        if (widgetUrl) {
+        if (widgetUrl && !$widget.is(':hover')) {
           $.ajax({
             'cache': false,
             'type': 'get',


### PR DESCRIPTION
Prevent widget refresh under the following scenarios:

1. User is hovering over the widget
2. User has a dropdown open for the current widget
3. User has activated the page thumbnail preview icon (only relevant for search result widgets)
4. User has triggered a click or a change event on the widget form