### PR TITLE
BSP-3011 Displays multiple visibility labels

### DIFF
--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1143,24 +1143,29 @@ public class ToolPageContext extends WebPageContext {
         }
 
         State state = State.getInstance(object);
+        Set<String> labels = new LinkedHashSet<>();
 
         if (draft != null) {
             if (draft.isNewContent()) {
                 Object original = draft.recreate();
 
                 if (original != null) {
-                    return State.getInstance(original).getVisibilityLabel();
+                    labels.add(State.getInstance(original).getVisibilityLabel());
                 }
 
             } else if (draft.getSchedule() != null) {
-                return localize(State.getInstance(object).getType(), "visibility.scheduledDraft");
+                labels.add(localize(state.getType(), "visibility.scheduledDraft"));
 
             } else {
-                return localize(Draft.class, "displayName");
+                labels.add(localize(Draft.class, "displayName"));
             }
         }
 
-        return State.getInstance(object).getVisibilityLabel();
+        labels.add(state.getVisibilityLabel());
+
+        return labels.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(", ", "", ""));
     }
 
     /**

--- a/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
+++ b/db/src/main/java/com/psddev/cms/tool/ToolPageContext.java
@@ -1136,10 +1136,6 @@ public class ToolPageContext extends WebPageContext {
 
         } else {
             draft = getOverlaidDraft(object);
-
-            if (draft != null) {
-                object = draft.recreate();
-            }
         }
 
         State state = State.getInstance(object);


### PR DESCRIPTION
Previously a `Draft` with a second visibility, would only have displayed a single visibility label:

![image](https://cloud.githubusercontent.com/assets/1299507/26130165/7a1c13f4-3a61-11e7-9cd3-38c7a52a8bf9.png)

This change updates `ToolPageContext#createVisibilityLabel` to produce a compound visibility label, comma delimited:

![image](https://cloud.githubusercontent.com/assets/1299507/26130206/9f3729bc-3a61-11e7-8706-e47b4310f908.png)


