### PR TITLE
BSP-3562 Dropdown JS unescapes html incorrectly

### DIFF
--- a/tool-ui/src/main/webapp/script/v3/jquery.dropdown.js
+++ b/tool-ui/src/main/webapp/script/v3/jquery.dropdown.js
@@ -256,9 +256,14 @@ define([ 'string', 'bsp-utils' ], function (S, bsp_utils) {
             $check;
 
         $item = $('<div/>', {
-          'class': plugin.className('listItem'),
-          'html': $option.attr("data-drop-down-html") || $option.text() || '&nbsp;'
-        });
+          'class': plugin.className('listItem')}
+        );
+
+        if ($option.attr("data-drop-down-html")) {
+          $item.html($option.attr("data-drop-down-html"));
+        } else {
+          $item.text($option.text() || '&nbsp;');
+        }
 
         $check = $('<input/>', {
           'type': isMultiple ? 'checkbox' : 'radio'


### PR DESCRIPTION
Updates dropdown.js to use .text instead of .html if it is text it is grabbing. When using .html it would unescape the text, which could allow for badly formed html. 